### PR TITLE
#patch (1197) Correction de la date d'actualisation sur la liste des sites

### DIFF
--- a/packages/frontend/src/js/app/pages/TownsList/__tests__/formatDateSince.js
+++ b/packages/frontend/src/js/app/pages/TownsList/__tests__/formatDateSince.js
@@ -58,15 +58,7 @@ describe(
         expect(result).toEqual("2 ans et 2 mois");
     }),
 
-    it("should work with a date of a few years ago", () => {
-        const d = new Date();
-        d.setDate(d.getDate() - 800);
-        const result = formatDateSince(d.getTime() / 1000);
-
-        expect(result).toEqual("2 ans et 2 mois");
-    }),
-
-    it.only("should work with yesterday even if it's less than 24h", () => {
+    it("should work with yesterday even if it's less than 24h", () => {
         const d = new Date();
         d.setDate(d.getDate() - 1);
         d.setHours(23, 59, 59);
@@ -76,7 +68,7 @@ describe(
         expect(result).toEqual("Hier");
     }),
 
-    it.only("should work with 2 days ago even if it's less than 48h", () => {
+    it("should work with 2 days ago even if it's less than 48h", () => {
         const d = new Date();
         d.setDate(d.getDate() - 2);
         d.setHours(23, 59, 59);

--- a/packages/frontend/src/js/app/pages/TownsList/__tests__/formatDateSince.js
+++ b/packages/frontend/src/js/app/pages/TownsList/__tests__/formatDateSince.js
@@ -56,5 +56,33 @@ describe(
         const result = formatDateSince(d.getTime() / 1000);
 
         expect(result).toEqual("2 ans et 2 mois");
+    }),
+
+    it("should work with a date of a few years ago", () => {
+        const d = new Date();
+        d.setDate(d.getDate() - 800);
+        const result = formatDateSince(d.getTime() / 1000);
+
+        expect(result).toEqual("2 ans et 2 mois");
+    }),
+
+    it.only("should work with yesterday even if it's less than 24h", () => {
+        const d = new Date();
+        d.setDate(d.getDate() - 1);
+        d.setHours(23, 59, 59);
+
+        const result = formatDateSince(d.getTime() / 1000);
+
+        expect(result).toEqual("Hier");
+    }),
+
+    it.only("should work with 2 days ago even if it's less than 48h", () => {
+        const d = new Date();
+        d.setDate(d.getDate() - 2);
+        d.setHours(23, 59, 59);
+
+        const result = formatDateSince(d.getTime() / 1000);
+
+        expect(result).toEqual("2 jours");
     })
 );

--- a/packages/frontend/src/js/app/pages/TownsList/formatDateSince.js
+++ b/packages/frontend/src/js/app/pages/TownsList/formatDateSince.js
@@ -14,6 +14,10 @@ export default function formatDateSince(date) {
         return `${months} mois`;
     }
 
+    if (days === 1) {
+        return `Hier`;
+    }
+
     if (days > 0) {
         return `${days} jours`;
     }

--- a/packages/frontend/src/js/app/pages/TownsList/getSince.js
+++ b/packages/frontend/src/js/app/pages/TownsList/getSince.js
@@ -2,10 +2,11 @@ export default function getSince(ts) {
     const now = new Date();
     const then = new Date(ts * 1000);
 
-    const days = Math.abs(
-        (now.getFullYear() - then.getFullYear()) * 365 +
-            (now.getFullYear() - then.getFullYear()) * (365 / 12) +
-            (now.getDate() - then.getDate())
+    now.setHours(0, 0, 0);
+    then.setHours(0, 0, 0);
+
+    const days = Math.floor(
+        Math.abs(now.getTime() - then.getTime()) / (1000 * 3600 * 24)
     );
 
     const weeks = Math.floor(days / 7);

--- a/packages/frontend/src/js/app/pages/TownsList/getSince.js
+++ b/packages/frontend/src/js/app/pages/TownsList/getSince.js
@@ -2,8 +2,10 @@ export default function getSince(ts) {
     const now = new Date();
     const then = new Date(ts * 1000);
 
-    const days = Math.floor(
-        Math.abs(now.getTime() - then.getTime()) / (1000 * 3600 * 24)
+    const days = Math.abs(
+        (now.getFullYear() - then.getFullYear()) * 365 +
+            (now.getFullYear() - then.getFullYear()) * (365 / 12) +
+            (now.getDate() - then.getDate())
     );
 
     const weeks = Math.floor(days / 7);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/r4KEmsoW/1197-bug-date-dactualisation-des-donn%C3%A9es-de-modification-des-sites-incoh%C3%A9rente-avec-les-dates-de-modification

## 🛠 Description de la PR
On faisait la différence de jours en prenant le timestamp / (1000 * 3600 * 24). Cela ne fonctionnait pas pour deux dates avec des horaires différentes (ie: Dimanche 23h50 et lundi 12h apparaissaient comme le même jour). 

Cette PR corrige la méthode de calcul en resettant l'heure pour les 2 dates avant de faire la diff de jours



