### PR TITLE
#patch (904) Extension des permissions epci/city à departement

### DIFF
--- a/packages/api/db/migrations/000112-add-column-write-to-features.js
+++ b/packages/api/db/migrations/000112-add-column-write-to-features.js
@@ -1,0 +1,51 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+        transaction => queryInterface.addColumn(
+            'features',
+            'write',
+            {
+                type: Sequelize.BOOLEAN,
+                allowNull: true,
+            },
+            {
+                transaction,
+            },
+        )
+            .then(() => Promise.all([
+                queryInterface.sequelize.query(
+                    'UPDATE features SET write = TRUE WHERE name NOT IN (:names)',
+                    {
+                        transaction,
+                        replacements: {
+                            names: ['listPrivate', 'export', 'read', 'list', 'access'],
+                        },
+                    },
+                ),
+                queryInterface.sequelize.query(
+                    'UPDATE features SET write = FALSE WHERE name IN (:names)',
+                    {
+                        transaction,
+                        replacements: {
+                            names: ['listPrivate', 'export', 'read', 'list', 'access'],
+                        },
+                    },
+                ),
+            ]))
+            .then(() => queryInterface.changeColumn(
+                'features',
+                'write',
+                {
+                    type: Sequelize.BOOLEAN,
+                    allowNull: false,
+                },
+                {
+                    transaction,
+                },
+            )),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.removeColumn('features', 'write', { transaction }),
+    ),
+
+};

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,6 +15,7 @@
     "agenda": "^3.1.0",
     "body-parser": "^1.18.3",
     "cors": "^2.8.5",
+    "deepmerge": "^4.2.2",
     "escape-html": "^1.0.3",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.16.0",

