### PR TITLE
#patch (1094) Revue de l'UI pour la date de dernière mise à jour + changement du tri par défaut des sites

### DIFF
--- a/packages/frontend/src/js/app/components/ui/Tag.vue
+++ b/packages/frontend/src/js/app/components/ui/Tag.vue
@@ -21,7 +21,7 @@ export default {
     computed: {
         variantClasses() {
             return {
-                default: "px-4 py-1 flex-row items-center bg-G200",
+                default: "px-4 py-1 flex-row items-center bg-blue200",
                 primary: "bg-blue100 text-primary px-3 mr-2 mb-2 rounded-lg"
             }[this.variant];
         }

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -332,27 +332,27 @@ export default {
 
             if (months === 0) {
                 if (days === 0) {
-                    return `Dernière actualisation aujourd'hui`;
+                    return `Dernière mise à jour aujourd'hui`;
                 }
 
                 if (days > 0 && days < 7) {
-                    return `Dernière actualisation il y a ${days} jour${
+                    return `Dernière mise à jour il y a ${days} jour${
                         days > 1 ? "s" : ""
                     }`;
                 }
 
                 if (weeks > 0 && months === 0) {
-                    return `Dernière actualisation il y a ${weeks} semaine${
+                    return `Dernière mise à jour il y a ${weeks} semaine${
                         weeks > 1 ? "s" : ""
                     }`;
                 }
             }
 
             if (months < 12) {
-                return `Dernière actualisation il y a ${months} mois`;
+                return `Dernière mise à jour il y a ${months} mois`;
             }
 
-            return "Dernière actualisation il y a plus d'un an";
+            return "Dernière mise à jour il y a plus d'un an";
         },
         isClosed() {
             return (

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -8,7 +8,7 @@
         @mouseleave="isHover = false"
     >
         <router-link :to="`site/${shantytown.id}`">
-            <div class="-mt-1">
+            <div class="-mt-1 print:mt-0">
                 <Tag
                     :class="[
                         'text-xs mb-4 mx-6 uppercase text-primary',

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -2,13 +2,21 @@
     <div
         :class="[
             'rounded-sm cursor-pointer border preventPrintBreak',
-            isHover ? 'bg-blue100 border-transparent' : ''
+            isHover ? 'bg-blue200 border-transparent' : ''
         ]"
         @mouseenter="isHover = true"
         @mouseleave="isHover = false"
     >
         <router-link :to="`site/${shantytown.id}`">
-            <div class="pt-6">
+            <div class="-mt-1">
+                <Tag
+                    :class="[
+                        'text-xs mb-4 mx-6 uppercase text-primary',
+                        isHover ? 'shadow-md' : ''
+                    ]"
+                >
+                    {{ lastUpdate }}
+                </Tag>
                 <div class="text-md px-6">
                     <div class="text-primary text-display-md ">
                         <span class="font-bold">
@@ -213,12 +221,7 @@
                         </div>
                     </div>
                 </div>
-                <div
-                    class="flex justify-between items-center px-4 pt-4 print:hidden"
-                >
-                    <Tag class="text-xs">
-                        {{ lastUpdate }}
-                    </Tag>
+                <div class="flex justify-end px-4 pt-4 print:hidden">
                     <div class="print:hidden">
                         <transition name="fade" v-if="isOpen">
                             <router-link

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -20,7 +20,7 @@ export default new Vuex.Store({
             data: [],
             loading: true,
             error: null,
-            sort: "cityName",
+            sort: "updatedAt",
             filters: {
                 population: [],
                 fieldType: [],


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/G9BsR2ai/1094

## 🛠 Description de la PR
Deux changements :
- le tri par défaut de la liste des sites est désormais par date de dernière mise à jour
- la UI a été changée pour mieux mettre en avant cette date de dernière mise à jour (petit changement de wording au passage)

## 📸 Captures d'écran
- La nouvelle UI
![Capture d’écran 2021-07-06 à 16 32 35](https://user-images.githubusercontent.com/1801091/124619792-3e25b600-de79-11eb-9985-b03c02c41268.png)
- La nouvelle UI au survol
![image](https://user-images.githubusercontent.com/1801091/124619873-4bdb3b80-de79-11eb-9471-b9f198178beb.png)
- La version "print"
![Capture d’écran 2021-07-06 à 16 43 49](https://user-images.githubusercontent.com/1801091/124619933-5990c100-de79-11eb-8931-9c120b27c074.png)