### PR TITLE
#patch (1196) Ecran de connexion, pas adapté pour du 13 pouces

### DIFF
--- a/packages/frontend/src/js/app/components/LoginLayout/index.vue
+++ b/packages/frontend/src/js/app/components/LoginLayout/index.vue
@@ -3,9 +3,9 @@
         <LoginNavBar />
 
         <div class="container px-10 mx-auto mb-4">
-            <div class="max-w-sm mx-auto py-20">
+            <div class="max-w-sm mx-auto pt-16 pb-12">
                 <img
-                    class="h-32 mx-auto mb-8"
+                    class="h-24 mx-auto mb-8"
                     src="../../../../../public/img/town.png"
                 />
 

--- a/packages/frontend/src/js/app/components/LoginLayout/index.vue
+++ b/packages/frontend/src/js/app/components/LoginLayout/index.vue
@@ -3,7 +3,7 @@
         <LoginNavBar />
 
         <div class="container px-10 mx-auto mb-4">
-            <div class="max-w-sm mx-auto pt-16 pb-12">
+            <div class="max-w-sm mx-auto py-10">
                 <img
                     class="h-24 mx-auto mb-8"
                     src="../../../../../public/img/town.png"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/emdEYNnI/1196-ecran-de-connexion-pas-adapt%C3%A9-pour-du-13-pouces-r%C3%A9duire-la-hauteur

## 🛠 Description de la PR
Ecran de connexion, pas adapté pour du 13 pouces

## 📸 Captures d'écran
Avant
![image](https://user-images.githubusercontent.com/5053593/130203432-43ae47c8-770b-4f62-b936-19c75912ff54.png)

Après
![image](https://user-images.githubusercontent.com/5053593/130203529-86805bf9-d1d0-4845-8750-8a75a13042fb.png)

