### PR TITLE
#patch (1180) Correction nombre de commentaires + tag covid

### DIFF
--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
@@ -23,6 +23,7 @@
                 <TownDetailsLeftColumn
                     :hasJusticePermission="hasJusticePermission"
                     :town="town"
+                    :nbComments="comments.length"
                     class="leftColumnWidth"
                     v-on:openHistory="openHistory"
                 />

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsLeftColumn.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsLeftColumn.vue
@@ -44,8 +44,8 @@
                     <div class="ml-2">
                         <div>Le journal du site</div>
                         <div>
-                            {{ town.comments.regular.length }} message{{
-                                town.comments.regular.length > 1 ? "s" : ""
+                            {{ nbComments }} message{{
+                                nbComments > 1 ? "s" : ""
                             }}
                         </div>
                     </div>
@@ -71,6 +71,9 @@ export default {
     props: {
         town: {
             type: Object
+        },
+        nbComments: {
+            type: Number
         },
         hasJusticePermission: {
             type: Boolean

--- a/packages/frontend/src/js/app/pages/TownDetails/ui/CommentBlock.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/ui/CommentBlock.vue
@@ -22,6 +22,12 @@
         </div>
         <div class="ml-5">
             <div class="flex flex-wrap">
+                <Tag
+                    v-if="!!comment.covid"
+                    variant="withoutBackground"
+                    :class="['inline-block', 'bg-red', 'text-white']"
+                    >Covid-19</Tag
+                >
                 <CovidTag
                     v-for="tag in covidTags"
                     :key="tag.prop"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/sTlX6oKo/1180-bug-incoh%C3%A9rence-sur-le-nombre-de-messages-affich%C3%A9-dans-la-rubrique-journal-du-site-ajout-de-la-distinction-des-messages-covid-da

## 🛠 Description de la PR
- Correction du nombre de commentaire sur le site
- Ajout d'un tag covid 19 lors d'un commentaire covid

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/5053593/131122906-c2e15898-b72c-4735-88ba-106af558c36d.png)
