### PR TITLE
#patch (1188) Les activités datant d'hier sont marquées comme datant "d'aujourd'hui"

### DIFF
--- a/packages/frontend/src/js/app/components/ActivityCard/utils/formatDate.js
+++ b/packages/frontend/src/js/app/components/ActivityCard/utils/formatDate.js
@@ -1,13 +1,23 @@
-import getSince from "#app/pages/TownsList/getSince";
+function isSameDay(now, then) {
+    return (
+        now.getFullYear() === then.getFullYear() &&
+        now.getMonth() === then.getMonth() &&
+        now.getDate() === then.getDate()
+    );
+}
 
 export default function formatDate(date) {
-    const { days } = getSince(date);
+    const now = new Date();
+    const then = new Date(date * 1000);
 
     let day = `${App.formatDate(date, "U")} ${App.formatDate(date, "d M y")}`;
-    if (days === 0) {
+    if (isSameDay(now, then)) {
         day = "Aujourd'hui";
-    } else if (days === 1) {
-        day = "Hier";
+    } else {
+        now.setDate(now.getDate() - 1);
+        if (isSameDay(now, then)) {
+            day = "Hier";
+        }
     }
 
     return `${day} à ${App.formatDate(date, "h")}h`;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/joquTpis/1188

## 🛠 Description de la PR
Le calcul "aujourd'hui" / "hier" se faisait sur la base d'un temps écoulé (24h ou moins = aujourd'hui, entre 24 et 48h = hier) ce qui est en fait faux.
Il ne faut pas se baser sur un temps écoulé mais sur... les dates (jour, mois, année) uniquement !

## 📸 Captures d'écran
- Avant
![Capture d’écran 2021-07-28 à 10 37 59](https://user-images.githubusercontent.com/1801091/127291894-0217e205-f5ec-45e5-bccb-6a404e99eb71.png)
- Après
![Capture d’écran 2021-07-28 à 10 39 04](https://user-images.githubusercontent.com/1801091/127291973-f47a3e43-d5ff-4353-bbd4-edb061b3cd47.png)