### PR TITLE
#patch (1131) Placeholder de l'espace message dans le journal du site et texte à gauche modifiés

### DIFF
--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
@@ -78,7 +78,7 @@
                         class="mb-4"
                         icon="info-circle"
                         title="À qui sont destinés les messages ?"
-                        description='À tous les acteurs du site. Un mail est automatiquement envoyé aux personnes signalées "intervenant sur ce site" et également aux acteurs en DDETS et Préfecture.'
+                        description="À tous les acteurs du site. Un mail est automatiquement envoyé aux personnes signalées « intervenant sur ce site», aux acteurs en DDETS, Préfecture et la Dihal."
                     ></TownDetailsNewCommentLeftColumn>
                     <TownDetailsNewCommentLeftColumn
                         icon="exclamation-triangle"

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
@@ -15,7 +15,7 @@
                 rows="5"
                 name="newComment"
                 v-model="newComment"
-                placeholder="Votre commentaire - Merci de respecter les règles de confidentialité."
+                placeholder="Partagez votre passage sur le site, le contexte sanitaire, la situation des habitants, difficultés rencontrées lors de votre intervention…"
             />
             <div
                 class="flex ml-4"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/mGXZvQ5O

## 🛠 Description de la PR
- Modification dans `TownDetailsNewComment.vue`: modification du wording du placeholder de la zone de texte relative aux comentaires
- Modification dans `TownDetails.vue`: modification du wording dans la colonne de gauche

## 📸 Captures d'écran
_Si pertinent, mettre ici des captures de présentation de la fonctionnalité._

## 🚨 Notes pour la mise en production
![image](https://user-images.githubusercontent.com/50863659/126290342-f017bef9-2b78-4688-b756-90150519a203.png)