### PR TITLE
#patch (1178) Activation du mode "history" pour les URLs sans "/#" en préfixe

### DIFF
--- a/packages/api/server/mails/README.md
+++ b/packages/api/server/mails/README.md
@@ -23,11 +23,11 @@ Les autres variables utilisés plus spécifiques:
 - activationUrl => Url d'activation  
 - activationUrlSentDate => date 
 - activationUrlExpDate => date
-- siteUrl => https://resorption-bidonvilles.beta.gouv.fr/#/site/406
-- contactUrl => https://resorption-bidonvilles.beta.gouv.fr/#/contact  
+- siteUrl => https://resorption-bidonvilles.beta.gouv.fr/site/406
+- contactUrl => https://resorption-bidonvilles.beta.gouv.fr/contact  
 - formationUrl => https://app.evalandgo.com/s/index.php?a=JTk2cCU5N2slOUElQjA=&id=JTk4ayU5QW4lOTYlQUY=
 - idealcoUrl => https://www.idealco.fr/campagne/?utm_campaign=g-386-3036d540
-- adminUrl => https://resorption-bidonvilles.beta.gouv.fr/#/liste-des-utilisateurs
+- adminUrl => https://resorption-bidonvilles.beta.gouv.fr/liste-des-utilisateurs
 
 ## Tracking 
 
@@ -37,7 +37,7 @@ Règles d’écriture des Url pour matomo
 Beta.gouv utilise la version 3.13.5 de matimo.
 Cette version n’utilise que 2 champs pour effectuer des campagnes de tracking dédiées: pk_campaign et pk_kwd.
 
-ie: Me connecter: https://resorption-bidonvilles.beta.gouv.fr/#/connexion?pk_campaign=recap-activite-email&pk_kwd=dep13-31-05-2021 (valeur à variabiliser) 
+ie: Me connecter: https://resorption-bidonvilles.beta.gouv.fr/connexion?pk_campaign=recap-activite-email&pk_kwd=dep13-31-05-2021 (valeur à variabiliser) 
 
 
 

