### PR TITLE
#patch (1190) Reduire le nombre d'informations remontées dans le fil d'actualité

### DIFF
--- a/packages/frontend/src/js/app/components/ActivityCard/ActivityCardBody/ActivityCardBodyShantytownUpdated.vue
+++ b/packages/frontend/src/js/app/components/ActivityCard/ActivityCardBody/ActivityCardBodyShantytownUpdated.vue
@@ -59,7 +59,12 @@ export default {
             return this.variant === "small";
         },
         fieldList() {
-            return this.activity.diff.map(({ field }) => field).join(", ");
+            let list = this.activity.diff.map(({ field }) => field);
+            if (this.variant === "small" && list.length > 4) {
+                list = [...list.slice(0, 4), "..."];
+            }
+
+            return list.join(", ");
         },
         toggleIcon() {
             return this.showDetails ? "chevron-up" : "chevron-down";

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -533,7 +533,7 @@ export default {
             });
         },
         lastActivities() {
-            return this.filteredActivities.slice(0, 5).filter(({ date }) => {
+            return this.filteredActivities.slice(0, 3).filter(({ date }) => {
                 const { days } = getSince(date);
                 return days <= 7;
             });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/e4hC1xpR/1190

## 🛠 Description de la PR
- limitation du nombre de champs listés dans la liste des champs modifiés à 4 max (ajout de "..." s'il y en a plus)
- limitation du nombre d'activités listées dans le fil d'actualité à 3 (au lieu de 5)