### PR TITLE
#patch (1160) Fix validation of pop_minors and pop_couples

### DIFF
--- a/packages/frontend/src/js/app/components/TownForm/inputs/InputPopulation.vue
+++ b/packages/frontend/src/js/app/components/TownForm/inputs/InputPopulation.vue
@@ -40,7 +40,8 @@ import { extend } from "vee-validate";
 extend("couplesLesserThanTotal", {
     params: ["target"],
     validate(couples, { target: total }) {
-        return parseInt(couples, 10) <= parseInt(total, 10);
+        const totalInt = parseInt(total, 10);
+        return !Number.isInteger(totalInt) || parseInt(couples, 10) <= totalInt;
     },
     message: "Le nombre de ménages doit être inférieur au nombre de personnes"
 });
@@ -48,7 +49,8 @@ extend("couplesLesserThanTotal", {
 extend("minorsLesserThanTotal", {
     params: ["target"],
     validate(minors, { target: total }) {
-        return parseInt(minors, 10) <= parseInt(total, 10);
+        const totalInt = parseInt(total, 10);
+        return !Number.isInteger(totalInt) || parseInt(minors, 10) <= totalInt;
     },
     message: "Le nombre de mineurs doit être inférieur au nombre de personnes"
 });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Gyah8yhT/1160

## 🛠 Description de la PR
Quand le nombre d'habitants était vide, la validation du nombre de ménages et de mineurs lançait une erreur.

## 📸 Captures d'écran
Plus d'erreur :
![Capture d’écran 2021-07-13 à 17 25 53](https://user-images.githubusercontent.com/1801091/125479758-d7228f50-2f4d-41bc-b442-56eb1e219549.png)