--- a/packages/api/server/controllers/planController.js
+++ b/packages/api/server/controllers/planController.js
@@ -475,8 +475,18 @@ module.exports = models => ({
 
     async find(req, res) {
         try {
-            const plans = await models.plan.findOne(req.user, req.params.id);
-            res.status(200).send(plans);
+            const plan = await models.plan.findOne(req.user, req.params.id);
+
+            if (plan === null) {
+                res.status(404).send({
+                    error: {
+                        user_message: 'Le dispositif demandé n\'existe pas',
+                    },
+                });
+                return;
+            }
+
+            res.status(200).send(plan);
         } catch (error) {
             res.status(500).send({
                 error: {

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -11,6 +11,7 @@ const mattermostUtils = require('#server/utils/mattermost');
 const userModel = require('#server/models/userModel')(sequelize);
 const mails = require('#server/mails/mails');
 const shantytownService = require('#server/services/shantytown');
+const { can } = require('#server/services/permissionService');
 
 function fromGeoLevelToTableName(geoLevel) {
     switch (geoLevel) {
@@ -308,20 +309,6 @@ module.exports = (models) => {
         },
 
         async export(req, res, next) {
-            function isLocationAllowed(user, location) {
-                if (user.permissions.shantytown.export.geographic_level === 'nation') {
-                    return true;
-                }
-
-                if (user.organization.location.type === 'nation') {
-                    return true;
-                }
-
-                return location[user.organization.location.type]
-                    && user.organization.location[user.organization.location.type]
-                    && user.organization.location[user.organization.location.type].code === location[user.organization.location.type].code;
-            }
-
             if (!Object.prototype.hasOwnProperty.call(req.query, 'locationType')
                 || !Object.prototype.hasOwnProperty.call(req.query, 'locationCode')) {
                 return res.status(400).send({
@@ -351,7 +338,7 @@ module.exports = (models) => {
                 next(error);
             }
 
-            if (!isLocationAllowed(req.user, location)) {
+            if (!can(req.user).do('export', 'shantytown').on(location)) {
                 return res.status(400).send({
                     success: false,
                     response: {

--- a/packages/api/server/controllers/userController.js
+++ b/packages/api/server/controllers/userController.js
@@ -113,7 +113,7 @@ module.exports = models => ({
         }
     },
 
-    async signin(req, res) {
+    async signin(req, res, next) {
         const { email, password } = req.body;
 
         if (typeof email !== 'string') {
@@ -142,9 +142,20 @@ module.exports = models => ({
             });
         }
 
-        const user = await models.user.findOneByEmail(email, {
-            auth: true,
-        });
+        let user;
+        try {
+            user = await models.user.findOneByEmail(email, {
+                auth: true,
+            });
+        } catch (error) {
+            res.status(500).send({
+                success: false,
+                error: {
+                    user_message: 'Une erreur est survenue lors de la lecture en base de données',
+                },
+            });
+            return next(error);
+        }
 
         if (user === null) {
             return res.status(403).send({

--- a/packages/api/server/models/permissionModel.js
+++ b/packages/api/server/models/permissionModel.js
@@ -75,9 +75,11 @@ module.exports = (database) => {
                 permissions.fk_feature AS feature,
                 permissions.allowed,
                 permissions.fk_geographic_level AS geographic_level,
+                features.write,
                 ${entity}_permissions.*
             FROM ${entity}_permissions
             LEFT JOIN permissions ON ${entity}_permissions.fk_permission = permissions.permission_id
+            LEFT JOIN features ON permissions.fk_feature = features.name AND permissions.fk_entity = features.fk_entity
             ${where.length > 0 ? `WHERE ${where.join(' OR ')}` : ''}
             ORDER BY role_admin ASC, role_regular ASC, organization ASC, feature ASC
         `, {
@@ -102,6 +104,7 @@ module.exports = (database) => {
             const permission = {
                 allowed: row.allowed,
                 geographic_level: row.geographic_level,
+                write: row.write,
             };
 
             Object.keys(row).filter(key => key.substr(0, 5) === 'data_').forEach((key) => {

--- a/packages/api/server/models/planModel.js
+++ b/packages/api/server/models/planModel.js
@@ -630,7 +630,7 @@ module.exports = (database) => {
 
         findOne: async (user, id) => {
             const rows = await query(user, 'read', {
-                plan_id: id,
+                id,
             });
 
             if (rows.length === 1) {

--- a/packages/api/server/models/planModel.js
+++ b/packages/api/server/models/planModel.js
@@ -641,7 +641,7 @@ module.exports = (database) => {
         },
 
         delete: planId => database.query(
-            'DELETE FROM plans WHERE plan_id = :planId',
+            'DELETE FROM plans2 WHERE plan_id = :planId',
             {
                 replacements: {
                     planId,

--- a/packages/api/server/services/permissionService.js
+++ b/packages/api/server/services/permissionService.js
@@ -1,0 +1,192 @@
+module.exports = {
+
+    can: user => ({
+        do: (feature, entity) => ({
+            on(location, plan = null) {
+                // on vérifie que l'utilisateur dispose de la permission demandée
+                if (!user || !user.permissions || !user.permissions[entity]) {
+                    return false;
+                }
+
+                const permission = user.permissions[entity][feature];
+                if (!permission || permission.allowed !== true) {
+                    return false;
+                }
+
+                if (permission.geographic_level === 'nation') {
+                    return true;
+                }
+
+                // on interprète la valeur spéciale "own", dédiée exclusivement aux permissions plan.update et plan.updateMarks
+                if (permission.geographic_level === 'own') {
+                    if (!plan) {
+                        throw new Error('Le dispositif est obligatoire pour une permission de type `own`');
+                    }
+
+                    if (feature === 'update') {
+                        if (!plan.government_contacts) {
+                            return false;
+                        }
+
+                        return plan.government_contacts.some(({ id }) => id === user.id);
+                    }
+
+                    if (feature === 'updateMarks') {
+                        if (!plan.operator_contacts) {
+                            return false;
+                        }
+
+                        return plan.operator_contacts.some(contact => contact.organization.id === user.organization.id);
+                    }
+
+                    // pour toute autre feature que "update" et "updateMarks", il suffit que
+                    // l'utilisateur soit soit pilote, soit opérateur
+                    if (plan.government_contacts && plan.government_contacts.some(({ id }) => id === user.id)) {
+                        return true;
+                    }
+
+                    if (plan.operator_contacts && plan.operator_contacts.some(contact => contact.organization.id === user.organization.id)) {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                // on détermine le niveau géographique de la permission
+                // (notamment, on traduit la valeur spéciale "local" en un niveau géographique spécifique)
+                let permissionLevel;
+                if (permission.geographic_level === 'local') {
+                    switch (user.organization.location.type) {
+                        case 'nation':
+                            return true;
+
+                        case 'region':
+                            permissionLevel = 'region';
+                            break;
+
+                        // pour tout utilisateur en-dessous du niveau régional, une permission "local" se traduit en permission "départementale"
+                        default:
+                            permissionLevel = 'departement';
+                    }
+                } else {
+                    permissionLevel = user.permissions.shantytown.export.geographic_level;
+                }
+
+                // on vérifie que l'utilisateur a bien le bon niveau géographique pour avoir la permission
+                if (!location[permissionLevel] || !user.organization.location[permissionLevel]) {
+                    return false;
+                }
+
+                return location[permissionLevel].code === user.organization.location[permissionLevel].code;
+            },
+        }),
+    }),
+
+    where: () => ({
+        can: user => ({
+            do(feature, entity) {
+                // on vérifie que l'utilisateur dispose de la permission demandée
+                if (!user || !user.permissions || !user.permissions[entity]) {
+                    throw new Error(`L'utilisateur ne dispose pas de la permission ${entity}.${feature}`);
+                }
+
+                const permission = user.permissions[entity][feature];
+                if (!permission || permission.allowed !== true) {
+                    throw new Error(`L'utilisateur ne dispose pas de la permission ${entity}.${feature}`);
+                }
+
+                // on détermine quel est le niveau géographique de la permission (on traduit notamment "local" en un niveau géographique concret)
+                let permissionLevel = permission.geographic_level;
+                if (permissionLevel === 'local') {
+                    switch (user.organization.location.type) {
+                        case 'nation':
+                        case 'region':
+                            permissionLevel = user.organization.location.type;
+                            break;
+
+                        // pour tout utilisateur en-dessous du niveau régional, une permission "local" se traduit en permission "départementale"
+                        default:
+                            permissionLevel = 'departement';
+                    }
+                }
+
+                switch (permissionLevel) {
+                    case 'nation':
+                        return null;
+
+                    case 'region':
+                        if (!user.organization.location.region) {
+                            throw new Error('Impossible d\'accorder une permission régionale à un utilisateur national');
+                        }
+
+                        return {
+                            statement: 'regions.code IN (:where_region)',
+                            replacements: {
+                                where_region: [user.organization.location.region.code],
+                            },
+                        };
+
+                    case 'departement':
+                        if (!user.organization.location.departement) {
+                            throw new Error('Impossible d\'accorder une permission départementale à un utilisateur non rattaché à un département');
+                        }
+
+                        return {
+                            statement: 'departements.code IN (:where_departement)',
+                            replacements: {
+                                where_departement: [user.organization.location.departement.code],
+                            },
+                        };
+
+                    case 'epci':
+                        if (!user.organization.location.epci) {
+                            throw new Error('Impossible d\'accorder une permission intercommunale à un utilisateur non rattaché à une epci');
+                        }
+
+                        if (entity === 'plan') {
+                            throw new Error('Impossible d\'accorder une permission de niveau `epci` à l\'entité `plan`');
+                        }
+
+                        return {
+                            statement: 'epci.code IN (:where_epci)',
+                            replacements: {
+                                where_epci: [user.organization.location.epci.code],
+                            },
+                        };
+
+                    case 'city':
+                        if (!user.organization.location.city) {
+                            throw new Error('Impossible d\'accorder une permission communale à un utilisateur non rattaché à une commune');
+                        }
+
+                        if (entity === 'plan') {
+                            throw new Error('Impossible d\'accorder une permission de niveau `city` à l\'entité `plan`');
+                        }
+
+                        return {
+                            statement: 'cities.code IN (:where_city) OR cities.fk_main IN (:where_city)',
+                            replacements: {
+                                where_city: [user.organization.location.city.code],
+                            },
+                        };
+
+                    case 'own':
+                        if (entity !== 'plan') {
+                            throw new Error(`Impossible d'accorder une permission de niveau \`own\` à l'entité \`${entity}\``);
+                        }
+
+                        return {
+                            statement: '(plan_managers && ARRAY[:where_managers]) OR (plan_operators && ARRAY[:where_managers])',
+                            replacements: {
+                                where_managers: [user.id],
+                            },
+                        };
+
+                    default:
+                        throw new Error('Niveau de permission inconnu');
+                }
+            },
+        }),
+    }),
+
+};

--- a/packages/api/server/services/permissionService.js
+++ b/packages/api/server/services/permissionService.js
@@ -64,9 +64,16 @@ module.exports = {
                             permissionLevel = 'region';
                             break;
 
-                        // pour tout utilisateur en-dessous du niveau régional, une permission "local" se traduit en permission "départementale"
+                        // pour tout utilisateur en-dessous du niveau régional :
+                        // une permission "local" se traduit :
+                        // - pour de la lecture en permission "départementale"
+                        // - pour de l'écriture en permission "locale"
                         default:
-                            permissionLevel = 'departement';
+                            if (['listPrivate', 'list', 'export', 'read', 'access'].includes(feature)) {
+                                permissionLevel = 'departement';
+                            } else {
+                                permissionLevel = user.organization.location.type;
+                            }
                     }
                 } else {
                     permissionLevel = user.permissions.shantytown.export.geographic_level;
@@ -77,7 +84,12 @@ module.exports = {
                     return false;
                 }
 
-                return location[permissionLevel].code === user.organization.location[permissionLevel].code;
+                const codes = [location[permissionLevel].code];
+                if (permissionLevel === 'city' && location[permissionLevel].main) {
+                    codes.push(location[permissionLevel].main);
+                }
+
+                return codes.includes(user.organization.location[permissionLevel].code);
             },
         }),
     }),
@@ -104,9 +116,16 @@ module.exports = {
                             permissionLevel = user.organization.location.type;
                             break;
 
-                        // pour tout utilisateur en-dessous du niveau régional, une permission "local" se traduit en permission "départementale"
+                        // pour tout utilisateur en-dessous du niveau régional
+                        // une permission "local" se traduit en :
+                        // - permission "départementale" pour une permission de lecture
+                        // - permission "locale" pour une permission d'écriture
                         default:
-                            permissionLevel = 'departement';
+                            if (['listPrivate', 'list', 'export', 'read', 'access'].includes(feature)) {
+                                permissionLevel = 'departement';
+                            } else {
+                                permissionLevel = user.organization.location.type;
+                            }
                     }
                 }
 

--- a/packages/api/server/services/permissionService.js
+++ b/packages/api/server/services/permissionService.js
@@ -66,13 +66,13 @@ module.exports = {
 
                         // pour tout utilisateur en-dessous du niveau régional :
                         // une permission "local" se traduit :
-                        // - pour de la lecture en permission "départementale"
                         // - pour de l'écriture en permission "locale"
+                        // - pour de la lecture en permission "départementale"
                         default:
-                            if (['listPrivate', 'list', 'export', 'read', 'access'].includes(feature)) {
-                                permissionLevel = 'departement';
-                            } else {
+                            if (permission.write) {
                                 permissionLevel = user.organization.location.type;
+                            } else {
+                                permissionLevel = 'departement';
                             }
                     }
                 } else {
@@ -118,13 +118,13 @@ module.exports = {
 
                         // pour tout utilisateur en-dessous du niveau régional
                         // une permission "local" se traduit en :
-                        // - permission "départementale" pour une permission de lecture
                         // - permission "locale" pour une permission d'écriture
+                        // - permission "départementale" pour une permission de lecture
                         default:
-                            if (['listPrivate', 'list', 'export', 'read', 'access'].includes(feature)) {
-                                permissionLevel = 'departement';
-                            } else {
+                            if (permission.write) {
                                 permissionLevel = user.organization.location.type;
+                            } else {
+                                permissionLevel = 'departement';
                             }
                     }
                 }

--- a/packages/api/server/utils/sql.js
+++ b/packages/api/server/utils/sql.js
@@ -1,0 +1,83 @@
+function buildClause(defaultTable, index, key, definition) {
+    // parse
+    const column = (definition && definition.query) || `${defaultTable}.${key}`;
+    const not = (definition && definition.not) === true;
+    const replacementKey = `${key}${index}`;
+    const operator = (definition && definition.operator) || 'IN';
+
+    let replacementValue = definition;
+    if (definition && Object.prototype.hasOwnProperty.call(definition, 'value')) {
+        replacementValue = definition.value;
+    }
+
+    // build
+    return {
+        statement: `(${column} ${not ? 'NOT' : ''} ${operator} (:${replacementKey}))`,
+        replacement: {
+            [replacementKey]: replacementValue,
+        },
+    };
+}
+
+
+function buildClauseGroup(defaultTable, index, group) {
+    const statement = [];
+    const replacement = {};
+
+    Object.keys(group).forEach((key) => {
+        const {
+            statement: subStatement,
+            replacement: subReplacement,
+        } = buildClause(defaultTable, index, key, group[key]);
+
+        statement.push(subStatement);
+        Object.assign(replacement, subReplacement);
+    });
+
+    return {
+        statement: `(${statement.join(' OR ')})`,
+        replacement,
+    };
+}
+
+/**
+ * Example of valid input:
+ * [
+ *      {
+ *          population_total: 10,
+ *          trash_evacuation: { value: false },
+ *      },
+ *      {
+ *          departement: { value: '78', query: 'departements.code' },
+ *          status: { not: true, value: ['open', 'unknown'] },
+ *      },
+ *      {
+ *          name: { operator: 'ILIKE', value: '%a%' }
+ *      }
+ *  ]
+ *
+ *  Which should translate into:
+ *  (population_total IN (10) OR trash_evacuation IN (false))
+ *  AND
+ *  (departements.code IN ('78') OR status NOT IN ('open', 'unknown'))
+ *  AND
+ *  (name ILIKE ('%a%'))
+ */
+module.exports = {
+    buildWhere(defaultTable, clauseGroups) {
+        return clauseGroups.reduce((acc, group, index) => {
+            const {
+                statement: subStatement,
+                replacement: subReplacement,
+            } = buildClauseGroup(defaultTable, index, group);
+
+            return {
+                statement: [...acc.statement, subStatement],
+                replacement: { ...acc.replacement, ...subReplacement },
+            };
+        }, {
+            statement: [],
+            replacement: {},
+        });
+    },
+};

--- a/packages/api/test/suites/server/services/permissionService/can.spec.js
+++ b/packages/api/test/suites/server/services/permissionService/can.spec.js
@@ -51,6 +51,7 @@ describe.only('PermissionService', () => {
                 user: location.nation(),
                 requested: location.nation(),
                 expected: true,
+                feature: 'update',
             },
             // region
             {
@@ -58,18 +59,21 @@ describe.only('PermissionService', () => {
                 user: location.region(),
                 requested: location.city(),
                 expected: true,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau régional et demande une permission sur une ville d\'une autre région, retourne false',
                 user: location.region(),
                 requested: location.city({ region: { code: '99' } }),
                 expected: false,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau régional et demande une permission au niveau national, retourne false',
                 user: location.region(),
                 requested: location.nation(),
                 expected: false,
+                feature: 'update',
             },
             // departement
             {
@@ -77,24 +81,28 @@ describe.only('PermissionService', () => {
                 user: location.departement(),
                 requested: location.city(),
                 expected: true,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau départemental et demande une permission sur une ville d\'un autre département, retourne false',
                 user: location.departement(),
                 requested: location.city({ departement: { code: '99' } }),
                 expected: false,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau départemental et demande une permission au niveau régional, retourne false',
                 user: location.departement(),
                 requested: location.region(),
                 expected: false,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau départemental et demande une permission au niveau national, retourne false',
                 user: location.departement(),
                 requested: location.nation(),
                 expected: false,
+                feature: 'update',
             },
             // epci
             {
@@ -102,30 +110,42 @@ describe.only('PermissionService', () => {
                 user: location.epci(),
                 requested: location.city(),
                 expected: true,
+                feature: 'update',
             },
             {
-                test: 'l\'utilisateur est de niveau epci et demande une permission au niveau départemental, retourne true',
+                test: 'l\'utilisateur est de niveau epci et demande une permission de lecture au niveau départemental, retourne true',
                 user: location.epci(),
                 requested: location.departement(),
                 expected: true,
+                feature: 'list',
             },
             {
-                test: 'l\'utilisateur est de niveau epci et demande une permission sur une ville d\'un autre département, retourne false',
+                test: 'l\'utilisateur est de niveau epci et demande une permission d\'écriture au niveau départemental, retourne false',
                 user: location.epci(),
-                requested: location.city({ departement: { code: '99' } }),
+                requested: location.departement(),
                 expected: false,
+                feature: 'update',
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission sur une ville d\'un autre epci, retourne false',
+                user: location.epci(),
+                requested: location.city({ epci: { code: '99' } }),
+                expected: false,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau epci et demande une permission au niveau régional, retourne false',
                 user: location.epci(),
                 requested: location.region(),
                 expected: false,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau epci et demande une permission au niveau national, retourne false',
                 user: location.epci(),
                 requested: location.nation(),
                 expected: false,
+                feature: 'update',
             },
             // city
             {
@@ -133,50 +153,68 @@ describe.only('PermissionService', () => {
                 user: location.city(),
                 requested: location.district(),
                 expected: true,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau communal et demande une permission sur sa ville, retourne true',
                 user: location.city(),
                 requested: location.city(),
                 expected: true,
+                feature: 'update',
             },
             {
-                test: 'l\'utilisateur est de niveau communal et demande une permission au niveau départemental, retourne true',
+                test: 'l\'utilisateur est de niveau communal et demande une permission de lecture au niveau départemental, retourne true',
                 user: location.city(),
                 requested: location.departement(),
                 expected: true,
+                feature: 'list',
             },
             {
-                test: 'l\'utilisateur est de niveau communal et demande une permission sur une ville d\'un autre département, retourne false',
+                test: 'l\'utilisateur est de niveau communal et demande une permission d\'écriture au niveau départemental, retourne false',
                 user: location.city(),
-                requested: location.city({ departement: { code: '99' } }),
+                requested: location.departement(),
                 expected: false,
+                feature: 'update',
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission sur une autre ville, retourne false',
+                user: location.city(),
+                requested: location.city({ city: { code: '99' } }),
+                expected: false,
+                feature: 'update',
             },
             {
                 test: 'l\'utilisateur est de niveau communal et demande une permission au niveau régional, retourne false',
                 user: location.city(),
                 requested: location.region(),
                 expected: false,
+                feature: 'update',
             },
             {
-                test: 'l\'utilisateur est de niveau v et demande une permission au niveau national, retourne false',
+                test: 'l\'utilisateur est de niveau communal et demande une permission au niveau national, retourne false',
                 user: location.city(),
                 requested: location.nation(),
                 expected: false,
+                feature: 'update',
             },
         ];
 
         dataset.forEach(({
-            test, user: userLocation, requested: requestedLocation, expected,
+            test, user: userLocation, requested: requestedLocation, expected, feature,
         }) => {
             it(`Si la permission est autorisée au niveau local et que ${test}`, () => {
                 expect(
                     can(createUser({
-                        permissions: { shantytown: { list: { geographic_level: 'local' } } },
+                        permissions: {
+                            shantytown: {
+                                list: { geographic_level: 'local' },
+                                update: { geographic_level: 'local' },
+                            },
+                        },
                         organization: {
                             location: userLocation,
                         },
-                    })).do('list', 'shantytown').on(requestedLocation),
+                    })).do(feature, 'shantytown').on(requestedLocation),
                 ).to.be.eql(expected);
             });
         });

--- a/packages/api/test/suites/server/services/permissionService/can.spec.js
+++ b/packages/api/test/suites/server/services/permissionService/can.spec.js
@@ -1,0 +1,290 @@
+const { expect } = require('chai');
+const { can } = require('#server/services/permissionService');
+const location = require('#test/utils/location');
+const { serialized: createUser } = require('#test/utils/user');
+const { serialized: createPlan } = require('#test/utils/plan');
+
+describe.only('PermissionService', () => {
+    describe('.can(user).do(feature, entity).on(location)', () => {
+        it('Si l\'utilisateur n\'est pas défini, retourne false', () => {
+            expect(
+                can(undefined).do('list', 'shantytown').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si l\'utilisateur n\'a pas de permissions définies, retourne false', () => {
+            expect(
+                can(createUser({ permissions: undefined })).do('list', 'shantytown').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si l\'utilisateur n\'a pas de permissions pour l\'entité demandée, retourne false', () => {
+            expect(
+                can(createUser()).do('list', 'whatever').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si l\'utilisateur n\'a pas de permissions pour la feature demandée, retourne false', () => {
+            expect(
+                can(createUser()).do('whatever', 'shantytown').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si la permission est allowed=false pour l\'utilisateur, retourne false', () => {
+            expect(
+                can(createUser({
+                    permissions: { shantytown: { list: { allowed: false } } },
+                })).do('list', 'shantytown').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si la permission est autorisée au niveau national, retourne true', () => {
+            expect(
+                can(createUser()).do('list', 'shantytown').on(location.nation()),
+            ).to.be.true;
+        });
+
+        const dataset = [
+            // nation
+            {
+                test: 'l\'utilisateur est de niveau national, retourne true',
+                user: location.nation(),
+                requested: location.nation(),
+                expected: true,
+            },
+            // region
+            {
+                test: 'l\'utilisateur est de niveau régional et demande une permission sur une ville de la région, retourne true',
+                user: location.region(),
+                requested: location.city(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau régional et demande une permission sur une ville d\'une autre région, retourne false',
+                user: location.region(),
+                requested: location.city({ region: { code: '99' } }),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau régional et demande une permission au niveau national, retourne false',
+                user: location.region(),
+                requested: location.nation(),
+                expected: false,
+            },
+            // departement
+            {
+                test: 'l\'utilisateur est de niveau départemental et demande une permission sur une ville du département, retourne true',
+                user: location.departement(),
+                requested: location.city(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau départemental et demande une permission sur une ville d\'un autre département, retourne false',
+                user: location.departement(),
+                requested: location.city({ departement: { code: '99' } }),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau départemental et demande une permission au niveau régional, retourne false',
+                user: location.departement(),
+                requested: location.region(),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau départemental et demande une permission au niveau national, retourne false',
+                user: location.departement(),
+                requested: location.nation(),
+                expected: false,
+            },
+            // epci
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission sur une ville du département associé, retourne true',
+                user: location.epci(),
+                requested: location.city(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission au niveau départemental, retourne true',
+                user: location.epci(),
+                requested: location.departement(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission sur une ville d\'un autre département, retourne false',
+                user: location.epci(),
+                requested: location.city({ departement: { code: '99' } }),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission au niveau régional, retourne false',
+                user: location.epci(),
+                requested: location.region(),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission au niveau national, retourne false',
+                user: location.epci(),
+                requested: location.nation(),
+                expected: false,
+            },
+            // city
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission sur un arrondissement de sa ville, retourne true',
+                user: location.city(),
+                requested: location.district(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission sur sa ville, retourne true',
+                user: location.city(),
+                requested: location.city(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission au niveau départemental, retourne true',
+                user: location.city(),
+                requested: location.departement(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission sur une ville d\'un autre département, retourne false',
+                user: location.city(),
+                requested: location.city({ departement: { code: '99' } }),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission au niveau régional, retourne false',
+                user: location.city(),
+                requested: location.region(),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau v et demande une permission au niveau national, retourne false',
+                user: location.city(),
+                requested: location.nation(),
+                expected: false,
+            },
+        ];
+
+        dataset.forEach(({
+            test, user: userLocation, requested: requestedLocation, expected,
+        }) => {
+            it(`Si la permission est autorisée au niveau local et que ${test}`, () => {
+                expect(
+                    can(createUser({
+                        permissions: { shantytown: { list: { geographic_level: 'local' } } },
+                        organization: {
+                            location: userLocation,
+                        },
+                    })).do('list', 'shantytown').on(requestedLocation),
+                ).to.be.eql(expected);
+            });
+        });
+
+        it('Si la permission est de niveau `own` mais que le dispositif est null, lance une exception', () => {
+            expect(
+                () => can(createUser({
+                    permissions: { plan: { list: { geographic_level: 'own' } } },
+                })).do('list', 'plan').on(location.nation(), null),
+            ).to.throw('Le dispositif est obligatoire pour une permission de type `own`');
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `update` et que le dispositif n\'a pas de pilote, retourne false', () => {
+            expect(
+                can(createUser({
+                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                })).do('update', 'plan').on(location.nation(), {}),
+            ).to.be.false;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `update` et que l\'utilisateur est le pilote du dispositif, retourne true', () => {
+            expect(
+                can(createUser({
+                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                })).do('update', 'plan').on(location.nation(), createPlan()),
+            ).to.be.true;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `update` et que l\'utilisateur n\'est pas le pilote du dispositif, retourne false', () => {
+            expect(
+                can(createUser({
+                    id: 3,
+                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                })).do('update', 'plan').on(location.nation(), createPlan()),
+            ).to.be.false;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `updateMarks` et que le dispositif n\'a pas d\'opérateur, retourne false', () => {
+            expect(
+                can(createUser({
+                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                })).do('updateMarks', 'plan').on(location.nation(), {}),
+            ).to.be.false;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `updateMarks` et que l\'utilisateur est un opérateur du dispositif, retourne true', () => {
+            expect(
+                can(createUser({
+                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                })).do('updateMarks', 'plan').on(location.nation(), createPlan()),
+            ).to.be.true;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `updateMarks` et que l\'utilisateur n\'est pas un opérateur du dispositif, retourne false', () => {
+            expect(
+                can(createUser({
+                    organization: {
+                        id: 3,
+                    },
+                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                })).do('updateMarks', 'plan').on(location.nation(), createPlan()),
+            ).to.be.false;
+        });
+
+        it('Si la permission est de niveau `own`, que la feature demandée n\'est ni `update` ni `updateMarks`, et que l\'utilisateur est pilote du dispositif, retourne true', () => {
+            const user = createUser({
+                id: 666,
+                organization: {
+                    id: 666,
+                },
+                permissions: { plan: { list: { geographic_level: 'own' } } },
+            });
+
+            expect(
+                can(user).do('list', 'plan').on(location.nation(), createPlan({
+                    government_contacts: [user],
+                })),
+            ).to.be.true;
+        });
+
+        it('Si la permission est de niveau `own`, que la feature demandée n\'est ni `update` ni `updateMarks`, et que l\'utilisateur est opérateur du dispositif, retourne true', () => {
+            const user = createUser({
+                id: 666,
+                organization: {
+                    id: 666,
+                },
+                permissions: { plan: { list: { geographic_level: 'own' } } },
+            });
+
+            expect(
+                can(user).do('list', 'plan').on(location.nation(), createPlan({
+                    operator_contacts: [user],
+                })),
+            ).to.be.true;
+        });
+
+        it('Si la permission est de niveau `own`, que la feature demandée n\'est ni `update` ni `updateMarks`, et que le dispositif n\'a ni pilote ni dispositif, retourne false', () => {
+            const user = createUser({
+                id: 666,
+                organization: {
+                    id: 666,
+                },
+                permissions: { plan: { list: { geographic_level: 'own' } } },
+            });
+
+            expect(
+                can(user).do('list', 'plan').on(location.nation(), {}),
+            ).to.be.false;
+        });
+    });
+});

--- a/packages/api/test/suites/server/services/permissionService/can.spec.js
+++ b/packages/api/test/suites/server/services/permissionService/can.spec.js
@@ -33,7 +33,7 @@ describe.only('PermissionService', () => {
         it('Si la permission est allowed=false pour l\'utilisateur, retourne false', () => {
             expect(
                 can(createUser({
-                    permissions: { shantytown: { list: { allowed: false } } },
+                    permissions: { shantytown: { list: { allowed: false, write: false } } },
                 })).do('list', 'shantytown').on(location.city()),
             ).to.be.false;
         });
@@ -207,8 +207,8 @@ describe.only('PermissionService', () => {
                     can(createUser({
                         permissions: {
                             shantytown: {
-                                list: { geographic_level: 'local' },
-                                update: { geographic_level: 'local' },
+                                list: { geographic_level: 'local', write: false },
+                                update: { geographic_level: 'local', write: true },
                             },
                         },
                         organization: {
@@ -222,7 +222,7 @@ describe.only('PermissionService', () => {
         it('Si la permission est de niveau `own` mais que le dispositif est null, lance une exception', () => {
             expect(
                 () => can(createUser({
-                    permissions: { plan: { list: { geographic_level: 'own' } } },
+                    permissions: { plan: { list: { geographic_level: 'own', write: false } } },
                 })).do('list', 'plan').on(location.nation(), null),
             ).to.throw('Le dispositif est obligatoire pour une permission de type `own`');
         });
@@ -230,7 +230,7 @@ describe.only('PermissionService', () => {
         it('Si la permission est de niveau `own` pour la feature `update` et que le dispositif n\'a pas de pilote, retourne false', () => {
             expect(
                 can(createUser({
-                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                    permissions: { plan: { update: { geographic_level: 'own', write: true } } },
                 })).do('update', 'plan').on(location.nation(), {}),
             ).to.be.false;
         });
@@ -238,7 +238,7 @@ describe.only('PermissionService', () => {
         it('Si la permission est de niveau `own` pour la feature `update` et que l\'utilisateur est le pilote du dispositif, retourne true', () => {
             expect(
                 can(createUser({
-                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                    permissions: { plan: { update: { geographic_level: 'own', write: true } } },
                 })).do('update', 'plan').on(location.nation(), createPlan()),
             ).to.be.true;
         });
@@ -247,7 +247,7 @@ describe.only('PermissionService', () => {
             expect(
                 can(createUser({
                     id: 3,
-                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                    permissions: { plan: { update: { geographic_level: 'own', write: true } } },
                 })).do('update', 'plan').on(location.nation(), createPlan()),
             ).to.be.false;
         });
@@ -255,7 +255,7 @@ describe.only('PermissionService', () => {
         it('Si la permission est de niveau `own` pour la feature `updateMarks` et que le dispositif n\'a pas d\'opérateur, retourne false', () => {
             expect(
                 can(createUser({
-                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                    permissions: { plan: { updateMarks: { geographic_level: 'own', write: true } } },
                 })).do('updateMarks', 'plan').on(location.nation(), {}),
             ).to.be.false;
         });
@@ -263,7 +263,7 @@ describe.only('PermissionService', () => {
         it('Si la permission est de niveau `own` pour la feature `updateMarks` et que l\'utilisateur est un opérateur du dispositif, retourne true', () => {
             expect(
                 can(createUser({
-                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                    permissions: { plan: { updateMarks: { geographic_level: 'own', write: true } } },
                 })).do('updateMarks', 'plan').on(location.nation(), createPlan()),
             ).to.be.true;
         });
@@ -274,7 +274,7 @@ describe.only('PermissionService', () => {
                     organization: {
                         id: 3,
                     },
-                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                    permissions: { plan: { updateMarks: { geographic_level: 'own', write: true } } },
                 })).do('updateMarks', 'plan').on(location.nation(), createPlan()),
             ).to.be.false;
         });
@@ -285,7 +285,7 @@ describe.only('PermissionService', () => {
                 organization: {
                     id: 666,
                 },
-                permissions: { plan: { list: { geographic_level: 'own' } } },
+                permissions: { plan: { list: { geographic_level: 'own', write: false } } },
             });
 
             expect(
@@ -301,7 +301,7 @@ describe.only('PermissionService', () => {
                 organization: {
                     id: 666,
                 },
-                permissions: { plan: { list: { geographic_level: 'own' } } },
+                permissions: { plan: { list: { geographic_level: 'own', write: false } } },
             });
 
             expect(
@@ -317,7 +317,7 @@ describe.only('PermissionService', () => {
                 organization: {
                     id: 666,
                 },
-                permissions: { plan: { list: { geographic_level: 'own' } } },
+                permissions: { plan: { list: { geographic_level: 'own', write: false } } },
             });
 
             expect(

--- a/packages/api/test/suites/server/services/permissionService/where.spec.js
+++ b/packages/api/test/suites/server/services/permissionService/where.spec.js
@@ -32,7 +32,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur est défini mais la permission demandée est set à allowed=false, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: false } } },
+                    permissions: { shantytown: { list: { allowed: false, write: false } } },
                 })).do('list', 'shantytown'),
             ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.list');
         });
@@ -46,7 +46,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau régional et qu\'il est de niveau communal, retourne sa région', () => {
             expect(
                 where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'region' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'region', write: false } } },
                     organization: { location: location.city() },
                 })).do('list', 'shantytown'),
             ).to.be.eql({ statement: 'regions.code IN (:where_region)', replacements: { where_region: ['11'] } });
@@ -55,7 +55,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau régional et qu\'il est de niveau national, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'region' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'region', write: false } } },
                 })).do('list', 'shantytown'),
             ).to.throw('Impossible d\'accorder une permission régionale à un utilisateur national');
         });
@@ -63,7 +63,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau départemental et qu\'il est de niveau communal, retourne son département', () => {
             expect(
                 where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'departement' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'departement', write: false } } },
                     organization: { location: location.city() },
                 })).do('list', 'shantytown'),
             ).to.be.eql({ statement: 'departements.code IN (:where_departement)', replacements: { where_departement: ['92'] } });
@@ -72,7 +72,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau départemental et qu\'il est de niveau régional, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'departement' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'departement', write: false } } },
                     organization: { location: location.region() },
                 })).do('list', 'shantytown'),
             ).to.throw('Impossible d\'accorder une permission départementale à un utilisateur non rattaché à un département');
@@ -81,7 +81,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau intercommunal et qu\'il est de niveau intercommunal, retourne son epci', () => {
             expect(
                 where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'epci' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'epci', write: false } } },
                     organization: { location: location.city() },
                 })).do('list', 'shantytown'),
             ).to.be.eql({ statement: 'epci.code IN (:where_epci)', replacements: { where_epci: ['200054781'] } });
@@ -90,7 +90,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau intercommunal et qu\'il est de niveau départemental, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'epci' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'epci', write: false } } },
                     organization: { location: location.departement() },
                 })).do('list', 'shantytown'),
             ).to.throw('Impossible d\'accorder une permission intercommunale à un utilisateur non rattaché à une epci');
@@ -99,7 +99,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau communal et qu\'il est de niveau communal, retourne sa commune', () => {
             expect(
                 where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'city' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'city', write: false } } },
                     organization: { location: location.city() },
                 })).do('list', 'shantytown'),
             ).to.be.eql({ statement: 'cities.code IN (:where_city) OR cities.fk_main IN (:where_city)', replacements: { where_city: ['75056'] } });
@@ -108,7 +108,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau communal et qu\'il est de niveau intercommunal, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'city' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'city', write: false } } },
                     organization: { location: location.epci() },
                 })).do('list', 'shantytown'),
             ).to.throw('Impossible d\'accorder une permission communale à un utilisateur non rattaché à une commune');
@@ -117,7 +117,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau national, retourne null', () => {
             expect(
                 where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local', write: false } } },
                 })).do('list', 'shantytown'),
             ).to.be.eql(null);
         });
@@ -125,7 +125,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau régional, retourne sa région', () => {
             expect(
                 where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local', write: false } } },
                     organization: { location: location.region() },
                 })).do('list', 'shantytown'),
             ).to.be.eql({ statement: 'regions.code IN (:where_region)', replacements: { where_region: ['11'] } });
