### PR TITLE
#patch (1225) Fix filtering of activities on history

### DIFF
--- a/packages/frontend/src/js/app/pages/History/History.vue
+++ b/packages/frontend/src/js/app/pages/History/History.vue
@@ -188,10 +188,7 @@ export default {
             }
 
             // on remplit la barre de recherche
-            if (
-                this.locationType === "nation" ||
-                this.$route.path === this.defaultPath
-            ) {
+            if (this.locationType === "nation") {
                 store.commit("setActivityLocationFilter", null);
             } else {
                 store.commit(

--- a/packages/frontend/src/js/app/store/modules/activities.js
+++ b/packages/frontend/src/js/app/store/modules/activities.js
@@ -91,9 +91,25 @@ export default {
                 // location filter
                 if (filters.location !== null) {
                     const { code, type } = filters.location.data;
-                    if (item.shantytown[type].code !== code) {
-                        return false;
+                    if (item.shantytown) {
+                        const shantytownLocation = item.shantytown[type];
+                        const shantytownCode =
+                            shantytownLocation.main || shantytownLocation.code;
+
+                        return shantytownCode === code;
                     }
+
+                    if (item.user) {
+                        const userLocation = item.user.location[type];
+
+                        const userCode = userLocation
+                            ? userLocation.main || userLocation.code
+                            : null;
+
+                        return userCode === code;
+                    }
+
+                    return false;
                 }
 
                 return true;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/INdEKCj7/1225

## 🛠 Description de la PR
Quand on utilisait la barre de recherche, les événements "Nouvel utilisateur" n'étaient pas filtrés.
J'ai également fait un changement (subtil), qui consiste à remplir la barre de recherche avec la zone géographique par défaut (avant on la laissait vide), ce qui corrige un bug où un getter (`activitiesFilteredItems`) n'était pas mis à jour dans certains cas.