### PR TITLE
#patch (1119) Définir les customVariables Matomo avant chaque trackEvent + Reset au logout

### DIFF
--- a/packages/frontend/.eslintrc
+++ b/packages/frontend/.eslintrc
@@ -29,6 +29,10 @@
                         "./src/js/helpers"
                     ],
                     [
+                        "#matomo",
+                        "./src/js/matomo"
+                    ],
+                    [
                         "#app",
                         "./src/js/app"
                     ],

--- a/packages/frontend/jsconfig.json
+++ b/packages/frontend/jsconfig.json
@@ -5,6 +5,9 @@
             "#helpers/*": [
                 "./src/js/helpers/*"
             ],
+            "#matomo/*": [
+                "./src/js/matomo/*"
+            ],
             "#app/*": [
                 "./src/js/app/*"
             ]

--- a/packages/frontend/src/js/app/components/TownForm/TownForm.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownForm.vue
@@ -528,11 +528,11 @@ export default {
 
         submitFn(data) {
             if (this.mode === "create") {
-                this.$piwik?.trackEvent("Site", "Création site");
+                this.$trackMatomoEvent("Site", "Création site");
                 return add(data);
             }
 
-            this.$piwik?.trackEvent("Site", "Mise à jour site");
+            this.$trackMatomoEvent("Site", "Mise à jour site");
             return edit(this.data.id, data);
         }
     }

--- a/packages/frontend/src/js/app/components/export2/Export.vue
+++ b/packages/frontend/src/js/app/components/export2/Export.vue
@@ -174,7 +174,7 @@ export default {
             }
 
             open(url);