@@ -134,7 +134,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau local, qu\'il s\'agit d\'une permission d\'écriture, et qu\'il est de niveau communal, retourne sa commune', () => {
             expect(
                 where().can(createUser({
-                    permissions: { shantytown: { update: { allowed: true, geographic_level: 'local' } } },
+                    permissions: { shantytown: { update: { allowed: true, geographic_level: 'local', write: true } } },
                     organization: { location: location.city() },
                 })).do('update', 'shantytown'),
             ).to.be.eql({ statement: 'cities.code IN (:where_city) OR cities.fk_main IN (:where_city)', replacements: { where_city: ['75056'] } });
@@ -143,7 +143,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau local, qu\'il s\'agit d\'une permission de lecture, et qu\'il est de niveau communal, retourne son département', () => {
             expect(
                 where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local', write: false } } },
                     organization: { location: location.city() },
                 })).do('list', 'shantytown'),
             ).to.be.eql({ statement: 'departements.code IN (:where_departement)', replacements: { where_departement: ['92'] } });
@@ -152,7 +152,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau own, et que l\'entité n\'est pas plan, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { shantytown: { update: { allowed: true, geographic_level: 'own' } } },
+                    permissions: { shantytown: { update: { allowed: true, geographic_level: 'own', write: true } } },
                 })).do('update', 'shantytown'),
             ).to.throw('Impossible d\'accorder une permission de niveau `own` à l\'entité `shantytown`');
         });
