### PR TITLE
#patch (1152) Sauvegarder la date et heure de dernière connexion

### DIFF
--- a/packages/api/db/migrations/001152-add-last-access-to-users.js
+++ b/packages/api/db/migrations/001152-add-last-access-to-users.js
@@ -1,0 +1,15 @@
+function addColumn(queryInterface, Sequelize, tableName) {
+    return queryInterface.addColumn(
+        tableName,
+        'last_access',
+        {
+            type: Sequelize.DATE,
+            allowNull: true,
+        },
+    );
+}
+
+module.exports = {
+    up: (queryInterface, Sequelize) => addColumn(queryInterface, Sequelize, 'users'),
+    down: queryInterface => queryInterface.removeColumn('users', 'last_access'),
+};

--- a/packages/api/server/middlewares/authMiddleware.js
+++ b/packages/api/server/middlewares/authMiddleware.js
@@ -54,6 +54,11 @@ module.exports = (models) => {
 
         Sentry.setUser({ id: user.id });
 
+        const now = new Date();
+        await models.user.update(user.id, {
+            last_access: now,
+        });
+
         return user;
     }
 

--- a/packages/api/server/models/userModel.js
+++ b/packages/api/server/models/userModel.js
@@ -548,7 +548,7 @@ module.exports = (database) => {
 
             const allowedProperties = [
                 'first_name', 'last_name', 'position', 'phone', 'password', 'defaultExport', 'fk_status',
-                'last_version', 'last_changelog', 'charte_engagement_signee',
+                'last_version', 'last_changelog', 'charte_engagement_signee', 'last_access',
             ];
             const propertiesToColumns = {
                 first_name: 'first_name',
@@ -561,6 +561,7 @@ module.exports = (database) => {
                 last_version: 'last_version',
                 last_changelog: 'last_changelog',
                 charte_engagement_signee: 'charte_engagement_signee',
+                last_access: 'last_access',
             };
             const setClauses = [];
             const replacements = {};


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/WC4IXf0J

## 🛠 Description de la PR
- Ajout d'une migration pour ajouter le champ `last_access' à la table `users`
- Ajout de la propriété `last_access` à la méthode `update` du modèle `userModel`
- Exécution de la mise à jour du champ `last_access` depuis la méthode `authenticate` du middleware `authMiddleware`

## 🚨 Notes pour la mise en production
- Exécuter la migration `001152-add-last-access-to-users.js`
- Mettre à jour la [requête de suivi des utilisateurs](https://github.com/MTES-MCT/resorption-bidonvilles/wiki/Suivi-des-utilisateurs/_edit) sur le wiki en ajoutant la date et l'heure de dernière connexion de l'utilisateur:
```sql
SELECT
    TO_CHAR(u.created_at :: DATE, 'dd/mm/yyyy') AS "Date de la demande d'accès",
    email AS "Courriel",
    INITCAP(first_name) AS "Prénom",
    UPPER(last_name) AS "Nom de famille",
    u.position AS "Fonction de l'utilisateur",
    u.phone as "Téléphone",
    CASE
        WHEN fk_status = 'active' THEN 'Compte activé'
        WHEN lua.expires_at < NOW() THEN 'Lien d''activation expiré'
        ELSE 'Lien d''activation toujours valide'
    END AS "Statut",
    TO_CHAR(lua.used_at :: DATE, 'dd/mm/yyyy') AS "Date d'activation du compte",
    TO_CHAR(u.last_access :: DATE, 'dd/mm/yyyy hh:mm:ss') AS "Date et heure de dernière connexion",    
	u.fk_role AS "Rôle de l'acteur",
    o.name AS "Organisation",
    o.abbreviation AS "Organisation abbr",
    rr.name AS "Rôle de l'organisation",
    o.region_code AS "Code région",
    o.region_name AS "Région",
    o.departement_code AS "Code département",
    o.departement_name AS "Département"
FROM
    users u
LEFT JOIN
    last_user_accesses lua ON lua.fk_user = u.user_id
LEFT JOIN
    localized_organizations o ON o.organization_id = u.fk_organization
LEFT JOIN
	organization_types ot ON ot.organization_type_id = o.fk_type
LEFT JOIN
	roles_regular rr ON rr.role_id = ot.fk_role
WHERE
    lua.user_access_id IS NOT NULL 
AND
	u.fk_status <> 'inactive'
ORDER BY
    "Code région",
    "Code département",
    used_at ASC,
    expires_at DESC;
```