### PR TITLE
#patch (1077) Rendre obligatoire le numéro de téléphone sur les demandes d'info et demande d'accès

### DIFF
--- a/packages/api/server/middlewares/validators/createContact.js
+++ b/packages/api/server/middlewares/validators/createContact.js
@@ -66,6 +66,10 @@ module.exports = newUser(
             .optional({ nullable: true })
             .isString().bail().withMessage('Le champ "Qui vous a recommandé la plateforme ?" est invalide')
             .trim(),
+
+        body('phone')
+            .trim()
+            .notEmpty().withMessage('Vous devez préciser votre téléphone'),
     ],
 
     (value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'),

--- a/packages/api/server/middlewares/validators/createContact.js
+++ b/packages/api/server/middlewares/validators/createContact.js
@@ -68,8 +68,9 @@ module.exports = newUser(
             .trim(),
 
         body('phone')
+            .isString().bail().withMessage('Le numéro de téléphone n\'est pas reconnu')
             .trim()
-            .notEmpty().withMessage('Vous devez préciser votre téléphone'),
+            .notEmpty().bail().withMessage('Vous devez préciser votre téléphone'),
     ],
 
     (value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'),

--- a/packages/frontend/src/js/app/messages/en/contactPage.json
+++ b/packages/frontend/src/js/app/messages/en/contactPage.json
@@ -2,7 +2,7 @@
   "title": "Neighbour, citizen, slum dweller... Any news? A question ? An alert?",
   "contactUs": "Contact us",
   "email": "Your email",
-  "phone": "Phone (optional)",
+  "phone": "Phone",
   "firstname": "First name",
   "lastname": "Last name",
   "requestType": "You want to...",

--- a/packages/frontend/src/js/app/messages/fr/contactPage.json
+++ b/packages/frontend/src/js/app/messages/fr/contactPage.json
@@ -2,7 +2,7 @@
   "title": "Voisin, citoyen, habitant d’un bidonville… Une info ? Une question ? Une alerte ?",
   "contactUs": "Contactez-nous",
   "email": "Votre email",
-  "phone": "Téléphone (facultatif)",
+  "phone": "Téléphone",
   "firstname": "Prénom",
   "lastname": "Nom de famille",
   "requestType": "Vous souhaitez...",

--- a/packages/frontend/src/js/app/pages/Contact/index.vue
+++ b/packages/frontend/src/js/app/pages/Contact/index.vue
@@ -51,6 +51,7 @@
                                 :label="$t('contactPage.phone')"
                                 v-model="commonFields.phone"
                                 id="phone"
+                                rules="required"
                             />
                         </InputGroup>
                         <CheckableGroup


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/AXJsS93J/1077-rendre-obligatoire-le-num%C3%A9ro-de-t%C3%A9l%C3%A9phone-sur-les-demandes-dinfo-et-demande-dacc%C3%A8s-depuis-la-page-daccueil-penser-%C3%A0-retirer-la-m

## 🛠 Description de la PR
Coté front: Le champ téléphone sur le formulaire de contact devient obligatoire 

Coté backend, j'ai laissé le champ en facultatif (coté BDD et création user coté admin). J'ai juste modifié les 2 validateurs en conséquence
- Sur le formulaire de contact, le champ est obligatoire : https://github.com/MTES-MCT/action-bidonvilles/blob/issue/1077/packages/api/server/middlewares/validators/createContact.js#L70
- Sur la création d'user et le formulaire de contact, le check de téléphone valide est toujours présent si le téléphone est renseigné : https://github.com/MTES-MCT/action-bidonvilles/blob/issue/1077/packages/api/server/middlewares/validators/common/newUser.js#L52 


## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/5053593/124566686-9346d500-de43-11eb-8b4f-384b8168ad14.png)

![image](https://user-images.githubusercontent.com/5053593/124566735-9e016a00-de43-11eb-8704-abe79931caa6.png)