@@ -160,7 +160,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau own, retourne un filtre sur les managers et operators', () => {
             expect(
                 where().can(createUser({
-                    permissions: { plan: { list: { allowed: true, geographic_level: 'own' } } },
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'own', write: false } } },
                 })).do('list', 'plan'),
             ).to.be.eql({ statement: '(plan_managers && ARRAY[:where_managers]) OR (plan_operators && ARRAY[:where_managers])', replacements: { where_managers: [2] } });
         });
@@ -168,7 +168,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau epci pour l\'entité plan, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { plan: { list: { allowed: true, geographic_level: 'epci' } } },
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'epci', write: false } } },
                     organization: { location: location.city() },
                 })).do('list', 'plan'),
             ).to.throw('Impossible d\'accorder une permission de niveau `epci` à l\'entité `plan`');
@@ -177,7 +177,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée au niveau city pour l\'entité plan, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { plan: { list: { allowed: true, geographic_level: 'city' } } },
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'city', write: false } } },
                     organization: { location: location.city() },
                 })).do('list', 'plan'),
             ).to.throw('Impossible d\'accorder une permission de niveau `city` à l\'entité `plan`');
@@ -186,7 +186,7 @@ describe.only('PermissionService', () => {
         it('Si l\'utilisateur dispose de la permission demandée à un niveau inconnu, lance une exception', () => {
             expect(
                 () => where().can(createUser({
-                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'whatever' } } },
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'whatever', write: false } } },
                 })).do('list', 'shantytown'),
             ).to.throw('Niveau de permission inconnu');
         });

