### PR TITLE
#patch (1170) Fix some links reputation in emails

### DIFF
--- a/packages/api/server/mails/dist/admin_access_activated.html
+++ b/packages/api/server/mails/dist/admin_access_activated.html
@@ -170,7 +170,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:formationUrl}}" class="link" style="color: #000091; text-decoration: none;">{{var:formationUrl}}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">{{var:formationUrl}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_access_activated.text
+++ b/packages/api/server/mails/dist/admin_access_activated.text
@@ -7,7 +7,7 @@ coordination des acteurs de la résorption des bidonvilles.
 Pour l’accompagner à prendre en main la plateforme, vous pouvez l’inviter à
 s’inscrire à l’une de nos sessions de formation personnalisées en lui
 transmettant ce lien :
-{{var:formationUrl}} [{{var:formationUrl}}]
+{{var:formationUrl}}
 Vous souhaitez favoriser l’utilisation de la plateforme sur votre territoire ?
 Vous souhaitez promouvoir l’outil auprès de vos partenaires ?
 Contactez votre interlocutrice Annie Rasatandrianombana :

--- a/packages/api/server/mails/dist/admin_new_request_notification.html
+++ b/packages/api/server/mails/dist/admin_new_request_notification.html
@@ -218,7 +218,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:formationUrl}}" class="link" style="color: #000091; text-decoration: none;">{{var:formationUrl}}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">{{var:formationUrl}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_new_request_notification.text
+++ b/packages/api/server/mails/dist/admin_new_request_notification.text
@@ -18,7 +18,7 @@ ouvrir l’accès si vous avez un doute sur l’identité de la personne.
 Pour accompagner ce partenaire dans sa prise en main de l’outil, vous pouvez lui
 proposer de s’inscrire à l’une de nos sessions de formation personnalisée en lui
 transmettant ce lien :
-{{var:formationUrl}} [{{var:formationUrl}}]
+{{var:formationUrl}}
 Pour toute question, votre interlocutrice Annie Rasatandrianombana se tient à
 votre disposition : annie.rasatandrianombana@dihal.gouv.fr
 [annie.rasatandrianombana@dihal.gouv.fr] ou 01 40 81 80 39.

--- a/packages/api/server/mails/src/common/formation_cta_other.mjml
+++ b/packages/api/server/mails/src/common/formation_cta_other.mjml
@@ -1,1 +1,1 @@
-<mj-text mj-class="pb-4"><a href="{{var:formationUrl}}" class="link">{{var:formationUrl}}</a></mj-text>
+<mj-text mj-class="pb-4">{{var:formationUrl}}</mj-text>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/52Q6Ihdf/1170

## 🛠 Description de la PR
Il n'y a en fait que deux mails où le problème existait : `admin_access_activated` et `admin_new_request_notification`.
Le problème était que ces deux mails contenait le wording suivant : "[...] partagez le lien suivant : <lien vers evalandgo>".

Évidemment, étant destiné à être partagé, le lien était inscrit en dur dans le mail, au sein d'une balise <a> censée rediriger vers le même lien. Hors, ce dernier était en fait réécrit par Mailjet pour pointer vers le domaine de redirection.

Impossible de changer le wording du lien, du coup, puisque ce que l'on souhaite c'est qu'il apparaisse textuellement dans le mail, donc j'ai simplement viré le <a>.