### PR TITLE
#patch (831) Barrer les cartes des sites fermés

### DIFF
--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -2,7 +2,8 @@
     <div
         :class="[
             'rounded-sm cursor-pointer border border-cardBorder preventPrintBreak',
-            isHover ? 'bg-blue200 border-transparent' : ''
+            isHover ? 'bg-blue200 border-transparent' : '',
+            shantytown.closedAt ? 'closedShantytown' : ''
         ]"
         @mouseenter="isHover = true"
         @mouseleave="isHover = false"
@@ -368,6 +369,27 @@ export default {
 }
 .customAlign {
     height: 30px;
+}
+
+.closedShantytown {
+    position: relative;
+    overflow: hidden;
+}
+
+.closedShantytown:before {
+    position: absolute;
+    content: "";
+    background: linear-gradient(
+        to left bottom,
+        transparent 50%,
+        currentColor 49.8%,
+        currentColor 50.2%,
+        transparent 50%
+    );
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
 }
 
 .preventPrintBreak {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/OdoZZamI/831-barrer-les-cartes-des-sites-ferm%C3%A9s-pour-mieux-distinguer-les-sites-existants-et-les-sites-ferm%C3%A9s

## 🛠 Description de la PR
Toutes les cartes ne font pas la meme hauteur, c'était donc un peu plus tricky qu'un simple transform: rotate(xDeg). En cherchant, j'ai trouvé qu'on pouvait utiliser les background-gradients pour ce genre de problèmes ! 

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/5053593/133113896-036f0a72-7bce-4075-870a-3f8a8f9dd86e.png)

![image](https://user-images.githubusercontent.com/5053593/133113939-5d1b6bf8-8e9c-436e-b435-e8f9b28ddf64.png)
