### PR TITLE
#patch (1146) Correction de l'export pour les villes à arrondissement

### DIFF
--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -379,6 +379,10 @@ module.exports = (models) => {
                         query: `${fromGeoLevelToTableName(location.type)}.code`,
                         value: location[location.type].code,
                     },
+                    location_main: {
+                        query: `${fromGeoLevelToTableName(location.type)}.fk_main`,
+                        value: location[location.type].code,
+                    },
                 });
             }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/p0cP73LP/1146-bug-impossible-dexporter-la-liste-des-sites-pour-une-ville-cf-message-derreur-en-pi%C3%A8ce-jointe

## 🛠 Description de la PR
L'export des sites avec arrondissement n'incluait pas les sites déclarés dans les arrondissements.