### PR TITLE
#patch (1029) Ouverture du Tableau de bord aux "national_establisment"

### DIFF
--- a/packages/api/db/migrations/001029-01-alter-permissions-stats.read.js
+++ b/packages/api/db/migrations/001029-01-alter-permissions-stats.read.js
@@ -1,0 +1,25 @@
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            `INSERT INTO permissions(fk_role_regular, fk_feature, fk_entity, allowed, fk_geographic_level)
+            VALUES('national_establisment', 'read', 'stats', true, 'local')
+            RETURNING permission_id`,
+            {
+                transaction,
+            },
+        )
+            .then(([[{ permission_id }]]) => queryInterface.sequelize.query(
+                'INSERT INTO stats_permissions(fk_permission) VALUES(:permission_id)',
+                {
+                    replacements: {
+                        permission_id,
+                    },
+                    transaction,
+                },
+            )),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.query(
+        'DELETE FROM permissions WHERE fk_role_regular = \'national_establisment\' AND fk_feature = \'read\' AND fk_entity = \'stats\'',
+    ),
+};

--- a/packages/frontend/src/js/app/layouts/navbar/items.js
+++ b/packages/frontend/src/js/app/layouts/navbar/items.js
@@ -64,6 +64,11 @@ export default {
             group: "directory"
         },
         {
+            label: "Tableau de bord",
+            target: "/statistiques",
+            group: "stats"
+        },
+        {
             label: "Administration",
             items: [
                 {
@@ -75,11 +80,6 @@ export default {
                     label: "Créer un utilisateur",
                     target: "/nouvel-utilisateur",
                     group: "userCreation"
-                },
-                {
-                    label: "Tableau de bord",
-                    target: "/statistiques",
-                    group: "stats"
                 },
                 {
                     label: "Dernières activités",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/WEzuLhQ1/1029

## 🛠 Description de la PR
- Ajout de la permission "stats.read" au role "national_establisment"
- Déplacement du lien "Tableau de bord" dans le menu

## 🚨 Notes pour la mise en production
Faire jouer les migrations.