### PR TITLE
(1133) Ajout du tag "Objectif résorption 2021 par la Préfecture"

### DIFF
--- a/packages/api/db/migrations/001133-add-resorption_target-to-shantytowns.js
+++ b/packages/api/db/migrations/001133-add-resorption_target-to-shantytowns.js
@@ -1,0 +1,47 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+        transaction => Promise.all([
+            queryInterface.addColumn(
+                'shantytowns',
+                'resorption_target',
+                {
+                    type: Sequelize.INTEGER,
+                    allowNull: true,
+                },
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.addColumn(
+                'ShantytownHistories',
+                'resorption_target',
+                {
+                    type: Sequelize.INTEGER,
+                    allowNull: true,
+                },
+                {
+                    transaction,
+                },
+            ),
+        ]),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.transaction(
+        transaction => Promise.all([
+            queryInterface.removeColumn(
+                'shantytowns',
+                'resorption_target',
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.removeColumn(
+                'ShantytownHistories',
+                'resorption_target',
+                {
+                    transaction,
+                },
+            ),
+        ]),
+    ),
+};

--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -464,6 +464,7 @@ function serializeShantytown(town, permission) {
         firePreventionSiteAccessible: town.firePreventionSiteAccessible,
         firePreventionDevices: town.firePreventionDevices,
         firePreventionComments: town.firePreventionComments,
+        resorptionTarget: town.resorptionTarget,
     };
 
     // @todo: alter all dates to a datetime so it can be easily serialized (just like closed_at)
@@ -561,6 +562,7 @@ const SQL = {
         'shantytowns.fire_prevention_site_accessible': 'firePreventionSiteAccessible',
         'shantytowns.fire_prevention_devices': 'firePreventionDevices',
         'shantytowns.fire_prevention_comments': 'firePreventionComments',
+        'shantytowns.resorption_target': 'resorptionTarget',
         'creators.user_id': 'createdById',
         'creators.first_name': 'createdByFirstName',
         'creators.last_name': 'createdByLastName',
@@ -1306,6 +1308,7 @@ module.exports = (database) => {
                         police_granted_at,
                         bailiff,
                         closed_with_solutions,
+                        resorption_target,
                         created_at,
                         created_by,
                         updated_at,
@@ -1379,6 +1382,7 @@ module.exports = (database) => {
                     police_granted_at,
                     bailiff,
                     closed_with_solutions,
+                    resorption_target,
                     created_at,
                     created_by,
                     updated_at,

--- a/packages/frontend/src/js/app/components/ui/Tag.vue
+++ b/packages/frontend/src/js/app/components/ui/Tag.vue
@@ -23,7 +23,9 @@ export default {
             return {
                 default: "px-4 py-1 flex-row items-center bg-blue200",
                 withoutBackground: "px-3 mr-2 mb-2",
-                primary: "bg-blue100 text-primary px-3 mr-2 mb-2 rounded-lg"
+                primary: "bg-blue100 text-primary px-3 mr-2 mb-2 rounded-lg",
+                highlight:
+                    "bg-yellow-200 py-1 px-3 uppercase text-xs text-primary"
             }[this.variant];
         }
     }

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -30,6 +30,12 @@
                 Mis à jour le
                 {{ formatDate(town.updatedAt, "d/m/y") }}
             </div>
+            <div class="flex items-center uppercase text-sm mr-4">
+                <Tag variant="highlight" v-if="town.resorptionTarget">
+                    Objectif résorption
+                    {{ town.resorptionTarget }} par la Préfecture
+                </Tag>
+            </div>
             <div
                 class="flex items-center text-red uppercase text-xs font-bold cursor-pointer"
                 @click="$emit('openCovid')"

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -9,14 +9,24 @@
     >
         <router-link :to="`site/${shantytown.id}`">
             <div class="-mt-1 print:mt-0">
-                <Tag
-                    :class="[
-                        'text-xs mb-4 mx-6 uppercase text-primary',
-                        isHover ? 'shadow-md' : ''
-                    ]"
-                >
-                    {{ lastUpdate }}
-                </Tag>
+                <div class="mb-4 px-6">
+                    <Tag
+                        :class="[
+                            'text-xs uppercase text-primary',
+                            isHover ? 'shadow-md' : ''
+                        ]"
+                    >
+                        {{ lastUpdate }}
+                    </Tag>
+                    <Tag
+                        :class="['ml-4 py-1 px-3', isHover ? 'shadow-md' : '']"
+                        variant="highlight"
+                        v-if="shantytown.resorptionTarget"
+                    >
+                        Objectif résorption
+                        {{ shantytown.resorptionTarget }} par la Préfecture
+                    </Tag>
+                </div>
                 <div class="text-md px-6">
                     <div class="text-primary text-display-md ">
                         <span class="font-bold">

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -95,7 +95,7 @@
             </TownsListHeader>
             <div v-if="!isLoading">
                 <div
-                    class="md:flex items-end mb-4 justify-between print:hidden"
+                    class="md:flex items-start mb-4 justify-between print:hidden"
                 >
                     <TownsListFilters>
                         <TownsListFilter
@@ -225,6 +225,16 @@
                             class="mr-2 mb-2"
                             :value="filters.actors"
                             @input="val => updateFilters('actors', val)"
+                            :options="[
+                                { value: 'yes', label: 'Oui' },
+                                { value: 'no', label: 'Non' }
+                            ]"
+                        />
+                        <TownsListFilter
+                            title="Objectif résorption"
+                            class="mr-2 mb-2"
+                            :value="filters.target"
+                            @input="val => updateFilters('target', val)"
                             :options="[
                                 { value: 'yes', label: 'Oui' },
                                 { value: 'no', label: 'Non' }

--- a/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
+++ b/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
@@ -62,6 +62,13 @@ export function filterShantytowns(shantytowns, filters) {
             return false;
         }
 
+        if (
+            filters.target.length > 0 &&
+            !checkTarget(shantytown, filters.target)
+        ) {
+            return false;
+        }
+
         return true;
     });
 }
@@ -200,6 +207,21 @@ function checkActors(shantytown, filters) {
     }
 
     if (filters.includes("no") && shantytown.actors.length === 0) {
+        return true;
+    }
+
+    return filters.length === 0;
+}
+
+/**
+ *
+ */
+function checkTarget(shantytown, filters) {
+    if (filters.includes("yes") && shantytown.resorptionTarget !== null) {
+        return true;
+    }
+
+    if (filters.includes("no") && shantytown.resorptionTarget === null) {
         return true;
     }
 

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -30,6 +30,7 @@ export default new Vuex.Store({
                 status: "open",
                 location: null,
                 actors: [],
+                target: [],
                 search: ""
             },
             currentPage: 1


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/TKTmfvZQ/1133

## 🛠 Description de la PR
Ajout d'une colonne `resorption_target` à la table `shantytowns`, qui est censée contenir soit `NULL` (pas d'objectif) soit l'année de la résorption.
Cette colonne n'est pas remplissable via l'interface.

## 📸 Captures d'écran
- tag sur la carte dans la liste des sites + filtre
![image](https://user-images.githubusercontent.com/1801091/127158473-ae64daff-934e-45a2-ae68-9a0272546e26.png)
- tag sur la fiche de détails d'un site
![image](https://user-images.githubusercontent.com/1801091/127158507-bb5ed5cd-4075-4c15-8598-208a5a5f4894.png)

## 🚨 Notes pour la mise en production
- Faire tourner les migrations
- Mettre à jour les sites indiqués sur la carte pour les marquer comme objectifs de résorption 2021