-            this.$piwik?.trackEvent("Export", "Export sites");
+            this.$trackMatomoEvent("Export", "Export sites");
         },
         close() {
             this.$emit("close");

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -233,32 +233,32 @@ export default {
             numberOfShantytownsBy: {
                 regions: {}, // sera rempli avec un objet du type : { "01": 0, "02": 0, ..., "11": 0 }
                 departements: {}, // sera rempli avec un objet du type : { "01": 0, "02": 0, ..., "92": 0 }
-                cities: {} /* sera rempli avec un objet du type :   
+                cities: {} /* sera rempli avec un objet du type :
                                                                     {
-                                                                        "01": 
+                                                                        "01":
                                                                             {
-                                                                                sites = 0, 
-                                                                                code = , 
-                                                                                name = , 
-                                                                                latitude = , 
-                                                                                longitude = 
+                                                                                sites = 0,
+                                                                                code = ,
+                                                                                name = ,
+                                                                                latitude = ,
+                                                                                longitude =
                                                                             },
-                                                                        "02":   
+                                                                        "02":
                                                                             {
-                                                                                sites = 0, 
-                                                                                code = , 
-                                                                                name = , 
-                                                                                latitude = , 
-                                                                                longitude = 
-                                                                            }, 
+                                                                                sites = 0,
+                                                                                code = ,
+                                                                                name = ,
+                                                                                latitude = ,
+                                                                                longitude =
+                                                                            },
                                                                         ...,
-                                                                        "92": 
+                                                                        "92":
                                                                             {
-                                                                                sites = 0, 
-                                                                                code = , 
-                                                                                name = , 
-                                                                                latitude = , 
-                                                                                longitude = 
+                                                                                sites = 0,
+                                                                                code = ,
+                                                                                name = ,
+                                                                                latitude = ,
+                                                                                longitude =
                                                                             }
                                                                     } */
             }
@@ -770,7 +770,7 @@ export default {
         },
 
         setSearchMarker(type, address, coordinates) {
-            this.$piwik?.trackEvent("Cartographie", "Recherche");
+            this.$trackMatomoEvent("Cartographie", "Recherche");
             this.clearSearchMarker();
 
             // check if there is a marker existing at that exact address

--- a/packages/frontend/src/js/app/components/quickview/quickview.js
+++ b/packages/frontend/src/js/app/components/quickview/quickview.js
@@ -218,7 +218,7 @@ export default {
         }
     },
     mounted() {
-        this.$piwik?.trackEvent("Cartographie", "Click sur site");
+        this.$trackMatomoEvent("Cartographie", "Click sur site");
         document.addEventListener("click", this.checkOutsideClick);
     },
     destroyed() {
@@ -243,7 +243,7 @@ export default {
             }
         },
         showTown() {
-            this.$piwik?.trackEvent("Cartographie", "Redirection page site");
+            this.$trackMatomoEvent("Cartographie", "Redirection page site");
 
             const routerData = this.$router.resolve(`/site/${this.town.id}`);
             open(routerData.href);

--- a/packages/frontend/src/js/app/pages/Contact/index.vue
+++ b/packages/frontend/src/js/app/pages/Contact/index.vue
@@ -424,7 +424,7 @@ export default {
                 this.loading = false;
                 // Si l'utilisateur a demandé un accès, on route vers le formulaire d'invitation
                 if (this.isRequestAccessAndActor) {
-                    this.$piwik?.trackEvent(
+                    this.$trackMatomoEvent(
                         "Demande d'accès",
                         "Demande d'accès"
                     );
@@ -432,7 +432,7 @@ export default {
                         `/invitation?email=${encodeURIComponent(result.email)}`
                     );
                 } else {
-                    this.$piwik?.trackEvent("Contact", "Demande d'information");
+                    this.$trackMatomoEvent("Contact", "Demande d'information");
 
                     this.$router.push("/");
                 }

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
@@ -227,7 +227,7 @@ export default {
         }
     },
     mounted() {
-        this.$piwik?.trackEvent(
+        this.$trackMatomoEvent(
             "Site",
             "Visite page site",
             this.$route.params.id
@@ -259,7 +259,7 @@ export default {
             this.covidOpen = true;
         },
         handleNewComment(comments) {
-            this.$piwik?.trackEvent(
+            this.$trackMatomoEvent(
                 "Commentaire",
                 "Création commentaire",
                 this.town.id

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCloseModal.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCloseModal.vue
@@ -179,7 +179,7 @@ export default {
                         }))
                 });
 
-                this.$piwik?.trackEvent(
+                this.$trackMatomoEvent(
                     "Site",
                     "Fermeture site",
                     this.form.closed_with_solutions

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
@@ -213,7 +213,7 @@ export default {
                 )
             })
                 .then(async response => {
-                    this.$piwik?.trackEvent(
+                    this.$trackMatomoEvent(
                         "Commentaire",
                         "Création commentaire Covid",
                         this.town.id

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsInviteActorModal.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsInviteActorModal.vue
@@ -186,7 +186,7 @@ export default {
 
         dispatch() {
             if (this.form.user && this.form.user.id) {
-                this.$piwik?.trackEvent(
+                this.$trackMatomoEvent(
                     "Intervenant",
                     "Déclaration intervenant",
                     this.townId
@@ -199,7 +199,7 @@ export default {
                 });
             }
 
-            this.$piwik?.trackEvent(
+            this.$trackMatomoEvent(
                 "Intervenant",
                 "Invitation intevernant",
                 this.townId

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -340,7 +340,7 @@ export default {
     },
     methods: {
         handleSearchBlur(data) {
-            this.$piwik?.trackEvent("Liste des sites", "Recherche");
+            this.$trackMatomoEvent("Liste des sites", "Recherche");
 
             store.commit("setFilters", {
                 ...this.filters,
@@ -387,7 +387,7 @@ export default {
             this.printMode = true;
             setTimeout(() => {
                 window.print();
-                this.$piwik?.trackEvent(
+                this.$trackMatomoEvent(
                     "Impression",
                     "Impression liste des sites"
                 );

--- a/packages/frontend/src/js/app/pages/dashboard/POIView.vue
+++ b/packages/frontend/src/js/app/pages/dashboard/POIView.vue
@@ -87,10 +87,10 @@ export default {
     },
     methods: {
         trackOpenPOI() {
-            this.$piwik.trackEvent("POI", "Open POI", this.poi.lieu_id);
+            this.$trackMatomoEvent("POI", "Open POI", this.poi.lieu_id);
         },
         trackOpenSoliguide() {
-            this.$piwik.trackEvent("POI", "Click See More", this.poi.lieu_id);
+            this.$trackMatomoEvent("POI", "Click See More", this.poi.lieu_id);
         },
         checkOutsideClick(event) {
             if (!this.poi) {

--- a/packages/frontend/src/js/app/pages/launcher/launcher.js
+++ b/packages/frontend/src/js/app/pages/launcher/launcher.js
@@ -40,7 +40,7 @@ export default {
         },
         track(user) {
             Sentry.setUser({ id: user.id });
-            setCustomVariables(user)
+            setCustomVariables(user);
         }
     }
 };

--- a/packages/frontend/src/js/app/pages/launcher/launcher.js
+++ b/packages/frontend/src/js/app/pages/launcher/launcher.js
@@ -40,7 +40,7 @@ export default {
         },
         track(user) {
             Sentry.setUser({ id: user.id });
-            setCustomVariables(user);
+            setCustomVariables(this.$piwik, user);
         }
     }
 };

--- a/packages/frontend/src/js/app/pages/launcher/launcher.js
+++ b/packages/frontend/src/js/app/pages/launcher/launcher.js
@@ -2,6 +2,7 @@ import NavBar from "#app/layouts/navbar/navbar.vue";
 import { isLoaded as isConfigLoaded, load, get } from "#helpers/api/config";
 import { getEntryPoint } from "#app/router";
 import * as Sentry from "@sentry/vue";
+import { setCustomVariables } from "#matomo/matomo";
 
 export default {
     data() {
@@ -39,39 +40,7 @@ export default {
         },
         track(user) {
             Sentry.setUser({ id: user.id });
-
-            if (!this.$piwik) {
-                return;
-            }
-
-            this.$piwik.setUserId(user.id);
-
-            const location =
-                user.organization.location[user.organization.location.type];
-
-            // Convert user's data to a easily parsable string:
-            // ie: superuser:false,is_admin:false,role:association,org_category:association,org_location_type:departement,org_location_name:Gironde,org_location_code:33
-            const userData = JSON.stringify({
-                superuser: user.is_superuser,
-                is_admin: user.is_admin,
-                role: user.role_id,
-                org_category: user.organization.category.uid,
-                org_location_type: user.organization.location.type,
-                org_location_name: location?.name,
-                org_location_code: location?.code
-            })
-                .replaceAll('"', "")
-                .replaceAll("{", "")
-                .replaceAll("}", "");
-
-            this.$piwik.setCustomVariable(1, "user", userData);
-
-            const departement = user.organization.location.departement || null;
-            this.$piwik.setCustomVariable(
-                5,
-                "departement_code",
-                departement ? departement.code : null
-            );
+            setCustomVariables(user)
         }
     }
 };

--- a/packages/frontend/src/js/app/pages/plans.create/plans.create.js
+++ b/packages/frontend/src/js/app/pages/plans.create/plans.create.js
@@ -479,7 +479,7 @@ export default {
                 title: "Dispositif correctement déclaré",
                 text: "Le dispositif a bien été ajouté en base de données"
             });
-            this.$piwik?.trackEvent("Dispositif", "Création dispositif");
+            this.$trackMatomoEvent("Dispositif", "Création dispositif");
 
             this.$router.push(`/dispositif/${id}`);
         }

--- a/packages/frontend/src/js/app/pages/plans.edit/plans.edit.js
+++ b/packages/frontend/src/js/app/pages/plans.edit/plans.edit.js
@@ -361,7 +361,7 @@ export default {
                 text: "Le dispositif a bien été mis à jour"
             });
 
-            this.$piwik?.trackEvent("Dispositif", "Mise à jour dispositif");
+            this.$trackMatomoEvent("Dispositif", "Mise à jour dispositif");
 
             this.$router.push(`/dispositif/${this.$route.params.id}`);
         }

--- a/packages/frontend/src/js/app/pages/plans.marks/plans.marks.js
+++ b/packages/frontend/src/js/app/pages/plans.marks/plans.marks.js
@@ -525,7 +525,7 @@ export default {
                 text: "Le dispositif a bien été mis à jour"
             });
 
-            this.$piwik?.trackEvent(
+            this.$trackMatomoEvent(
                 "Dispositif",
                 "Mise à jour indicateurs",
                 this.$route.params.id

--- a/packages/frontend/src/js/app/pages/signin/signin.js
+++ b/packages/frontend/src/js/app/pages/signin/signin.js
@@ -46,7 +46,7 @@ export default {
     },
     methods: {
         onComplete() {
-            this.$piwik?.trackEvent("Login", "Connection");
+            this.$trackMatomoEvent("Login", "Connection");
             window.localStorage.setItem("logged_once", true);
             this.$router.push({ path: "/" });
         }

--- a/packages/frontend/src/js/app/pages/users.activate/users.activate.js
+++ b/packages/frontend/src/js/app/pages/users.activate/users.activate.js
@@ -50,7 +50,7 @@ export default {
                     submitPrefix:
                         'En cliquant sur "Activer mon compte", j\'accepte les <a href="/#/conditions-d-utilisation">conditions générales d\'utilisation</a> et de partager mes données (nom, prénom, courriel, structure et lorsque renseigné, numéro de téléphone) aux utilisateurs de la plateforme via l’annuaire',
                     submit: data => {
-                        this.$piwik?.trackEvent(
+                        this.$trackMatomoEvent(
                             "Demande d'accès",
                             "Création compte"
                         );

--- a/packages/frontend/src/js/app/pages/users.validate/users.validate.js
+++ b/packages/frontend/src/js/app/pages/users.validate/users.validate.js
@@ -219,7 +219,7 @@ export default {
                 .then(() => {
                     this.validation.state = null;
 
-                    this.$piwik?.trackEvent(
+                    this.$trackMatomoEvent(
                         "Demande d'accès",
                         "Approuver accès"
                     );
@@ -254,7 +254,7 @@ export default {
                 .then(() => {
                     this.validation.state = null;
 
-                    this.$piwik?.trackEvent("Demande d'accès", "Refuser accès");
+                    this.$trackMatomoEvent("Demande d'accès", "Refuser accès");
                     notify({
                         group: "notifications",
                         type: "success",

--- a/packages/frontend/src/js/helpers/api/user.js
+++ b/packages/frontend/src/js/helpers/api/user.js
@@ -45,10 +45,8 @@ export function logout(piwik) {
 
     if (piwik) {
         piwik.resetUserId();
-        piwik.setCustomVariable(1, "superuser", null);
-        piwik.setCustomVariable(2, "structure", null);
-        piwik.setCustomVariable(3, "niveau_geo", null);
-        piwik.setCustomVariable(4, "geo_nom", null);
+        piwik.setCustomVariable(1, "user", null);
+        piwik.setCustomVariable(5, "departement_code", null);
     }
 }
 

--- a/packages/frontend/src/js/index.js
+++ b/packages/frontend/src/js/index.js
@@ -206,6 +206,8 @@ if (VUE_APP_MATOMO_ON === "true") {
         // Default: false
         debug: true
     });
+} else {
+    Vue.prototype.$trackMatomoEvent = () => {};
 }
 
 // Register styleguide components

--- a/packages/frontend/src/js/matomo/matomo.js
+++ b/packages/frontend/src/js/matomo/matomo.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-console */
+import { get as getConfig } from "#helpers/api/config";
 
 const defaultOptions = {
     debug: false,
@@ -10,7 +11,7 @@ const defaultOptions = {
 };
 
 function loadScript(trackerScript) {
-    const scriptPromise = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
         const script = document.createElement("script");
         script.async = true;
         script.defer = true;
@@ -22,15 +23,55 @@ function loadScript(trackerScript) {
         script.onload = resolve;
         script.onerror = reject;
     });
+}
 
-    scriptPromise.catch(error => {
-        const msg = `[vue-matomo] An error occurred trying to load ${error.target.src}. `;
-        ("If the file exists you may have an ad- or trackingblocker enabled.");
+export function setCustomVariables(user) {
+    if (!this || !this.$piwik) {
+        return;
+    }
 
-        console.error(msg);
-    });
+    this.$piwik.setUserId(user.id);
 
-    return scriptPromise;
+    const location =
+        user.organization.location[user.organization.location.type];
+
+    // Convert user's data to a easily parsable string:
+    // ie: superuser:false,is_admin:false,role:association,org_category:association,org_location_type:departement,org_location_name:Gironde,org_location_code:33
+    const userData = JSON.stringify({
+        superuser: user.is_superuser,
+        is_admin: user.is_admin,
+        role: user.role_id,
+        org_category: user.organization.category.uid,
+        org_location_type: user.organization.location.type,
+        org_location_name: location?.name,
+        org_location_code: location?.code
+    })
+        .replaceAll('"', "")
+        .replaceAll("{", "")
+        .replaceAll("}", "");
+
+    this.$piwik.setCustomVariable(1, "user", userData);
+
+    const departement = user.organization.location.departement || null;
+    this.$piwik.setCustomVariable(
+        5,
+        "departement_code",
+        departement ? departement.code : null
+    );
+}
+
+function trackEvent(eventCategory, eventName, eventArgs) {
+    if (!this.piwik) {
+        return;
+    }
+
+    const { user } = getConfig();
+
+    if (user) {
+        setCustomVariables(user);
+    }
+
+    this.$piwik.trackEvent(eventCategory, eventName, eventArgs);
 }
 
 function initMatomo(Vue, options) {
@@ -42,6 +83,7 @@ function initMatomo(Vue, options) {
     // Assign matomo to Vue
     Vue.prototype.$piwik = Matomo;
     Vue.prototype.$matomo = Matomo;
+    Vue.prototype.$trackMatomoEvent = trackEvent;
 
     if (options.requireConsent) {
         Matomo.requireConsent();
@@ -92,5 +134,14 @@ export default function install(Vue, setupOptions = {}) {
     const { host, trackerFileName } = options;
     const trackerScript = `${host}/${trackerFileName}.js`;
 
-    loadScript(trackerScript).then(() => initMatomo(Vue, options));
+    loadScript(trackerScript)
+        .then(() => initMatomo(Vue, options))
+        .catch(error => {
+            const msg = `[vue-matomo] An error occurred trying to load ${error.target.src}. `;
+            ("If the file exists you may have an ad- or trackingblocker enabled.");
+
+            console.error(msg);
+
+            Vue.prototype.$trackMatomoEvent = () => {};
+        });
 }

--- a/packages/frontend/src/js/matomo/matomo.js
+++ b/packages/frontend/src/js/matomo/matomo.js
@@ -25,12 +25,12 @@ function loadScript(trackerScript) {
     });
 }
 
-export function setCustomVariables(user) {
-    if (!this || !this.$piwik) {
+export function setCustomVariables($piwik, user) {
+    if (!$piwik) {
         return;
     }
 
-    this.$piwik.setUserId(user.id);
+    $piwik.setUserId(user.id);
 
     const location =
         user.organization.location[user.organization.location.type];
@@ -50,28 +50,28 @@ export function setCustomVariables(user) {
         .replaceAll("{", "")
         .replaceAll("}", "");
 
-    this.$piwik.setCustomVariable(1, "user", userData);
+    $piwik.setCustomVariable(1, "user", userData);
 
     const departement = user.organization.location.departement || null;
-    this.$piwik.setCustomVariable(
+    $piwik.setCustomVariable(
         5,
         "departement_code",
         departement ? departement.code : null
     );
 }
 
-function trackEvent(eventCategory, eventName, eventArgs) {
-    if (!this.piwik) {
+function trackEvent($piwik, eventCategory, eventName, eventArgs) {
+    if (!$piwik) {
         return;
     }
 
     const { user } = getConfig();
 
     if (user) {
-        setCustomVariables(user);
+        setCustomVariables($piwik, user);
     }
 
-    this.$piwik.trackEvent(eventCategory, eventName, eventArgs);
+    $piwik.trackEvent(eventCategory, eventName, eventArgs);
 }
 
 function initMatomo(Vue, options) {
@@ -83,7 +83,7 @@ function initMatomo(Vue, options) {
     // Assign matomo to Vue
     Vue.prototype.$piwik = Matomo;
     Vue.prototype.$matomo = Matomo;
-    Vue.prototype.$trackMatomoEvent = trackEvent;
+    Vue.prototype.$trackMatomoEvent = trackEvent.bind(window, Matomo);
 
     if (options.requireConsent) {
         Matomo.requireConsent();

--- a/packages/frontend/vue.config.js
+++ b/packages/frontend/vue.config.js
@@ -40,7 +40,8 @@ module.exports = {
         config.resolve.alias
             .set("#app", path.resolve(__dirname, "./src/js/app/"))
             .set("#src", path.resolve(__dirname, "./src/"))
-            .set("#helpers", path.resolve(__dirname, "./src/js/helpers"));
+            .set("#helpers", path.resolve(__dirname, "./src/js/helpers"))
+            .set("#matomo", path.resolve(__dirname, "./src/js/matomo"));
         config.plugins.delete("progress");
     },
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/miVvQxo5/1119-bug-le-renseignement-du-profil-de-m-estermann-variable-personnalis%C3%A9e-user-ne-fonctionne-pas

## 🛠 Description de la PR
- Le reset des variables personnalisées au logout n'était plus bon suite à la modification des noms : https://github.com/MTES-MCT/resorption-bidonvilles/pull/207/files#diff-7221601a466dd3634968905e896248eb4b93227e144d65542944e8d66cb43e25
- Pour etre sur que les variables personnalisées soient bien set avant chaque trackEvent, j'ai rajouté un helper `this.$trackMatomoEvent` qui s'occupe de le faire : https://github.com/MTES-MCT/resorption-bidonvilles/pull/207/files#diff-09faf97dad491dadd083b5324e9952ec36dc69c7a408510eb6c6568641770726
