### PR TITLE
#patch (1149) Ajout de l'email/téléphone + replyTo pour les messages de contact

### DIFF
--- a/packages/api/server/controllers/contactController.js
+++ b/packages/api/server/controllers/contactController.js
@@ -5,7 +5,7 @@ const accessRequestService = require('#server/services/accessRequest/accessReque
 
 const { sendAdminContactMessage } = require('#server/mails/mails');
 
-const sendEmailNewContactMessageToAdmins = async (data, models, message) => {
+const sendEmailNewContactMessageToAdmins = async (models, message) => {
     const admins = await models.user.getNationalAdmins();
 
     for (let i = 0; i < admins.length; i += 1) {
@@ -13,12 +13,15 @@ const sendEmailNewContactMessageToAdmins = async (data, models, message) => {
             variables: {
                 message: {
                     created_at: dateToString(new Date()),
-                    last_name: message.last_name,
-                    first_name: message.first_name,
-                    access_request_message: message.access_request_message,
+                    ...message,
                 },
             },
             preserveRecipient: false,
+            replyTo: {
+                email: message.email,
+                last_name: message.last_name,
+                first_name: message.first_name,
+            },
         });
     }
 };
@@ -74,7 +77,9 @@ module.exports = models => ({
 
         // contact request
         try {
-            await sendEmailNewContactMessageToAdmins(req.body, models, {
+            await sendEmailNewContactMessageToAdmins(models, {
+                email: req.body.email,
+                phone: req.body.phone,
                 last_name: req.body.last_name,
                 first_name: req.body.first_name,
                 access_request_message: req.body.access_request_message,

--- a/packages/api/server/mails/dist/admin_contact_message.html
+++ b/packages/api/server/mails/dist/admin_contact_message.html
@@ -165,6 +165,22 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">{{var:message.email}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">{{var:message.phone}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">{{var:message.access_request_message}}</div>
     
                 </td>

--- a/packages/api/server/mails/dist/admin_contact_message.text
+++ b/packages/api/server/mails/dist/admin_contact_message.text
@@ -4,6 +4,8 @@ Merci
 
 Date du message : {{var:message.created_at}}
 {{var:message.last_name}} {{var:message.first_name}}
+{{var:message.email}}
+{{var:message.phone}}
 {{var:message.access_request_message}}
 
 Cordialement,

--- a/packages/api/server/mails/mails.js
+++ b/packages/api/server/mails/mails.js
@@ -74,7 +74,7 @@ module.exports = {
      * @param {Object} options
      */
     sendAdminContactMessage: (recipient, options = {}) => {
-        const { variables, preserveRecipient = false } = options;
+        const { variables, preserveRecipient = false, replyTo } = options;
 
         return mailService.send('admin_contact_message', {
             recipient,
@@ -83,6 +83,7 @@ module.exports = {
                 message: variables.message,
             },
             preserveRecipient,
+            replyTo,
         });
     },
 

--- a/packages/api/server/mails/src/admin_contact_message.mjml
+++ b/packages/api/server/mails/src/admin_contact_message.mjml
@@ -22,6 +22,8 @@
             <mj-column padding="1rem" background-color="#dddddd">
                 <mj-text mj-class="pb-4">Date du message : {{var:message.created_at}}</mj-text>
                 <mj-text>{{var:message.last_name}} {{var:message.first_name}}</mj-text>
+                <mj-text>{{var:message.email}}</mj-text>
+                <mj-text>{{var:message.phone}}</mj-text>
                 <mj-text>{{var:message.access_request_message}}</mj-text>
             </mj-column>
         </mj-section>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/jqD0POXO/1149-correctif-manque-ladresse-mail-de-l%C3%A9metteur-du-message

## 🛠 Description de la PR
Ajout de l'email/téléphone + replyTo pour les messages de contact

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/5053593/124722423-5691e100-df0a-11eb-987f-fb8b0fb53b02.png)
