### PR TITLE
# patch (1223) Permission mal calculées pour une fiche site rattaché à un arrondissement

### DIFF
--- a/packages/api/db/migrations/001223-01-alter-localized_organizations-add-city_main.js
+++ b/packages/api/db/migrations/001223-01-alter-localized_organizations-add-city_main.js
@@ -1,0 +1,494 @@
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'DROP VIEW shantytown_watchers',
+            {
+                transaction,
+            },
+        )
+            .then(() => queryInterface.sequelize.query('DROP MATERIALIZED VIEW localized_organizations', {
+                transaction,
+            }))
+            .then(() => queryInterface.sequelize.query(
+                `CREATE MATERIALIZED VIEW localized_organizations AS
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'nation' AS location_type,
+                        NULL AS "region_code",
+                        NULL AS "region_name",
+                        NULL AS "departement_code",
+                        NULL AS "departement_name",
+                        NULL AS "epci_code",
+                        NULL AS "epci_name",
+                        NULL AS "city_code",
+                        NULL AS "city_name",
+                        NULL AS "city_main",
+    
+                        46.7755829 AS "latitude",
+                        2.0497727 AS "longitude"
+                    FROM
+                        organizations
+                    WHERE
+                        organizations.fk_region IS NULL
+                        AND
+                        organizations.fk_departement IS NULL
+                        AND
+                        organizations.fk_epci IS NULL
+                        AND
+                        organizations.fk_city IS NULL
+                )
+                UNION
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'region' AS location_type,
+                        regions.code AS "region_code",
+                        regions.name AS "region_name",
+                        NULL AS "departement_code",
+                        NULL AS "departement_name",
+                        NULL AS "epci_code",
+                        NULL AS "epci_name",
+                        NULL AS "city_code",
+                        NULL AS "city_name",
+                        NULL AS "city_main",
+    
+                        NULL AS "latitude",
+                        NULL AS "longitude"
+                    FROM
+                        organizations
+                    LEFT JOIN
+                        regions ON organizations.fk_region = regions.code
+                    WHERE
+                        organizations.fk_region IS NOT NULL
+                )
+                UNION
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'departement' AS location_type,
+                        regions.code AS "region_code",
+                        regions.name AS "region_name",
+                        departements.code AS "departement_code",
+                        departements.name AS "departement_name",
+                        NULL AS "epci_code",
+                        NULL AS "epci_name",
+                        NULL AS "city_code",
+                        NULL AS "city_name",
+                        NULL AS "city_main",
+    
+                        departements.latitude AS "latitude",
+                        departements.longitude AS "longitude"
+                    FROM
+                        organizations
+                    LEFT JOIN
+                        departements ON organizations.fk_departement = departements.code
+                    LEFT JOIN
+                        regions ON departements.fk_region = regions.code
+                    WHERE
+                        organizations.fk_departement IS NOT NULL
+                )
+                UNION
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'epci' AS location_type,
+                        regions.code AS "region_code",
+                        regions.name AS "region_name",
+                        departements.code AS "departement_code",
+                        departements.name AS "departement_name",
+                        epci.code AS "epci_code",
+                        epci.name AS "epci_name",
+                        NULL AS "city_code",
+                        NULL AS "city_name",
+                        NULL AS "city_main",
+    
+                        departements.latitude AS "latitude",
+                        departements.longitude AS "longitude"
+                    FROM
+                        organizations
+                    LEFT JOIN
+                        epci_to_departement ON epci_to_departement.fk_epci = organizations.fk_epci
+                    LEFT JOIN
+                        departements ON epci_to_departement.fk_departement = departements.code
+                    LEFT JOIN
+                        epci ON organizations.fk_epci = epci.code
+                    LEFT JOIN
+                        regions ON departements.fk_region = regions.code
+                    WHERE
+                        organizations.fk_epci IS NOT NULL
+                )
+                UNION
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'city' AS location_type,
+                        regions.code AS "region_code",
+                        regions.name AS "region_name",
+                        departements.code AS "departement_code",
+                        departements.name AS "departement_name",
+                        epci.code AS "epci_code",
+                        epci.name AS "epci_name",
+                        cities.code AS "city_code",
+                        cities.name AS "city_name",
+                        cities.fk_main AS "city_main",
+    
+                        departements.latitude AS "latitude",
+                        departements.longitude AS "longitude"
+                    FROM
+                        organizations
+                    LEFT JOIN
+                        cities ON cities.code = organizations.fk_city
+                    LEFT JOIN
+                        departements ON cities.fk_departement = departements.code
+                    LEFT JOIN
+                        epci ON cities.fk_epci = epci.code
+                    LEFT JOIN
+                        regions ON departements.fk_region = regions.code
+                    WHERE
+                        organizations.fk_city IS NOT NULL
+                )`,
+                {
+                    transaction,
+                },
+            ))
+            .then(() => queryInterface.sequelize.query(
+                `CREATE VIEW shantytown_watchers AS
+                (
+                    (
+                    SELECT
+                        s.shantytown_id AS fk_shantytown,
+                        u.user_id AS fk_user
+                    FROM shantytowns s
+                    LEFT JOIN cities c ON s.fk_city = c.code
+                    LEFT JOIN departements d ON c.fk_departement = d.code
+                    LEFT JOIN localized_organizations lo ON lo.region_code = d.fk_region
+                    LEFT JOIN users u ON u.fk_organization = lo.organization_id
+                    WHERE
+                        lo.active = true
+                        AND
+                        u.fk_status = 'active'
+                        AND
+                        lo.location_type = 'region'
+                        AND
+                        u.fk_role = 'local_admin'
+                    )
+            
+                    UNION
+            
+                    (
+                    SELECT
+                        s.shantytown_id AS fk_shantytown,
+                        u.user_id AS fk_user
+                    FROM shantytowns s
+                    LEFT JOIN cities c ON s.fk_city = c.code
+                    LEFT JOIN localized_organizations lo ON lo.departement_code = c.fk_departement
+                    LEFT JOIN users u ON u.fk_organization = lo.organization_id
+                    WHERE
+                        lo.active = true
+                        AND
+                        u.fk_status = 'active'
+                        AND
+                        u.fk_role = 'local_admin'
+                    )
+            
+                    UNION
+            
+                    (
+                    SELECT
+                        sa.fk_shantytown,
+                        u.user_id AS fk_user
+                    FROM shantytown_actors sa
+                    LEFT JOIN users u ON sa.fk_user = u.user_id
+                    LEFT JOIN organizations o ON u.fk_organization = o.organization_id
+                    WHERE
+                        u.fk_status = 'active'
+                        AND
+                        o.active = TRUE
+                    )
+                )`,
+                {
+                    transaction,
+                },
+            )),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'DROP VIEW shantytown_watchers',
+            {
+                transaction,
+            },
+        )
+            .then(() => queryInterface.sequelize.query('DROP MATERIALIZED VIEW localized_organizations', {
+                transaction,
+            }))
+            .then(() => queryInterface.sequelize.query(
+                `CREATE MATERIALIZED VIEW localized_organizations AS
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'nation' AS location_type,
+                        NULL AS "region_code",
+                        NULL AS "region_name",
+                        NULL AS "departement_code",
+                        NULL AS "departement_name",
+                        NULL AS "epci_code",
+                        NULL AS "epci_name",
+                        NULL AS "city_code",
+                        NULL AS "city_name",
+    
+                        46.7755829 AS "latitude",
+                        2.0497727 AS "longitude"
+                    FROM
+                        organizations
+                    WHERE
+                        organizations.fk_region IS NULL
+                        AND
+                        organizations.fk_departement IS NULL
+                        AND
+                        organizations.fk_epci IS NULL
+                        AND
+                        organizations.fk_city IS NULL
+                )
+                UNION
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'region' AS location_type,
+                        regions.code AS "region_code",
+                        regions.name AS "region_name",
+                        NULL AS "departement_code",
+                        NULL AS "departement_name",
+                        NULL AS "epci_code",
+                        NULL AS "epci_name",
+                        NULL AS "city_code",
+                        NULL AS "city_name",
+    
+                        NULL AS "latitude",
+                        NULL AS "longitude"
+                    FROM
+                        organizations
+                    LEFT JOIN
+                        regions ON organizations.fk_region = regions.code
+                    WHERE
+                        organizations.fk_region IS NOT NULL
+                )
+                UNION
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'departement' AS location_type,
+                        regions.code AS "region_code",
+                        regions.name AS "region_name",
+                        departements.code AS "departement_code",
+                        departements.name AS "departement_name",
+                        NULL AS "epci_code",
+                        NULL AS "epci_name",
+                        NULL AS "city_code",
+                        NULL AS "city_name",
+    
+                        departements.latitude AS "latitude",
+                        departements.longitude AS "longitude"
+                    FROM
+                        organizations
+                    LEFT JOIN
+                        departements ON organizations.fk_departement = departements.code
+                    LEFT JOIN
+                        regions ON departements.fk_region = regions.code
+                    WHERE
+                        organizations.fk_departement IS NOT NULL
+                )
+                UNION
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'epci' AS location_type,
+                        regions.code AS "region_code",
+                        regions.name AS "region_name",
+                        departements.code AS "departement_code",
+                        departements.name AS "departement_name",
+                        epci.code AS "epci_code",
+                        epci.name AS "epci_name",
+                        NULL AS "city_code",
+                        NULL AS "city_name",
+    
+                        departements.latitude AS "latitude",
+                        departements.longitude AS "longitude"
+                    FROM
+                        organizations
+                    LEFT JOIN
+                        epci_to_departement ON epci_to_departement.fk_epci = organizations.fk_epci
+                    LEFT JOIN
+                        departements ON epci_to_departement.fk_departement = departements.code
+                    LEFT JOIN
+                        epci ON organizations.fk_epci = epci.code
+                    LEFT JOIN
+                        regions ON departements.fk_region = regions.code
+                    WHERE
+                        organizations.fk_epci IS NOT NULL
+                )
+                UNION
+                (
+                    SELECT
+                        organizations.organization_id AS organization_id,
+                        organizations.name AS name,
+                        organizations.abbreviation AS abbreviation,
+                        organizations.active AS active,
+                        organizations.fk_type AS fk_type,
+                        organizations.created_at AS created_at,
+                        organizations.updated_at AS updated_at,
+    
+                        'city' AS location_type,
+                        regions.code AS "region_code",
+                        regions.name AS "region_name",
+                        departements.code AS "departement_code",
+                        departements.name AS "departement_name",
+                        epci.code AS "epci_code",
+                        epci.name AS "epci_name",
+                        cities.code AS "city_code",
+                        cities.name AS "city_name",
+    
+                        departements.latitude AS "latitude",
+                        departements.longitude AS "longitude"
+                    FROM
+                        organizations
+                    LEFT JOIN
+                        cities ON cities.code = organizations.fk_city
+                    LEFT JOIN
+                        departements ON cities.fk_departement = departements.code
+                    LEFT JOIN
+                        epci ON cities.fk_epci = epci.code
+                    LEFT JOIN
+                        regions ON departements.fk_region = regions.code
+                    WHERE
+                        organizations.fk_city IS NOT NULL
+                )`,
+                {
+                    transaction,
+                },
+            ))
+            .then(() => queryInterface.sequelize.query(
+                `CREATE VIEW shantytown_watchers AS
+                (
+                    (
+                    SELECT
+                        s.shantytown_id AS fk_shantytown,
+                        u.user_id AS fk_user
+                    FROM shantytowns s
+                    LEFT JOIN cities c ON s.fk_city = c.code
+                    LEFT JOIN departements d ON c.fk_departement = d.code
+                    LEFT JOIN localized_organizations lo ON lo.region_code = d.fk_region
+                    LEFT JOIN users u ON u.fk_organization = lo.organization_id
+                    WHERE
+                        lo.active = true
+                        AND
+                        u.fk_status = 'active'
+                        AND
+                        lo.location_type = 'region'
+                        AND
+                        u.fk_role = 'local_admin'
+                    )
+            
+                    UNION
+            
+                    (
+                    SELECT
+                        s.shantytown_id AS fk_shantytown,
+                        u.user_id AS fk_user
+                    FROM shantytowns s
+                    LEFT JOIN cities c ON s.fk_city = c.code
+                    LEFT JOIN localized_organizations lo ON lo.departement_code = c.fk_departement
+                    LEFT JOIN users u ON u.fk_organization = lo.organization_id
+                    WHERE
+                        lo.active = true
+                        AND
+                        u.fk_status = 'active'
+                        AND
+                        u.fk_role = 'local_admin'
+                    )
+            
+                    UNION
+            
+                    (
+                    SELECT
+                        sa.fk_shantytown,
+                        u.user_id AS fk_user
+                    FROM shantytown_actors sa
+                    LEFT JOIN users u ON sa.fk_user = u.user_id
+                    LEFT JOIN organizations o ON u.fk_organization = o.organization_id
+                    WHERE
+                        u.fk_status = 'active'
+                        AND
+                        o.active = TRUE
+                    )
+                )`,
+                {
+                    transaction,
+                },
+            )),
+    ),
+};