--- a/packages/frontend/cypress/integration/towns.create-edit-delete-fromFullToMin.spec.js
+++ b/packages/frontend/cypress/integration/towns.create-edit-delete-fromFullToMin.spec.js
@@ -51,7 +51,7 @@ describe("Gestion des sites", () => {
 
                             // assert
                             cy.url().should("contain", "/liste-des-sites");
-                            cy.visit(`/#/site/${siteId}`);
+                            cy.visit(`/site/${siteId}`);
                             cy.get("body").should(
                                 "contain",
                                 "Le site demandé n'existe pas en base de données"

--- a/packages/frontend/cypress/integration/towns.create-edit-delete-fromMinToFull.spec.js
+++ b/packages/frontend/cypress/integration/towns.create-edit-delete-fromMinToFull.spec.js
@@ -51,7 +51,7 @@ describe("Gestion des sites", () => {
 
                             // assert
                             cy.url().should("contain", "/liste-des-sites");
-                            cy.visit(`/#/site/${siteId}`);
+                            cy.visit(`/site/${siteId}`);
                             cy.get("body").should(
                                 "contain",
                                 "Le site demandé n'existe pas en base de données"

--- a/packages/frontend/cypress/integration/towns.create-edit-delete-fromMinToMin.spec.js
+++ b/packages/frontend/cypress/integration/towns.create-edit-delete-fromMinToMin.spec.js
@@ -50,7 +50,7 @@ describe("Gestion des sites", () => {
 
                         // assert
                         cy.url().should("contain", "/liste-des-sites");
-                        cy.visit(`/#/site/${siteId}`);
+                        cy.visit(`/site/${siteId}`);
                         cy.get("body").should(
                             "contain",
                             "Le site demandé n'existe pas en base de données"

--- a/packages/frontend/cypress/support/commands/signinAs.js
+++ b/packages/frontend/cypress/support/commands/signinAs.js
@@ -7,7 +7,7 @@
  * @returns {undefined}
  */
 Cypress.Commands.add("signinAs", ({ email, password }) => {
-    cy.visit("/#/connexion");
+    cy.visit("/connexion");
     cy.get("#input-email").type(email);
     cy.get("#input-password").type(password);
     cy.contains("Me connecter").click();

--- a/packages/frontend/src/js/app/pages/Contact/SocialShare.vue
+++ b/packages/frontend/src/js/app/pages/Contact/SocialShare.vue
@@ -18,7 +18,7 @@ export default {
     computed: {
         url() {
             return encodeURIComponent(
-                "https://resorption-bidonvilles.beta.gouv.fr/#/contact"
+                "https://resorption-bidonvilles.beta.gouv.fr/contact"
             );
         }
     }

--- a/packages/frontend/src/js/app/pages/signin/signin.js
+++ b/packages/frontend/src/js/app/pages/signin/signin.js
@@ -37,7 +37,7 @@ export default {
                             error: "La tentative de connexion a échoué"
                         },
                         submitPrefix:
-                            '<a href="/#/nouveau-mot-de-passe">J\'ai perdu mon mot de passe</a>',
+                            '<a href="/nouveau-mot-de-passe">J\'ai perdu mon mot de passe</a>',
                         submit: ({ email, password }) => login(email, password)
                     }
                 ]

--- a/packages/frontend/src/js/app/pages/signin/signin.pug
+++ b/packages/frontend/src/js/app/pages/signin/signin.pug
@@ -2,6 +2,6 @@
     <div class="page--withMargin">
         <NavBar></NavBar>
         <Form v-bind="formDefinition" v-model="formData" @complete="onComplete"></Form>
-        <div class="text-center mt-4">Vous n'avez pas encore de compte ? <a href="https://resorption-bidonvilles.beta.gouv.fr/#/contact">Demandez un accès</a></div>
+        <div class="text-center mt-4">Vous n'avez pas encore de compte ? <a href="https://resorption-bidonvilles.beta.gouv.fr/contact">Demandez un accès</a></div>
     </div>
 </div>

--- a/packages/frontend/src/js/app/pages/users.activate/users.activate.js
+++ b/packages/frontend/src/js/app/pages/users.activate/users.activate.js
@@ -48,7 +48,7 @@ export default {
                             "Vous pouvez désormais vous connecter à la plateforme"
                     },
                     submitPrefix:
-                        'En cliquant sur "Activer mon compte", j\'accepte les <a href="/#/conditions-d-utilisation">conditions générales d\'utilisation</a> et de partager mes données (nom, prénom, courriel, structure et lorsque renseigné, numéro de téléphone) aux utilisateurs de la plateforme via l’annuaire',
+                        'En cliquant sur "Activer mon compte", j\'accepte les <a href="/conditions-d-utilisation">conditions générales d\'utilisation</a> et de partager mes données (nom, prénom, courriel, structure et lorsque renseigné, numéro de téléphone) aux utilisateurs de la plateforme via l’annuaire',
                     submit: data => {
                         this.$trackMatomoEvent(
                             "Demande d'accès",

--- a/packages/frontend/src/js/app/router.js
+++ b/packages/frontend/src/js/app/router.js
@@ -160,20 +160,24 @@ const guardians = {
  *
  * @returns {string}
  */
-function home() {
+function home(to, from, next) {
+    if (to.fullPath.substr(0, 2) === "/#") {
+        return next(to.fullPath.substr(2));
+    }
+
     if (isLoggedIn() !== true) {
         if (alreadyLoggedBefore()) {
-            return "/connexion";
+            return next("/connexion");
         }
 
-        return "/landing";
+        return next("/landing");
     }
 
     if (isConfigLoaded() !== true) {
-        return "/launcher";
+        return next("/launcher");
     }
 
-    return "/cartographie";
+    return next("/cartographie");
 }
 
 /**
@@ -200,7 +204,7 @@ const router = new VueRouter({
     routes: [
         {
             path: "/",
-            redirect: home,
+            beforeEnter: home,
             meta: {
                 analyticsIgnore: true
             }
@@ -509,6 +513,15 @@ const router = new VueRouter({
             }
         }
     ]
+});
+
+router.beforeEach((to, from, next) => {
+    if (to.fullPath.substr(0, 2) === "/#") {
+        next(to.fullPath.substr(2));
+        return;
+    }
+
+    next();
 });
 
 export { router };

--- a/packages/frontend/src/js/app/router.js
+++ b/packages/frontend/src/js/app/router.js
@@ -170,7 +170,7 @@ function home(to, from, next) {
             return next("/connexion");
         }
 
-        return next("/landing");
+        return next();
     }
 
     if (isConfigLoaded() !== true) {
@@ -205,13 +205,14 @@ const router = new VueRouter({
         {
             path: "/",
             beforeEnter: home,
+            component: LandingPage,
             meta: {
                 analyticsIgnore: true
             }
         },
         {
             path: "/landing",
-            component: LandingPage,
+            redirect: "/",
             beforeEnter: guardians.anonymous
         },
         {

--- a/packages/frontend/src/js/app/router.js
+++ b/packages/frontend/src/js/app/router.js
@@ -180,6 +180,7 @@ function home() {
  * Obviously, the routing configuration of the whole app
  */
 const router = new VueRouter({
+    mode: "history",
     scrollBehavior: (to, from, savedPosition) => {
         if (to.hash) {
             return {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/9sH45OfD/1178

Voir la PR côté deploy : https://github.com/MTES-MCT/resorption-bidonvilles-deploy/pull/12

## 🛠 Description de la PR
En bref :
- activation du mode "history" dans le router
- ajout d'un guard "beforeach" pour réécrire toutes les URLs commençant par "/#" afin de maintenir le support des anciennes URLs (cette réécriture ne peut pas se faire côté nginx car le hash n'est pas passé au serveur)
- mise à jour des quelques URLs écrites en dur pour retirer le "/#"

## 📸 Captures d'écran
Ø

## 🚨 Notes pour la mise en production
Mettre à jour la variable `RB_API_FRONT_URL` dans `config/.env` pour retirer le `/#` de l'URL.