### PR TITLE
#patch (1107+ 1121) - Redirection systématique vers page d'invitation + origine mentionnée dans les notifications Mattermost 

### DIFF
--- a/packages/api/server/controllers/inviteController.js
+++ b/packages/api/server/controllers/inviteController.js
@@ -28,7 +28,7 @@ const sendMattermostNotifications = async (guests, greeter, invite_from) => {
     if (!mattermost) {
         return;
     }
-    let from = 'via une source non identifiable';
+    let from = null;
     // invite_from is initialized in pages/Contact/index.vue or in api/server/amils/mails.js (see sendUserShare)
     if (invite_from === 'access_request') {
         from = "via le formulaire de demande d'accès";

--- a/packages/api/server/controllers/inviteController.js
+++ b/packages/api/server/controllers/inviteController.js
@@ -24,16 +24,25 @@ const sendEmailsInvitations = async (guests, greeter) => {
     }
 };
 
-const sendMattermostNotifications = async (guests, greeter) => {
+const sendMattermostNotifications = async (guests, greeter, invite_from) => {
     if (!mattermost) {
         return;
+    }
+    let from = 'via une source non identifiable';
+    // invite_from is initialized in pages/Contact/index.vue or in api/server/amils/mails.js (see sendUserShare)
+    if (invite_from === 'access_request') {
+        from = "via le formulaire de demande d'accès";
+    } else if (invite_from === 'contact_others') {
+        from = "via le formulaire de contact (signaler / aider / demande d'info / demander de l'aide)";
+    } else if (invite_from === 'push_mail') {
+        from = 'via push mail J+15';
     }
 
     for (let i = 0; i < guests.length; i += 1) {
         // Send a mattermost alert, if it fails, do nothing
         try {
             // eslint-disable-next-line no-await-in-loop
-            await triggerPeopleInvitedAlert(guests[i], greeter, "via le formulaire de demande d'accès");
+            await triggerPeopleInvitedAlert(guests[i], greeter, from);
         } catch (err) {
             // eslint-disable-next-line no-console
             console.log(`Error with invited people mattermost webhook : ${Object.entries(err.message).flat()}`);
@@ -43,7 +52,7 @@ const sendMattermostNotifications = async (guests, greeter) => {
 
 module.exports = () => ({
     async invite(req, res, next) {
-        const { greeter, guests } = req.body;
+        const { greeter, guests, invite_from } = req.body;
 
         // Send an email to each guest
         try {
@@ -60,7 +69,7 @@ module.exports = () => ({
 
         // Send a mattermost alert for each guest
         try {
-            await sendMattermostNotifications(guests, greeter);
+            await sendMattermostNotifications(guests, greeter, invite_from);
         } catch (err) {
             // ignore
         }

--- a/packages/api/server/controllers/inviteController.js
+++ b/packages/api/server/controllers/inviteController.js
@@ -43,8 +43,7 @@ const sendMattermostNotifications = async (guests, greeter) => {
 
 module.exports = () => ({
     async invite(req, res, next) {
-        const { greeter_full: greeter } = req;
-        const { guests } = req.body;
+        const { greeter, guests } = req.body;
 
         // Send an email to each guest
         try {

--- a/packages/api/server/mails/mails.js
+++ b/packages/api/server/mails/mails.js
@@ -615,7 +615,7 @@ module.exports = {
             recipient,
             variables: {
                 recipientName: formatName(recipient.first_name, recipient.last_name),
-                invitationUrl: `${invitationUrl}?email=${encodeURIComponent(recipient.email)}&first_name=${recipient.first_name}&last_name=${recipient.last_name}&from=push_mail&${utm}`,
+                invitationUrl: `${invitationUrl}?email=${encodeURIComponent(recipient.email)}&first_name=${encodeURIComponent(recipient.first_name)}&last_name=${encodeURIComponent(recipient.last_name)}&from=push_mail&${utm}`,
                 backUrl,
                 frontUrl: `${frontUrl}?${utm}`,
             },

--- a/packages/api/server/mails/mails.js
+++ b/packages/api/server/mails/mails.js
@@ -615,7 +615,7 @@ module.exports = {
             recipient,
             variables: {
                 recipientName: formatName(recipient.first_name, recipient.last_name),
-                invitationUrl: `${invitationUrl}?email=${encodeURIComponent(recipient.email)}&${utm}`,
+                invitationUrl: `${invitationUrl}?email=${encodeURIComponent(recipient.email)}&first_name=${recipient.first_name}&last_name=${recipient.last_name}&from="push_mail"&${utm}`,
                 backUrl,
                 frontUrl: `${frontUrl}?${utm}`,
             },

--- a/packages/api/server/mails/mails.js
+++ b/packages/api/server/mails/mails.js
@@ -615,7 +615,7 @@ module.exports = {
             recipient,
             variables: {
                 recipientName: formatName(recipient.first_name, recipient.last_name),
-                invitationUrl: `${invitationUrl}?email=${encodeURIComponent(recipient.email)}&first_name=${recipient.first_name}&last_name=${recipient.last_name}&from="push_mail"&${utm}`,
+                invitationUrl: `${invitationUrl}?email=${encodeURIComponent(recipient.email)}&first_name=${recipient.first_name}&last_name=${recipient.last_name}&from=push_mail&${utm}`,
                 backUrl,
                 frontUrl: `${frontUrl}?${utm}`,
             },

--- a/packages/api/server/middlewares/validators/invite.js
+++ b/packages/api/server/middlewares/validators/invite.js
@@ -8,7 +8,12 @@ module.exports = [
     body('invite_from')
         .isString().bail().withMessage('L\'origine de l\'invitation est invalide')
         .trim()
-        .notEmpty().bail().withMessage('L\'origine de l\'invitation est obligatoire'),
+        .notEmpty().bail().withMessage('L\'origine de l\'invitation est obligatoire')
+        .custom((value) => {
+            if (!['access_request', 'contact_others', 'push_mail'].includes(value)) {
+                throw new Error('Le paramètre de requête indiquant l\'origine de l\'invitation doit être fourni');
+            }
+        }),
 
     body('greeter.email')
         .trim()

--- a/packages/api/server/middlewares/validators/invite.js
+++ b/packages/api/server/middlewares/validators/invite.js
@@ -11,8 +11,9 @@ module.exports = [
         .notEmpty().bail().withMessage('L\'origine de l\'invitation est obligatoire')
         .custom((value) => {
             if (!['access_request', 'contact_others', 'push_mail'].includes(value)) {
-                throw new Error('Le paramètre de requête indiquant l\'origine de l\'invitation doit être fourni');
+                throw new Error('L\'origine de l\'invitation est invalide');
             }
+            return true;
         }),
 
     body('greeter.email')

--- a/packages/api/server/middlewares/validators/invite.js
+++ b/packages/api/server/middlewares/validators/invite.js
@@ -5,7 +5,7 @@ const userModel = require('#server/models/userModel')(sequelize);
 
 module.exports = [
 
-    body('greeter')
+    body('greeter.email')
         .trim()
         .notEmpty().bail().withMessage('Le courriel de la personne a l\'initiative de l\'invitation doit être renseigné')
         .isEmail().bail().withMessage('Le courriel de la personne a l\'initiative de l\'invitation n\'est pas valide')
@@ -16,22 +16,17 @@ module.exports = [
             outlookdotcom_remove_subaddress: false,
             yahoo_remove_subaddress: false,
             icloud_remove_subaddress: false,
-        })
-        .custom(async (value, { req }) => {
-            let user = null;
-
-            try {
-                user = await userModel.findOneByEmail(value);
-                if ((Object.keys(user).length < 1) || (user === null)) {
-                    throw new Error('La personne a l\'initiative de l\'invitation n\'existe pas');
-                }
-            } catch (error) {
-                throw new Error('La personne a l\'initiative de l\'invitation n\'a pas été trouvée');
-            }
-
-            req.greeter_full = user;
-            return true;
         }),
+
+    body('greeter.first_name')
+        .isString().bail().withMessage('Le prénom de la peersonne à l\'initiative de l\'invitation est invalide')
+        .trim()
+        .notEmpty().bail().withMessage('Le prénom de la peersonne à l\'initiative de l\'invitation est obligatoire'),
+
+    body('greeter.last_name')
+        .isString().bail().withMessage('Le nom de la peersonne à l\'initiative de l\'invitation est invalide')
+        .trim()
+        .notEmpty().bail().withMessage('Le nom de la peersonne à l\'initiative de l\'invitation est obligatoire'),
 
     body('guests')
         .customSanitizer((value) => {

--- a/packages/api/server/middlewares/validators/invite.js
+++ b/packages/api/server/middlewares/validators/invite.js
@@ -5,6 +5,11 @@ const userModel = require('#server/models/userModel')(sequelize);
 
 module.exports = [
 
+    body('invite_from')
+        .isString().bail().withMessage('L\'origine de l\'invitation est invalide')
+        .trim()
+        .notEmpty().bail().withMessage('L\'origine de l\'invitation est obligatoire'),
+
     body('greeter.email')
         .trim()
         .notEmpty().bail().withMessage('Le courriel de la personne a l\'initiative de l\'invitation doit être renseigné')
@@ -19,14 +24,14 @@ module.exports = [
         }),
 
     body('greeter.first_name')
-        .isString().bail().withMessage('Le prénom de la peersonne à l\'initiative de l\'invitation est invalide')
+        .isString().bail().withMessage('Le prénom de la personne à l\'initiative de l\'invitation est invalide')
         .trim()
-        .notEmpty().bail().withMessage('Le prénom de la peersonne à l\'initiative de l\'invitation est obligatoire'),
+        .notEmpty().bail().withMessage('Le prénom de la personne à l\'initiative de l\'invitation est obligatoire'),
 
     body('greeter.last_name')
-        .isString().bail().withMessage('Le nom de la peersonne à l\'initiative de l\'invitation est invalide')
+        .isString().bail().withMessage('Le nom de la personne à l\'initiative de l\'invitation est invalide')
         .trim()
-        .notEmpty().bail().withMessage('Le nom de la peersonne à l\'initiative de l\'invitation est obligatoire'),
+        .notEmpty().bail().withMessage('Le nom de la personne à l\'initiative de l\'invitation est obligatoire'),
 
     body('guests')
         .customSanitizer((value) => {

--- a/packages/frontend/src/js/app/components/ui/Form/input/TextArea.vue
+++ b/packages/frontend/src/js/app/components/ui/Form/input/TextArea.vue
@@ -84,7 +84,7 @@ export default {
             type: String
         },
         rows: {
-            type: [String, Array]
+            type: [String, Number]
         },
         cols: {
             type: String

--- a/packages/frontend/src/js/app/components/ui/Form/input/TextArea.vue
+++ b/packages/frontend/src/js/app/components/ui/Form/input/TextArea.vue
@@ -84,7 +84,7 @@ export default {
             type: String
         },
         rows: {
-            type: String
+            type: [String, Array]
         },
         cols: {
             type: String

--- a/packages/frontend/src/js/app/components/ui/Icon.vue
+++ b/packages/frontend/src/js/app/components/ui/Icon.vue
@@ -7,7 +7,7 @@ export default {
     name: "Icon",
     props: {
         icon: {
-            type: String,
+            type: [String, Array],
             required: true
         },
         spin: {

--- a/packages/frontend/src/js/app/pages/Contact/index.vue
+++ b/packages/frontend/src/js/app/pages/Contact/index.vue
@@ -440,8 +440,7 @@ export default {
                         this.commonFields.email
                     )}&first_name=${encodeURIComponent(
                         this.commonFields.first_name
-                    )}
-                    &last_name=${encodeURIComponent(
+                    )}&last_name=${encodeURIComponent(
                         this.commonFields.last_name
                     )}&from=${from}`
                 );

--- a/packages/frontend/src/js/app/pages/Contact/index.vue
+++ b/packages/frontend/src/js/app/pages/Contact/index.vue
@@ -26,6 +26,7 @@
                     >
                         <InputGroup>
                             <TextInput
+                                :showMandatoryStar="true"
                                 :label="$t('contactPage.email')"
                                 v-model="commonFields.email"
                                 id="email"
@@ -33,6 +34,7 @@
                                 rules="required|email"
                             />
                             <TextInput
+                                :showMandatoryStar="true"
                                 :label="$t('contactPage.firstname')"
                                 v-model="commonFields.first_name"
                                 id="first_name"
@@ -40,6 +42,7 @@
                                 rules="required"
                             />
                             <TextInput
+                                :showMandatoryStar="true"
                                 :label="$t('contactPage.lastname')"
                                 v-model="commonFields.last_name"
                                 id="last_name"
@@ -47,6 +50,7 @@
                                 rules="required"
                             />
                             <TextInput
+                                :showMandatoryStar="true"
                                 :rows="8"
                                 :label="$t('contactPage.phone')"
                                 v-model="commonFields.phone"
@@ -420,22 +424,26 @@ export default {
             };
             this.loading = true;
             try {
-                const result = await contact(data);
+                // Create a user and send an email to admins
+                await contact(data);
                 this.loading = false;
-                // Si l'utilisateur a demandé un accès, on route vers le formulaire d'invitation
+
                 if (this.isRequestAccessAndActor) {
                     this.$trackMatomoEvent(
                         "Demande d'accès",
                         "Demande d'accès"
                     );
-                    this.$router.push(
-                        `/invitation?email=${encodeURIComponent(result.email)}`
-                    );
                 } else {
                     this.$trackMatomoEvent("Contact", "Demande d'information");
-
-                    this.$router.push("/");
                 }
+                this.$router.push(
+                    `/invitation?email=${encodeURIComponent(
+                        this.commonFields.email
+                    )}&first_name=${this.commonFields.first_name}&last_name=${
+                        this.commonFields.last_name
+                    }`
+                );
+
                 notify({
                     group: "notifications",
                     type: "success",

--- a/packages/frontend/src/js/app/pages/Contact/index.vue
+++ b/packages/frontend/src/js/app/pages/Contact/index.vue
@@ -26,7 +26,6 @@
                     >
                         <InputGroup>
                             <TextInput
-                                :showMandatoryStar="true"
                                 :label="$t('contactPage.email')"
                                 v-model="commonFields.email"
                                 id="email"
@@ -34,7 +33,6 @@
                                 rules="required|email"
                             />
                             <TextInput
-                                :showMandatoryStar="true"
                                 :label="$t('contactPage.firstname')"
                                 v-model="commonFields.first_name"
                                 id="first_name"
@@ -42,7 +40,6 @@
                                 rules="required"
                             />
                             <TextInput
-                                :showMandatoryStar="true"
                                 :label="$t('contactPage.lastname')"
                                 v-model="commonFields.last_name"
                                 id="last_name"
@@ -50,7 +47,6 @@
                                 rules="required"
                             />
                             <TextInput
-                                :showMandatoryStar="true"
                                 :rows="8"
                                 :label="$t('contactPage.phone')"
                                 v-model="commonFields.phone"
@@ -442,9 +438,12 @@ export default {
                 this.$router.push(
                     `/invitation?email=${encodeURIComponent(
                         this.commonFields.email
-                    )}&first_name=${this.commonFields.first_name}&last_name=${
+                    )}&first_name=${encodeURIComponent(
+                        this.commonFields.first_name
+                    )}
+                    &last_name=${encodeURIComponent(
                         this.commonFields.last_name
-                    }&from=${from}`
+                    )}&from=${from}`
                 );
 
                 notify({

--- a/packages/frontend/src/js/app/pages/Contact/index.vue
+++ b/packages/frontend/src/js/app/pages/Contact/index.vue
@@ -427,21 +427,24 @@ export default {
                 // Create a user and send an email to admins
                 await contact(data);
                 this.loading = false;
+                let from = null;
 
                 if (this.isRequestAccessAndActor) {
                     this.$trackMatomoEvent(
                         "Demande d'accès",
                         "Demande d'accès"
                     );
+                    from = "access_request";
                 } else {
                     this.$trackMatomoEvent("Contact", "Demande d'information");
+                    from = "contact_others";
                 }
                 this.$router.push(
                     `/invitation?email=${encodeURIComponent(
                         this.commonFields.email
                     )}&first_name=${this.commonFields.first_name}&last_name=${
                         this.commonFields.last_name
-                    }`
+                    }&from=${from}`
                 );
 
                 notify({

--- a/packages/frontend/src/js/app/pages/Invitation/index.vue
+++ b/packages/frontend/src/js/app/pages/Invitation/index.vue
@@ -120,6 +120,9 @@ export default {
                 last_name: this.$route.query.last_name
             };
         },
+        inviteFrom() {
+            return this.$route.query.from;
+        },
         errors() {
             const labels = {
                 greeter:
@@ -182,7 +185,8 @@ export default {
                         last_name
                     })
                 ),
-                greeter: this.greeter
+                greeter: this.greeter,
+                invite_from: this.inviteFrom
             };
 
             // Préparation du message de confirmation d'envoi des mails

--- a/packages/frontend/src/js/app/pages/Invitation/index.vue
+++ b/packages/frontend/src/js/app/pages/Invitation/index.vue
@@ -114,7 +114,11 @@ export default {
     },
     computed: {
         greeter() {
-            return this.$route.query.email;
+            return {
+                email: this.$route.query.email,
+                first_name: this.$route.query.first_name,
+                last_name: this.$route.query.last_name
+            };
         },
         errors() {
             const labels = {


### PR DESCRIPTION
## 🧾 Ticket Trello
[Redirection systématique vers la page d'invitation depuis le formulaire de contact]( https://trello.com/c/JQNs6sJA)
[Notif mattermost pour invitation quelque soit l'objet du message depuis landing](https://trello.com/c/JQNs6sJA)

## 🛠 Description de la PR
**Info**: La branche initiale `issue/1107` correspondant à la première carte a été intégrée à la `branche issue/1121`, les deux sujets étant liés.
- La première carte conerne la redirection vers la page permettant d'nviter d'autres acteurs à décourvrir la platforme systématique, quelque soit le motif de la demande de contact. Auparavant, seules les demandes d'accès à la plateforme faisaient l'objet de cette redirection.
- La seconde carte consiste à préciser l'origine de l'invitation dans la notification Mattermost qui est déclechée à chaque saisie d'une invitation à rejoindre la plateforme.
- Deux bugs mineurs ont été corrigés au passage:
> *"Expected String, got Array for prop Icon"* concernant le composant `ui/Icon.vue`
> *"Expected String, got Number for prop rows"* concernant le composant `ui/form/input/TextArea.vue`

## 🚨 Notes pour la mise en production
Dans **Matomo**, créer deux exceptions permettant d'éviter le tracking des paramètres `first_name` et `last_name` dans les paramètres de requêtes.