--- a/packages/api/test/suites/server/services/permissionService/where.spec.js
+++ b/packages/api/test/suites/server/services/permissionService/where.spec.js
@@ -1,0 +1,185 @@
+const { expect } = require('chai');
+const { where } = require('#server/services/permissionService');
+const { serialized: createUser } = require('#test/utils/user');
+const location = require('#test/utils/location');
+
+describe.only('PermissionService', () => {
+    describe('.where().can(user).do(feature, entity)', () => {
+        it('Si l\'utilisateur n\'est pas défini, lance une exception', () => {
+            expect(
+                () => where().can(undefined).do('list', 'shantytown'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.list');
+        });
+
+        it('Si l\'utilisateur est défini mais ne dispose pas de permissions, lance une exception', () => {
+            expect(
+                () => where().can(createUser({ permissions: undefined })).do('list', 'shantytown'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.list');
+        });
+
+        it('Si l\'utilisateur est défini mais ne dispose pas de permissions pour l\'entitée demandée, lance une exception', () => {
+            expect(
+                () => where().can(createUser()).do('list', 'whatever'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission whatever.list');
+        });
+
+        it('Si l\'utilisateur est défini mais ne dispose pas de la permission demandée, lance une exception', () => {
+            expect(
+                () => where().can(createUser()).do('whatever', 'shantytown'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.whatever');
+        });
+
+        it('Si l\'utilisateur est défini mais la permission demandée est set à allowed=false, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: false } } },
+                })).do('list', 'shantytown'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.list');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau national, retourne null', () => {
+            expect(
+                where().can(createUser()).do('list', 'shantytown'),
+            ).to.be.eql(null);
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau régional et qu\'il est de niveau communal, retourne sa région', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'region' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'regions.code IN (:where_region)', replacements: { where_region: ['11'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau régional et qu\'il est de niveau national, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'region' } } },
+                })).do('list', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission régionale à un utilisateur national');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau départemental et qu\'il est de niveau communal, retourne son département', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'departement' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'departements.code IN (:where_departement)', replacements: { where_departement: ['92'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau départemental et qu\'il est de niveau régional, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'departement' } } },
+                    organization: { location: location.region() },
+                })).do('list', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission départementale à un utilisateur non rattaché à un département');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau intercommunal et qu\'il est de niveau intercommunal, retourne son epci', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'epci' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'epci.code IN (:where_epci)', replacements: { where_epci: ['200054781'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau intercommunal et qu\'il est de niveau départemental, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'epci' } } },
+                    organization: { location: location.departement() },
+                })).do('list', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission intercommunale à un utilisateur non rattaché à une epci');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau communal et qu\'il est de niveau communal, retourne sa commune', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'city' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'cities.code IN (:where_city) OR cities.fk_main IN (:where_city)', replacements: { where_city: ['75056'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau communal et qu\'il est de niveau intercommunal, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'city' } } },
+                    organization: { location: location.epci() },
+                })).do('list', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission communale à un utilisateur non rattaché à une commune');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau national, retourne null', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                })).do('list', 'shantytown'),
+            ).to.be.eql(null);
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau régional, retourne sa région', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                    organization: { location: location.region() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'regions.code IN (:where_region)', replacements: { where_region: ['11'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau communal, retourne son département', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'departements.code IN (:where_departement)', replacements: { where_departement: ['92'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau own, et que l\'entité n\'est pas plan, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { update: { allowed: true, geographic_level: 'own' } } },
+                })).do('update', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission de niveau `own` à l\'entité `shantytown`');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau own, retourne un filtre sur les managers et operators', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'own' } } },
+                })).do('list', 'plan'),
+            ).to.be.eql({ statement: '(plan_managers && ARRAY[:where_managers]) OR (plan_operators && ARRAY[:where_managers])', replacements: { where_managers: [2] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau epci pour l\'entité plan, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'epci' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'plan'),
+            ).to.throw('Impossible d\'accorder une permission de niveau `epci` à l\'entité `plan`');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau city pour l\'entité plan, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'city' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'plan'),
+            ).to.throw('Impossible d\'accorder une permission de niveau `city` à l\'entité `plan`');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée à un niveau inconnu, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'whatever' } } },
+                })).do('list', 'shantytown'),
+            ).to.throw('Niveau de permission inconnu');
+        });
+    });
+});