--- a/packages/api/server/models/userModel.js
+++ b/packages/api/server/models/userModel.js
@@ -916,7 +916,17 @@ module.exports = () => {
                     lua.used_at AS "date",
                     users.first_name,
                     users.last_name,
-                    organizations.organization_id
+                    organizations.organization_id,
+                    organizations.location_type,
+                    organizations.region_code,
+                    organizations.region_name,
+                    organizations.departement_code,
+                    organizations.departement_name,
+                    organizations.epci_code,
+                    organizations.epci_name,
+                    organizations.city_code,
+                    organizations.city_name,
+                    organizations.city_main
                 FROM last_user_accesses lua
                 LEFT JOIN users ON lua.fk_user = users.user_id
                 LEFT JOIN localized_organizations organizations ON users.fk_organization = organizations.organization_id
@@ -937,6 +947,26 @@ module.exports = () => {
                 user: {
                     name: model.formatName(activity),
                     organization: activity.organization_id,
+                    location: {
+                        type: activity.location_type,
+                        region: activity.region_code !== null ? {
+                            code: activity.region_code,
+                            name: activity.region_name,
+                        } : null,
+                        departement: activity.departement_code !== null ? {
+                            code: activity.departement_code,
+                            name: activity.departement_name,
+                        } : null,
+                        epci: activity.epci_code !== null ? {
+                            code: activity.epci_code,
+                            name: activity.epci_name,
+                        } : null,
+                        city: activity.city_code !== null ? {
+                            code: activity.city_code,
+                            name: activity.city_name,
+                            main: activity.city_main,
+                        } : null,
+                    },
                 },
             }));
     };

