### PR TITLE
#patch (1187) Setup mail blacklisting

### DIFF
--- a/packages/api/server/config.js
+++ b/packages/api/server/config.js
@@ -23,6 +23,9 @@ const config = {
         dsn: process.env.RB_API_SENTRY_DSN || '',
     },
     testEmail: process.env.RB_API_TEST_EMAIL || null,
+    mailBlacklist: process.env.RB_API_EMAIL_BLACKLIST
+        ? process.env.RB_API_EMAIL_BLACKLIST.split(',').map(id => parseInt(id, 10))
+        : [],
 };
 
 config.mattermost = process.env.RB_API_MATTERMOST_WEBHOOK;

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -146,7 +146,7 @@ module.exports = (models) => {
                 // Send a notification to all users of the related departement
                 try {
                     const { departement } = req.body.shantytown;
-                    const watchers = await userModel.getDepartementWatchers(departement.code);
+                    const watchers = await userModel.getDepartementWatchers(departement.code, true);
                     watchers
                         .filter(({ user_id }) => user_id !== req.user.id) // do not send an email to the user who closed the town
                         .forEach((watcher) => {

--- a/packages/api/server/models/userModel.js
+++ b/packages/api/server/models/userModel.js
@@ -851,7 +851,7 @@ module.exports = (database) => {
         },
     );
 
-    model.getDepartementWatchers = async (departementCode) => {
+    model.getDepartementWatchers = async (departementCode, applyBlacklist = false) => {
         const users = await database.query(
             `SELECT
                 u.user_id,
@@ -872,7 +872,11 @@ module.exports = (database) => {
             },
         );
 
-        return users.filter(({ user_id }) => !mailBlacklist.includes(user_id));
+        if (applyBlacklist === true) {
+            return users.filter(({ user_id }) => !mailBlacklist.includes(user_id));
+        }
+
+        return users;
     };
 
     return model;

--- a/packages/api/server/services/shantytown/create.js
+++ b/packages/api/server/services/shantytown/create.js
@@ -119,7 +119,7 @@ module.exports = async (townData, user) => {
 
     // Send a notification to all users of the related departement
     try {
-        const watchers = await getDepartementWatchers(townData.city.departement.code);
+        const watchers = await getDepartementWatchers(townData.city.departement.code, true);
         watchers
             .filter(({ user_id }) => user_id !== user.id) // do not send an email to the user who created the town
             .forEach((watcher) => {

--- a/packages/api/test/suites/server/controllers/townController/close.spec.js
+++ b/packages/api/test/suites/server/controllers/townController/close.spec.js
@@ -85,7 +85,7 @@ describe.only('townController.close()', () => {
             };
 
             dependencies.getDepartementWatchers
-                .withArgs('78')
+                .withArgs('78', true)
                 .resolves(output.watchers);
             dependencies.shantytownFindOne
                 .withArgs(input.user, 1)


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/NnOTTbWt/1187

Voir la PR sur deploy : https://github.com/MTES-MCT/resorption-bidonvilles-deploy/pull/13

## 🛠 Description de la PR
Ajout d'une blacklist pour exclure des utilisateurs des "shantytown watchers".

## 📸 Captures d'écran
Ø

## 🚨 Notes pour la mise en production
Penser à mettre à jour le fichier `config/.env` pour set `RB_API_EMAIL_BLACKLIST` (voir la carte pour l'id de l'utilisateur à exclure)