--- a/packages/api/test/suites/server/services/permissionService/where.spec.js
+++ b/packages/api/test/suites/server/services/permissionService/where.spec.js
@@ -131,7 +131,16 @@ describe.only('PermissionService', () => {
             ).to.be.eql({ statement: 'regions.code IN (:where_region)', replacements: { where_region: ['11'] } });
         });
 
-        it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau communal, retourne son département', () => {
+        it('Si l\'utilisateur dispose de la permission demandée au niveau local, qu\'il s\'agit d\'une permission d\'écriture, et qu\'il est de niveau communal, retourne sa commune', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { update: { allowed: true, geographic_level: 'local' } } },
+                    organization: { location: location.city() },
+                })).do('update', 'shantytown'),
+            ).to.be.eql({ statement: 'cities.code IN (:where_city) OR cities.fk_main IN (:where_city)', replacements: { where_city: ['75056'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau local, qu\'il s\'agit d\'une permission de lecture, et qu\'il est de niveau communal, retourne son département', () => {
             expect(
                 where().can(createUser({
                     permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },

--- a/packages/api/test/utils/changelog.js
+++ b/packages/api/test/utils/changelog.js
@@ -1,3 +1,5 @@
+const merge = require('deepmerge');
+
 module.exports = {
     raw(override = {}) {
         const defaultObj = {
@@ -8,6 +10,6 @@ module.exports = {
             image: 'https://api.resorption-bidonvilles.localhost/assets/changelog/0.0.0/item_1.jpg',
         };
 
-        return Object.assign(defaultObj, override);
+        return merge(defaultObj, override);
     },
 };

--- a/packages/api/test/utils/location.js
+++ b/packages/api/test/utils/location.js
@@ -1,0 +1,107 @@
+const merge = require('deepmerge');
+
+module.exports = {
+    district(override = {}) {
+        return merge({
+            type: 'city',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: {
+                name: 'Hauts-de-Seine',
+                code: '92',
+            },
+            epci: {
+                name: 'Métropole du Grand Paris',
+                code: '200054781',
+            },
+            city: {
+                name: 'Paris 1er Arrondissement',
+                code: '75101',
+                main: '75056',
+            },
+        }, override);
+    },
+
+    city(override = {}) {
+        return merge({
+            type: 'city',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: {
+                name: 'Hauts-de-Seine',
+                code: '92',
+            },
+            epci: {
+                name: 'Métropole du Grand Paris',
+                code: '200054781',
+            },
+            city: {
+                name: 'Paris',
+                code: '75056',
+                main: null,
+            },
+        }, override);
+    },
+
+    epci(override = {}) {
+        return merge({
+            type: 'epci',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: {
+                name: 'Hauts-de-Seine',
+                code: '92',
+            },
+            epci: {
+                name: 'Métropole du Grand Paris',
+                code: '200054781',
+            },
+            city: null,
+        }, override);
+    },
+
+    departement(override = {}) {
+        return merge({
+            type: 'departement',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: {
+                name: 'Hauts-de-Seine',
+                code: '92',
+            },
+            epci: null,
+            city: null,
+        }, override);
+    },
+
+    region(override = {}) {
+        return merge({
+            type: 'region',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: null,
+            epci: null,
+            city: null,
+        }, override);
+    },
+
+    nation() {
+        return {
+            type: 'nation',
+            region: null,
+            departement: null,
+            epci: null,
+            city: null,
+        };
+    },
+};

--- a/packages/api/test/utils/plan.js
+++ b/packages/api/test/utils/plan.js
@@ -1,0 +1,46 @@
+const merge = require('deepmerge');
+const { serialized: createUser } = require('#test/utils/user');
+
+module.exports = {
+    serialized(override = {}) {
+        const defaultPlan = {
+            id: 2,
+            name: 'Dispositif',
+            started_at: (new Date(2020, 0, 1, 0, 0, 0)).getTime(),
+            expected_to_end_at: (new Date(2022, 0, 1, 0, 0, 0)).getTime(),
+            closed_at: null,
+            updated_at: null,
+            in_and_out: true,
+            goals: 'Objectif de dispositif',
+            location_type: {
+                id: 'housing',
+                label: 'sur terrain d\'insertion',
+            },
+            location_details: null,
+            final_comment: null,
+            government_contacts: [
+                createUser(),
+            ],
+            departement: {
+                code: '78',
+                name: 'Yvelines',
+            },
+            region: {
+                code: '11',
+                name: 'Île-de-France',
+            },
+            operator_contacts: [
+                createUser(),
+            ],
+            states: [],
+            topics: [{
+                uid: 'health',
+                name: 'Santé',
+            }],
+            createdBy: 2,
+            updatedBy: null,
+        };
+
+        return merge(defaultPlan, override);
+    },
+};

--- a/packages/api/test/utils/user.js
+++ b/packages/api/test/utils/user.js
@@ -1,3 +1,5 @@
+const merge = require('deepmerge');
+
 module.exports = {
     serialized(override = {}) {
         const defaultUser = {
@@ -96,6 +98,6 @@ module.exports = {
             last_changelog: '0.0.0',
         };
 
-        return Object.assign(defaultUser, override);
+        return merge(defaultUser, override);
     },
 };

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -118,6 +118,14 @@ export default {
                     ? permission.geographic_level
                     : this.user.organization.location.type;
 
+            if (
+                !permission.write &&
+                permission.geographic_level === "local" &&
+                ["epci", "city"].includes(this.user.organization.location.type)
+            ) {
+                level = "departement";
+            }
+
             if (level === "nation") {
                 return true;
             } else if (this.user.organization.location[level] === null) {


### PR DESCRIPTION
- création d'un permissionService qui expose deux fonctions can() et where() qui respectivement indique si un utilisateur a le droit de faire une action sur une entité donnée, et génère les conditions à injecter dans une requête SQL pour effectuer une action de lecture. Ce service prend en compte le périmètre géographique.
- écriture de tests unitaires sur le permissionService
- création d'utilitaires pour les tests unitaires qui génèrent des données de test
- màj des sources (notamment validators et modèles) pour utiliser le permissionService (là où c'était faisable sans trop de complexité)