--- a/packages/api/server/models/userModel.js
+++ b/packages/api/server/models/userModel.js
@@ -89,6 +89,7 @@ function serializeUser(user, latestCharte, filters, permissionMap) {
                 city: user.city_code !== null ? {
                     code: user.city_code,
                     name: user.city_name,
+                    main: user.city_main,
                 } : null,
             },
         },
@@ -243,6 +244,7 @@ module.exports = () => {
                 organizations.epci_name,
                 organizations.city_code,
                 organizations.city_name,
+                organizations.city_main,
                 organizations.latitude,
                 organizations.longitude,
                 organization_types.organization_type_id,
@@ -647,6 +649,7 @@ module.exports = () => {
                     organizations.epci_name,
                     organizations.city_code,
                     organizations.city_name,
+                    organizations.city_main,
                     roles_regular.name AS role,
                     users.user_id AS "user_id",
                     users.fk_role AS "user_role",
@@ -699,6 +702,7 @@ module.exports = () => {
                             city: user.city_code !== null ? {
                                 code: user.city_code,
                                 name: user.city_name,
+                                main: user.city_main,
                             } : null,
                         },
                         type: {

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -124,16 +124,17 @@ export default {
                     ? permission.geographic_level
                     : this.user.organization.location.type;
 
+            const userLocation = this.user.organization.location[level];
             if (level === "nation") {
                 return true;
-            } else if (this.user.organization.location[level] === null) {
+            } else if (userLocation === null) {
                 return false;
             }
 
-            return (
-                this.town[level].code ===
-                this.user.organization.location[level].code
-            );
+            const townCode = this.town[level].main || this.town[level].code;
+            const userCode = userLocation.main || userLocation.code;
+
+            return townCode === userCode;
         },
         // Force scroll even if hash is already present in url
         scrollFix(to) {

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -532,7 +532,22 @@ export default {
 
             return this.activities.filter(item => {
                 const { code, type } = this.filters.location.data;
-                return item.shantytown[type].code === code;
+
+                // activity related to a shantytown
+                if (item.shantytown) {
+                    return item.shantytown[type].code === code;
+                }
+
+                // activity related to a user
+                if (item.user) {
+                    const location = item.user.location[type];
+                    const locationCode = location
+                        ? location.main || location.code
+                        : null;
+                    return locationCode === code;
+                }
+
+                return false;
             });
         },
         lastActivities() {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/S7STZflj/1223

## 🛠 Description de la PR
Je corrige deux bugs :
- le bug initial : l'arrondissement n'était pas pris en compte dans le calcul des permissions
- un autre bug trouvé au passage : les nouvelles activités "nouvel utilisateur" provoquent un bug dans la recherche sur la liste des sites, car ces activités n'ont pas de "shantytown" rattaché

## 🚨 Notes pour la mise en production
Migrations à faire tourner