### PR TITLE
#patch (1214) Fiche site mettre la carte en vision satellite par défaut

### DIFF
--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -263,44 +263,15 @@ export default {
              * @type {Object}
              */
             numberOfShantytownsBy: {
-                regions: {}, // sera rempli avec un objet du type : { "01": 0, "02": 0, ..., "11": 0 }
-                departements: {}, // sera rempli avec un objet du type : { "01": 0, "02": 0, ..., "92": 0 }
-                cities: {} /* sera rempli avec un objet du type :
-                                                                    {
-                                                                        "01":
-                                                                            {
-                                                                                sites = 0,
-                                                                                code = ,
-                                                                                name = ,
-                                                                                latitude = ,
-                                                                                longitude =
-                                                                            },
-                                                                        "02":
-                                                                            {
-                                                                                sites = 0,
-                                                                                code = ,
-                                                                                name = ,
-                                                                                latitude = ,
-                                                                                longitude =
-                                                                            },
-                                                                        ...,
-                                                                        "92":
-                                                                            {
-                                                                                sites = 0,
-                                                                                code = ,
-                                                                                name = ,
-                                                                                latitude = ,
-                                                                                longitude =
-                                                                            }
-                                                                    } */
+                regions: {},
+                departements: {},
+                cities: {}
             },
 
             /**
              *
              */
-            layersControl: null,
-
-            layerToDisplay: this.layerName
+            layersControl: null
         };
     },
 
@@ -599,7 +570,7 @@ export default {
          */
         createMap() {
             this.map = L.map("map", {
-                layers: this.mapLayers[this.layerToDisplay], // fond de carte à afficher
+                layers: this.mapLayers[this.layerName], // fond de carte à afficher
                 scrollWheelZoom: false // interdire le zoom via la molette de la souris
             });
 

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -120,6 +120,12 @@ export default {
             type: Boolean,
             default: true,
             required: false
+        },
+
+        layerName: {
+            type: String,
+            required: false,
+            default: "Dessin"
         }
     },
 
@@ -292,7 +298,9 @@ export default {
             /**
              *
              */
-            layersControl: null
+            layersControl: null,
+
+            layerToDisplay: this.layerName
         };
     },
 
@@ -591,7 +599,7 @@ export default {
          */
         createMap() {
             this.map = L.map("map", {
-                layers: this.mapLayers.Dessin, // fond de carte par défaut
+                layers: this.mapLayers[this.layerToDisplay], // fond de carte à afficher
                 scrollWheelZoom: false // interdire le zoom via la molette de la souris
             });
 

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
@@ -119,6 +119,7 @@
                             :towns="[town]"
                             :default-view="center"
                             :load-territory-layers="false"
+                            layer-name="Satellite"
                         ></Map>
                     </div>
                 </div>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/UGSFVd5w

## 🛠 Description de la PR
- Ajout d'une propriété **layerName** au composant **Map**
- Passage de la valeur "Satellite" à la propriété **layer-name** du composant **map* instancié dans **TownDetailsPanelCharacteristics.vue**

## 📸 Captures d'écran
- Non

## 🚨 Notes pour la mise en production
- Ràs