### PR TITLE
(1153) PR feedback

### DIFF
--- a/packages/api/db/migrations/001153-01-alter-table-comments-covid-add-intervention-types.js
+++ b/packages/api/db/migrations/001153-01-alter-table-comments-covid-add-intervention-types.js
@@ -6,7 +6,7 @@ module.exports = {
                 'action_mediation_sante',
                 {
                     type: Sequelize.BOOLEAN,
-                    defaultValue: true,
+                    defaultValue: false,
                 },
                 {
                     transaction,
@@ -17,7 +17,7 @@ module.exports = {
                 'sensibilisation_vaccination',
                 {
                     type: Sequelize.BOOLEAN,
-                    defaultValue: true,
+                    defaultValue: false,
                 },
                 {
                     transaction,
@@ -28,7 +28,7 @@ module.exports = {
                 'equipe_mobile_depistage',
                 {
                     type: Sequelize.BOOLEAN,
-                    defaultValue: true,
+                    defaultValue: false,
                 },
                 {
                     transaction,
@@ -39,13 +39,59 @@ module.exports = {
                 'equipe_mobile_vaccination',
                 {
                     type: Sequelize.BOOLEAN,
-                    defaultValue: true,
+                    defaultValue: false,
                 },
                 {
                     transaction,
                 },
             ),
-        ]),
+        ])
+            .then(() => Promise.all([
+                queryInterface.changeColumn(
+                    'shantytown_covid_comments',
+                    'action_mediation_sante',
+                    {
+                        type: Sequelize.BOOLEAN,
+                        allowNull: false,
+                    },
+                    {
+                        transaction,
+                    },
+                ),
+                queryInterface.changeColumn(
+                    'shantytown_covid_comments',
+                    'sensibilisation_vaccination',
+                    {
+                        type: Sequelize.BOOLEAN,
+                        allowNull: false,
+                    },
+                    {
+                        transaction,
+                    },
+                ),
+                queryInterface.changeColumn(
+                    'shantytown_covid_comments',
+                    'equipe_mobile_depistage',
+                    {
+                        type: Sequelize.BOOLEAN,
+                        allowNull: false,
+                    },
+                    {
+                        transaction,
+                    },
+                ),
+                queryInterface.changeColumn(
+                    'shantytown_covid_comments',
+                    'equipe_mobile_vaccination',
+                    {
+                        type: Sequelize.BOOLEAN,
+                        allowNull: false,
+                    },
+                    {
+                        transaction,
+                    },
+                ),
+            ])),
     ),
 
     down: queryInterface => queryInterface.sequelize.transaction(

--- a/packages/api/db/migrations/001153-02-alter-table-covid_comments-default_old_columns_to_false.js
+++ b/packages/api/db/migrations/001153-02-alter-table-covid_comments-default_old_columns_to_false.js
@@ -1,0 +1,100 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+        transaction => Promise.all([
+            queryInterface.changeColumn(
+                'shantytown_covid_comments',
+                'equipe_maraude',
+                {
+                    type: Sequelize.BOOLEAN,
+                    defaultValue: false,
+                },
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.changeColumn(
+                'shantytown_covid_comments',
+                'equipe_sanitaire',
+                {
+                    type: Sequelize.BOOLEAN,
+                    defaultValue: false,
+                },
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.changeColumn(
+                'shantytown_covid_comments',
+                'equipe_accompagnement',
+                {
+                    type: Sequelize.BOOLEAN,
+                    defaultValue: false,
+                },
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.changeColumn(
+                'shantytown_covid_comments',
+                'distribution_alimentaire',
+                {
+                    type: Sequelize.BOOLEAN,
+                    defaultValue: false,
+                },
+                {
+                    transaction,
+                },
+            ),
+        ]),
+    ),
+
+    down: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+        transaction => Promise.all([
+            queryInterface.changeColumn(
+                'shantytown_covid_comments',
+                'equipe_maraude',
+                {
+                    type: Sequelize.BOOLEAN,
+                    allowNull: false,
+                },
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.changeColumn(
+                'shantytown_covid_comments',
+                'equipe_sanitaire',
+                {
+                    type: Sequelize.BOOLEAN,
+                    allowNull: false,
+                },
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.changeColumn(
+                'shantytown_covid_comments',
+                'equipe_accompagnement',
+                {
+                    type: Sequelize.BOOLEAN,
+                    allowNull: false,
+                },
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.changeColumn(
+                'shantytown_covid_comments',
+                'distribution_alimentaire',
+                {
+                    type: Sequelize.BOOLEAN,
+                    allowNull: false,
+                },
+                {
+                    transaction,
+                },
+            ),
+        ]),
+    ),
+
+};

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -1374,8 +1374,7 @@ module.exports = (models) => {
                     description: typeof body.description === 'string' ? validator.trim(body.description) : null,
                 };
 
-                ['equipe_maraude', 'equipe_sanitaire', 'equipe_accompagnement',
-                    'distribution_alimentaire', 'personnes_orientees', 'personnes_avec_symptomes',
+                ['personnes_orientees', 'personnes_avec_symptomes',
                     'besoin_action', 'action_mediation_sante', 'sensibilisation_vaccination', 'equipe_mobile_depistage', 'equipe_mobile_vaccination']
                     .forEach((name) => {
                         sanitizedBody[name] = typeof body[name] === 'boolean' ? body[name] : null;
@@ -1389,10 +1388,6 @@ module.exports = (models) => {
             // validate input
             const labels = {
                 date: 'La date',
-                equipe_maraude: 'Le champ "Équipe de maraude"',
-                equipe_sanitaire: 'Le champ "Équipe sanitaire"',
-                equipe_accompagnement: 'Le champ "Équipe d\'accompagnement"',
-                distribution_alimentaire: 'Le champ "Distribution d\'aide alimentaire"',
                 action_mediation_sante: 'Le champ "Action de médiation en santé"',
                 sensibilisation_vaccination: 'Le champ "Sensibilisation à la vaccination"',
                 equipe_mobile_depistage: 'Le champ "Équipe mobile de dépistage"',

--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -932,10 +932,6 @@ module.exports = (database) => {
                         shantytown_covid_comments(
                             fk_comment,
                             date,
-                            equipe_maraude,
-                            equipe_sanitaire,
-                            equipe_accompagnement,
-                            distribution_alimentaire,
                             action_mediation_sante,
                             sensibilisation_vaccination,
                             equipe_mobile_depistage,
@@ -949,10 +945,6 @@ module.exports = (database) => {
                         (
                             :id,
                             :date,
-                            :equipe_maraude,
-                            :equipe_sanitaire,
-                            :equipe_accompagnement,
-                            :distribution_alimentaire,
                             :action_mediation_sante,
                             :sensibilisation_vaccination,
                             :equipe_mobile_depistage,

--- a/packages/api/test/suites/server/controllers/townController/createCovidComment.spec.js
+++ b/packages/api/test/suites/server/controllers/townController/createCovidComment.spec.js
@@ -34,22 +34,6 @@ describe.only('townController.createCovidComment()', () => {
             label: 'La date',
             badFormat: global.generate().not('stringdate'),
         },
-        equipe_maraude: {
-            label: 'Le champ "Équipe de maraude"',
-            badFormat: global.generate().not('boolean'),
-        },
-        equipe_sanitaire: {
-            label: 'Le champ "Équipe sanitaire"',
-            badFormat: global.generate().not('boolean'),
-        },
-        equipe_accompagnement: {
-            label: 'Le champ "Équipe d\'accompagnement"',
-            badFormat: global.generate().not('boolean'),
-        },
-        distribution_alimentaire: {
-            label: 'Le champ "Distribution d\'aide alimentaire"',
-            badFormat: global.generate().not('boolean'),
-        },
         action_mediation_sante: {
             label: 'Le champ "Action de médiation en santé"',
             badFormat: global.generate().not('boolean'),
@@ -95,10 +79,6 @@ describe.only('townController.createCovidComment()', () => {
             },
             body: {
                 date: (new Date(2000, 0, 1)).toString(),
-                equipe_maraude: true,
-                equipe_sanitaire: true,
-                equipe_accompagnement: true,
-                distribution_alimentaire: true,
                 action_mediation_sante: true,
                 sensibilisation_vaccination: true,
                 equipe_mobile_depistage: true,

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
@@ -191,18 +191,6 @@ export default {
             addCovidComment(this.$route.params.id, {
                 date: this.form.date,
                 description: this.form.newComment,
-                equipe_maraude: this.form.interventionType.includes(
-                    "equipe_maraude"
-                ),
-                equipe_sanitaire: this.form.interventionType.includes(
-                    "equipe_sanitaire"
-                ),
-                equipe_accompagnement: this.form.interventionType.includes(
-                    "equipe_accompagnement"
-                ),
-                distribution_alimentaire: this.form.interventionType.includes(
-                    "distribution_alimentaire"
-                ),
                 action_mediation_sante: this.form.interventionType.includes(
                     "action_mediation_sante"
                 ),

--- a/packages/frontend/src/js/app/pages/TownDetails/ui/CommentBlock.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/ui/CommentBlock.vue
@@ -59,8 +59,8 @@ export default {
     },
     computed: {
         covidTags: function() {
-            if (!this.comment) {
-                return;
+            if (!this.comment || !this.comment.covid) {
+                return [];
             }
 
             return covidTags.filter(t => {


### PR DESCRIPTION
Propositions de changements :
- renommer la migration car elle n'a pas le même nombre de chiffres que les autres (perturbe sa position dans la liste)
- modifier la migration pour faire en sorte que les anciens commentaires COVID aient pour valeur par défaut `false` sur les nouvelles colonnes + ne pas set de valeur par défaut pour les nouveaux commentaires (ce qui évite d'oublier de les set dans un INSERT et ne pas s'en rendre compte)
- modifier les anciennes colonnes pour leur donner une valeur par défaut à false (ce qui évite d'avoir à les set dans un INSERT alors qu'elles n'existent théoriquement plus)
- complètement retirer mention des anciennes colonnes dans tout le parcours d'écriture des commentaires (allège le code)
- corriger l'affichage des commentaires "regular" (journal de bord)