### PR TITLE
#patch (1072) Ajout d'une colonne code INSEE dans l'export des sites

### DIFF
--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -459,19 +459,19 @@ module.exports = (models) => {
                     align: 'left',
                     width: COLUMN_WIDTHS.LARGE,
                 },
-                citycode: {
-                    title: 'Code INSEE',
-                    data: ({ city }) => city.code,
-                    bold: true,
-                    align: 'left',
-                    width: COLUMN_WIDTHS.SMALL,
-                },
                 city: {
                     title: 'Commune',
                     data: ({ city }) => city.name,
                     bold: true,
                     align: 'left',
                     width: COLUMN_WIDTHS.MEDIUM,
+                },
+                citycode: {
+                    title: 'Code INSEE',
+                    data: ({ city }) => city.code,
+                    bold: true,
+                    align: 'left',
+                    width: COLUMN_WIDTHS.SMALL,
                 },
                 address: {
                     title: 'Adresse',
@@ -1128,8 +1128,8 @@ module.exports = (models) => {
                 title: 'Localisation',
                 properties: [
                     properties.departement,
-                    properties.citycode,
                     properties.city,
+                    properties.citycode,
                     properties.address,
                     properties.name,
                 ],

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -459,6 +459,13 @@ module.exports = (models) => {
                     align: 'left',
                     width: COLUMN_WIDTHS.LARGE,
                 },
+                citycode: {
+                    title: 'Code INSEE',
+                    data: ({ city }) => city.code,
+                    bold: true,
+                    align: 'left',
+                    width: COLUMN_WIDTHS.SMALL,
+                },
                 city: {
                     title: 'Commune',
                     data: ({ city }) => city.name,
@@ -1121,6 +1128,7 @@ module.exports = (models) => {
                 title: 'Localisation',
                 properties: [
                     properties.departement,
+                    properties.citycode,
                     properties.city,
                     properties.address,
                     properties.name,

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -487,7 +487,7 @@ module.exports = (models) => {
                 },
                 coordinates: {
                     title: 'Coordonnées GPS',
-                    data: ({ latitude, longitude }) => `${latitude.toFixed(4)},${longitude.toFixed(4)}`,
+                    data: ({ latitude, longitude }) => `${latitude},${longitude}`,
                     width: COLUMN_WIDTHS.SMALL,
                 },
                 name: {

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -487,13 +487,13 @@ module.exports = (models) => {
                 },
                 coordinates: {
                     title: 'Coordonnées GPS',
-                    data: ({ latitude, longitude }) => `${latitude},${longitude}`,
+                    data: ({ latitude, longitude }) => `${latitude.toFixed(4)},${longitude.toFixed(4)}`,
                     width: COLUMN_WIDTHS.SMALL,
                 },
                 name: {
                     title: 'Appellation du site',
                     data: ({ name }) => name,
-                    width: COLUMN_WIDTHS.SMALL,
+                    width: COLUMN_WIDTHS.LARGE,
                 },
                 fieldType: {
                     title: 'Type de site',


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/7r5mXhgc

## 🛠 Description de la PR
- Ajout d'une propriété **citycode** placée juste après le nom de la ville dans les colonnes du tableau d'export.

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/133402795-81e35376-f792-45b2-beae-5125c12d84a8.png)

## 🚨 Notes pour la mise en production
- Ràs