### PR TITLE
#patch (1104) Initialisation d'un workflow de déploiement

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -1,0 +1,28 @@
+name: deploy-qa
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Nom de la branche Github à déployer (normalement `issue/...`)'
+        required: true
+        default: 'issue/'
+      tag:
+        description: 'Nom de l''image Docker correspondante (`qa-...`), à générer préalablement via le workflow `qa`'
+        required: true
+        default: 'qa-'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.PREPROD_HOST }}
+          username: ${{ secrets.PREPROD_USERNAME }}
+          key: ${{ secrets.PREPROD_KEY }}
+          port: ${{ secrets.PREPROD_PORT }}
+          # fingerprint: ${{ secrets.PREPROD_FINGERPRINT }}
+          script: |
+            cd /srv/resorption-bidonvilles
+            scripts/deploy.sh ${{ github.event.inputs.branch }} ${{ github.event.inputs.tag }}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/bkHJBsBC/1104

## 🛠 Description de la PR
Ajout d'un workflow qui permet d'exécuter via une session SSH le script `deploy.sh`, ce qui permet un déploiement automatisé en préprod.

Voir également (et surtout), la PR côté deploy : https://github.com/MTES-MCT/resorption-bidonvilles-deploy/pull/9

## 📸 Captures d'écran
- Bilan d'un run réussi :
<img width="366" alt="Capture d’écran 2021-06-14 à 10 54 14" src="https://user-images.githubusercontent.com/1801091/121866167-f76ff080-ccfe-11eb-98d8-ecb7a1c548b5.png">

- Exemple d'output pour la fin du run :
<img width="747" alt="Capture d’écran 2021-06-14 à 10 54 42" src="https://user-images.githubusercontent.com/1801091/121866123-ee7f1f00-ccfe-11eb-97bf-14ad125505ed.png">


## 🚨 Notes pour la mise en production
*CE SCRIPT N'EST VALABLE QUE POUR LA PREPROD*