### PR TITLE
#minor (1229) - Supprime la colonne default_export de la table users

### DIFF
--- a/packages/api/db/migrations/001229-01-remove-default_export_from_users.js
+++ b/packages/api/db/migrations/001229-01-remove-default_export_from_users.js
@@ -1,0 +1,12 @@
+module.exports = {
+    up: queryInterface => queryInterface.removeColumn('users', 'default_export'),
+
+    down: (queryInterface, Sequelize) => queryInterface.addColumn(
+        'users',
+        'default_export',
+        {
+            type: Sequelize.TEXT,
+            allowNull: true,
+        },
+    ),
+};


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/jSIL6W7o

## 🛠 Description de la PR
- Supprime la colonne **default_export** de la table **users**

## 🚨 Notes pour la mise en production
- Exécuter la migration 001229-01-remove-default_export_from_users.js