### PR TITLE
(1107) PR feedback

### DIFF
--- a/packages/api/server/controllers/contactController.js
+++ b/packages/api/server/controllers/contactController.js
@@ -74,7 +74,11 @@ module.exports = models => ({
                 next(err);
             }
 
-            return res.status(200).send(result);
+            return res.status(200).send({
+                first_name: result.first_name,
+                last_name: result.last_name,
+                email: result.email,
+            });
         }
 
         // contact request
@@ -83,8 +87,6 @@ module.exports = models => ({
                 first_name: req.body.first_name,
                 last_name: req.body.last_name,
                 email: req.body.email,
-                phone: req.body.phone,
-                access_request_message: req.body.access_request_message,
             };
 
             await sendEmailNewContactMessageToAdmins(models, {

--- a/packages/api/server/middlewares/validators/invite.js
+++ b/packages/api/server/middlewares/validators/invite.js
@@ -4,7 +4,6 @@ const { sequelize } = require('#db/models');
 const userModel = require('#server/models/userModel')(sequelize);
 
 module.exports = [
-
     body('greeter.email')
         .trim()
         .notEmpty().bail().withMessage('Le courriel de la personne a l\'initiative de l\'invitation doit être renseigné')
@@ -17,6 +16,17 @@ module.exports = [
             yahoo_remove_subaddress: false,
             icloud_remove_subaddress: false,
         }),
+
+    body('greeter.first_name')
+        .isString().bail().withMessage('Le prénom de la peersonne à l\'initiative de l\'invitation est invalide')
+        .trim()
+        .notEmpty().bail().withMessage('Le prénom de la peersonne à l\'initiative de l\'invitation est obligatoire'),
+
+    body('greeter.last_name')
+        .isString().bail().withMessage('Le nom de la peersonne à l\'initiative de l\'invitation est invalide')
+        .trim()
+        .notEmpty().bail().withMessage('Le nom de la peersonne à l\'initiative de l\'invitation est obligatoire'),
+
     body('guests')
         .customSanitizer((value) => {
             if (value === undefined || value === null) {

--- a/packages/frontend/src/js/app/pages/Invitation/index.vue
+++ b/packages/frontend/src/js/app/pages/Invitation/index.vue
@@ -234,11 +234,14 @@ export default {
         }
     },
     created() {
-        if (!this.$store.state.greeter.email) {
+        if (!this.$store.state.greeter) {
             this.backHomeWithErrMsg(
                 "Impossible d'identifier l'utilisateur' à l'origine de l'invitation"
             );
         }
+    },
+    unmounted() {
+        this.$store.commit("setGreeter", null);
     }
 };
 </script>

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -35,11 +35,7 @@ export default new Vuex.Store({
             currentPage: 1
         },
         detailedTown: null,
-        greeter: {
-            first_name: "",
-            last_name: "",
-            email: ""
-        }
+        greeter: null
     },
     mutations: {
         setLoading(state, value) {
@@ -107,16 +103,8 @@ export default new Vuex.Store({
                 }
             }
         },
-        setGreeter(state, { first_name, last_name, email }) {
-            if (first_name !== null) {
-                state.greeter.first_name = first_name;
-            }
-            if (last_name !== null) {
-                state.greeter.last_name = last_name;
-            }
-            if (email !== null) {
-                state.greeter.email = email;
-            }
+        setGreeter(state, greeter) {
+            state.greeter = greeter;
         },
         saveHost(currentState, host) {
             let index = currentState.hosts.findIndex(


### PR DESCRIPTION
Feedbacks sur la PR : https://github.com/MTES-MCT/resorption-bidonvilles/pull/208

Trois changements :
- modification de la réponse de la route POST /contact pour la réduire au minimum utilisé par le frontend
- ajout de validators pour greeter.first_name et greeter.last_name dans l'inviteController
- simplification de l'utilisation du store pour stocker greeter

II reste un problème : Il existe un push mail qui iinvite un utilisateur existant à inviter des partenaires, et ledit mail inclus un lien qui redirige directement vers : `resorption-bidonvilles.beta.gouv.fr/#/invitation?email=user@email.org`
Avec les changements de ta PR, ce parcours ne marche plus (car le paramètre `email` n'est plus pris en compte).

Par ailleurs, spécifiquement pour ce parcours il serait préférable de maintenir la validation de l'email du greeter côté API (pour éviter d'éventuels robots).