### PR TITLE
#patch (1227) Fix filtering on history page

### DIFF
--- a/packages/frontend/src/js/app/store/modules/activities.js
+++ b/packages/frontend/src/js/app/store/modules/activities.js
@@ -91,8 +91,16 @@ export default {
                 // location filter
                 if (filters.location !== null) {
                     const { code, type } = filters.location.data;
-                    if (item.shantytown[type].code !== code) {
-                        return false;
+                    if (item.shantytown) {
+                        return item.shantytown[type].code === code;
+                    }
+
+                    if (item.user) {
+                        const location = item.user.location[type];
+                        const locationCode = location
+                            ? location.main || location.code
+                            : null;
+                        return locationCode === code;
                     }
                 }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/3t0INqQP/1227

## 🛠 Description de la PR
Les activités "nouvel utilisateur" cassaient le filtering des activités.