### PR TITLE
#patch (1232, 1237) Éviter les doublons lors de la création de site + Fiche site

### DIFF
--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -1515,5 +1515,10 @@ module.exports = (models) => {
         models,
     );
 
+    // eslint-disable-next-line global-require
+    methods.findNearbyTowns = require('./townController/findNearbyTowns')(
+        models,
+    );
+
     return methods;
 };

--- a/packages/api/server/controllers/townController/findNearbyTowns.js
+++ b/packages/api/server/controllers/townController/findNearbyTowns.js
@@ -1,0 +1,14 @@
+
+module.exports = models => async (req, res, next) => {
+    try {
+        const { latitude, longitude, distance = 1 } = req.query;
+        const towns = await models.shantytown.findNearby(latitude, longitude, distance);
+        return res.status(200).send({ towns });
+    } catch (error) {
+        res.status(500).send({
+            error,
+            user_message: 'Une erreur est survenue lors de la lecture en base de données',
+        });
+        return next(error);
+    }
+};

--- a/packages/api/server/controllers/townController/findNearbyTowns.js
+++ b/packages/api/server/controllers/townController/findNearbyTowns.js
@@ -1,7 +1,7 @@
 
 module.exports = models => async (req, res, next) => {
     try {
-        const { latitude, longitude, distance = 1 } = req.query;
+        const { latitude, longitude, distance = 0.5 } = req.query;
         const towns = await models.shantytown.findNearby(req.user, latitude, longitude, distance);
         return res.status(200).send({ towns });
     } catch (error) {

--- a/packages/api/server/controllers/townController/findNearbyTowns.js
+++ b/packages/api/server/controllers/townController/findNearbyTowns.js
@@ -1,7 +1,8 @@
 
 module.exports = models => async (req, res, next) => {
     try {
-        const { latitude, longitude, distance = 0.5 } = req.query;
+        const { latitude, longitude } = req.query;
+        const distance = 0.5;
         const towns = await models.shantytown.findNearby(req.user, latitude, longitude, distance);
         return res.status(200).send({ towns });
     } catch (error) {

--- a/packages/api/server/controllers/townController/findNearbyTowns.js
+++ b/packages/api/server/controllers/townController/findNearbyTowns.js
@@ -2,7 +2,7 @@
 module.exports = models => async (req, res, next) => {
     try {
         const { latitude, longitude, distance = 1 } = req.query;
-        const towns = await models.shantytown.findNearby(latitude, longitude, distance);
+        const towns = await models.shantytown.findNearby(req.user, latitude, longitude, distance);
         return res.status(200).send({ towns });
     } catch (error) {
         res.status(500).send({

--- a/packages/api/server/loaders/routesLoader.js
+++ b/packages/api/server/loaders/routesLoader.js
@@ -242,6 +242,7 @@ module.exports = (app) => {
 
     app.get(
         '/towns/findNearby',
+        validators.findNearbyTowns,
         middlewares.auth.authenticate,
         (...args) => middlewares.auth.checkPermissions(['shantytown.list'], ...args),
         middlewares.charte.check,

--- a/packages/api/server/loaders/routesLoader.js
+++ b/packages/api/server/loaders/routesLoader.js
@@ -240,6 +240,15 @@ module.exports = (app) => {
         controllers.town.getRelations,
     );
 
+    app.get(
+        '/towns/findNearby',
+        middlewares.auth.authenticate,
+        (...args) => middlewares.auth.checkPermissions(['shantytown.list'], ...args),
+        middlewares.charte.check,
+        middlewares.appVersion.sync,
+        controllers.town.findNearbyTowns,
+    );
+
     // plans
     app.get(
         '/plans',

--- a/packages/api/server/middlewares/validators/findNearbyTowns.js
+++ b/packages/api/server/middlewares/validators/findNearbyTowns.js
@@ -1,0 +1,13 @@
+/* eslint-disable newline-per-chained-call */
+const { query } = require('express-validator');
+
+module.exports = [
+    query('longitude')
+        .isFloat()
+        .notEmpty().withMessage('Le paramètre longitude est obligatoire'),
+
+    query('latitude')
+        .isFloat()
+        .notEmpty().withMessage('Le paramètre latitude est obligatoire'),
+
+];

--- a/packages/api/server/middlewares/validators/index.js
+++ b/packages/api/server/middlewares/validators/index.js
@@ -12,6 +12,7 @@ const inviteShantytownActor = require('./shantytownActors/inviteShantytownActor'
 const invite = require('./invite');
 const createShantytownComment = require('./shantytownComment/create');
 const activityList = require('./activity/list');
+const findNearbyTowns = require('./findNearbyTowns');
 
 module.exports = {
     closeTown,
@@ -20,6 +21,7 @@ module.exports = {
     editTown,
     createUser,
     editUser,
+    findNearbyTowns,
     shantytownActors: {
         addShantytownActor,
         updateShantytownActor,

--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -1477,5 +1477,30 @@ module.exports = (database) => {
         }
     };
 
+    methods.findNearby = async (latitude, longitude, distance) => {
+        const distanceCalc = '(6371 * 2 * ASIN(SQRT( POWER(SIN(( :latitude - shantytowns.latitude) *  pi()/180 / 2), 2) +COS( :latitude * pi()/180) * COS(shantytowns.latitude * pi()/180) * POWER(SIN(( :longitude - shantytowns.longitude) * pi()/180 / 2), 2) )))';
+
+        return database.query(`
+        SELECT 
+            shantytowns.shantytown_id,
+            shantytowns.name,
+            shantytowns.status,
+            shantytowns.declared_at,
+            shantytowns.built_at,
+            shantytowns.closed_at,
+            shantytowns.latitude,
+            shantytowns.longitude,
+            shantytowns.address,
+            shantytowns.address_details,
+            ${distanceCalc} as distance
+        FROM shantytowns
+        WHERE ${distanceCalc} < :distanceRadius
+        `,
+        {
+            type: database.QueryTypes.SELECT,
+            replacements: { latitude, longitude, distanceRadius: distance },
+        });
+    };
+
     return methods;
 };

--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -1506,18 +1506,15 @@ module.exports = (database) => {
 
         const distanceCalc = '(6371 * 2 * ASIN(SQRT( POWER(SIN(( :latitude - shantytowns.latitude) *  pi()/180 / 2), 2) +COS( :latitude * pi()/180) * COS(shantytowns.latitude * pi()/180) * POWER(SIN(( :longitude - shantytowns.longitude) * pi()/180 / 2), 2) )))';
 
-        return database.query(`
+        const result = await database.query(`
         SELECT 
             shantytowns.shantytown_id,
             shantytowns.name,
-            shantytowns.status,
-            shantytowns.declared_at,
-            shantytowns.built_at,
             shantytowns.closed_at,
             shantytowns.latitude,
             shantytowns.longitude,
             shantytowns.address,
-            shantytowns.address_details,
+            shantytowns.access_to_water,
             ${distanceCalc} as distance,
             (SELECT regexp_matches(shantytowns.address, '^(.+) [0-9]+ [^,]+,? [0-9]+,? [^, ]+(,.+)?$'))[1] as address_simple
         FROM shantytowns
@@ -1537,6 +1534,18 @@ module.exports = (database) => {
                 ...replacements, latitude, longitude, distanceRadius: distance,
             },
         });
+
+        return result.map(r => ({
+            id: r.shantytown_id,
+            name: r.name,
+            closedAt: r.closed_at !== null ? (r.closed_at.getTime() / 1000) : null,
+            latitude: r.latitude,
+            longitude: r.longitude,
+            address: r.address,
+            addressSimple: r.address_simple,
+            accessToWater: r.access_to_water,
+            distance: r.distance,
+        }));
     };
 
     return methods;

--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -1492,7 +1492,8 @@ module.exports = (database) => {
             shantytowns.longitude,
             shantytowns.address,
             shantytowns.address_details,
-            ${distanceCalc} as distance
+            ${distanceCalc} as distance,
+            (SELECT regexp_matches(shantytowns.address, '^(.+) [0-9]+ [^,]+,? [0-9]+,? [^, ]+(,.+)?$'))[1] as address_simple
         FROM shantytowns
         WHERE ${distanceCalc} < :distanceRadius
         `,

--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -718,15 +718,14 @@ module.exports = (database) => {
     }
 
     /**
-     * Fetches a list of shantytowns from the database
+     * Helper to add filters to restrict access to shantytowns based on user's location
      *
      * @returns {Array.<Object>}
      */
-    async function query(where = [], order = ['departements.code ASC', 'cities.name ASC'], user, feature, includeChangelog = false) {
-        const replacements = {};
-
+    function updateWhereClauseWithUserLocation(user, feature, where = []) {
         const featureLevel = user.permissions.shantytown[feature].geographic_level;
         const userLevel = user.organization.location.type;
+
         if (featureLevel !== 'nation' && (featureLevel !== 'local' || userLevel !== 'nation')) {
             const level = featureLevel === 'local' ? userLevel : featureLevel;
             if (user.organization.location[level] === null) {
@@ -749,14 +748,35 @@ module.exports = (database) => {
             }
         }
 
-        const whereClause = where.map((clauses, index) => {
+        return where;
+    }
+
+    /**
+     * Stringify a list of where clauses
+     *
+     * @returns String
+     */
+    function stringifyWhereClause(where, replacements) {
+        return where.map((clauses, index) => {
             const clauseGroup = Object.keys(clauses).map((column) => {
+                // eslint-disable-next-line no-param-reassign
                 replacements[`${column}${index}`] = clauses[column].value || clauses[column];
                 return `${clauses[column].query || `shantytowns.${column}`} ${clauses[column].not ? 'NOT ' : ''}IN (:${column}${index})`;
             }).join(' OR ');
 
             return `(${clauseGroup})`;
         }).join(' AND ');
+    }
+
+    /**
+     * Fetches a list of shantytowns from the database
+     *
+     * @returns {Array.<Object>}
+     */
+    async function query(where = [], order = ['departements.code ASC', 'cities.name ASC'], user, feature, includeChangelog = false) {
+        const replacements = {};
+        updateWhereClauseWithUserLocation(user, feature, where);
+        const whereClause = stringifyWhereClause(where, replacements);
 
         const towns = await database.query(
             getBaseSql(
@@ -1477,7 +1497,13 @@ module.exports = (database) => {
         }
     };
 
-    methods.findNearby = async (latitude, longitude, distance) => {
+
+    methods.findNearby = async (user, latitude, longitude, distance) => {
+        const replacements = {};
+        const locationWhere = [];
+        updateWhereClauseWithUserLocation(user, 'list', locationWhere);
+        const locationWhereClause = stringifyWhereClause(locationWhere, replacements);
+
         const distanceCalc = '(6371 * 2 * ASIN(SQRT( POWER(SIN(( :latitude - shantytowns.latitude) *  pi()/180 / 2), 2) +COS( :latitude * pi()/180) * COS(shantytowns.latitude * pi()/180) * POWER(SIN(( :longitude - shantytowns.longitude) * pi()/180 / 2), 2) )))';
 
         return database.query(`
@@ -1495,11 +1521,21 @@ module.exports = (database) => {
             ${distanceCalc} as distance,
             (SELECT regexp_matches(shantytowns.address, '^(.+) [0-9]+ [^,]+,? [0-9]+,? [^, ]+(,.+)?$'))[1] as address_simple
         FROM shantytowns
-        WHERE ${distanceCalc} < :distanceRadius
+        LEFT JOIN cities on shantytowns.fk_city = cities.code
+        LEFT JOIN epci on cities.fk_epci = epci.code
+        LEFT JOIN departements on cities.fk_departement = departements.code
+        LEFT JOIN regions on departements.fk_region = regions.code
+        WHERE 
+            ${distanceCalc} < :distanceRadius
+            AND closed_at is NULL
+            ${locationWhereClause ? `AND ${locationWhereClause}` : ''}
+        ORDER BY distance ASC
         `,
         {
             type: database.QueryTypes.SELECT,
-            replacements: { latitude, longitude, distanceRadius: distance },
+            replacements: {
+                ...replacements, latitude, longitude, distanceRadius: distance,
+            },
         });
     };
 

--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -1500,8 +1500,7 @@ module.exports = (database) => {
 
     methods.findNearby = async (user, latitude, longitude, distance) => {
         const replacements = {};
-        const locationWhere = [];
-        updateWhereClauseWithUserLocation(user, 'list', locationWhere);
+        const locationWhere = updateWhereClauseWithUserLocation(user, 'list');
         const locationWhereClause = stringifyWhereClause(locationWhere, replacements);
 
         const distanceCalc = '(6371 * 2 * ASIN(SQRT( POWER(SIN(( :latitude - shantytowns.latitude) *  pi()/180 / 2), 2) +COS( :latitude * pi()/180) * COS(shantytowns.latitude * pi()/180) * POWER(SIN(( :longitude - shantytowns.longitude) * pi()/180 / 2), 2) )))';
@@ -1535,17 +1534,21 @@ module.exports = (database) => {
             },
         });
 
-        return result.map(r => ({
-            id: r.shantytown_id,
-            name: r.name,
-            closedAt: r.closed_at !== null ? (r.closed_at.getTime() / 1000) : null,
-            latitude: r.latitude,
-            longitude: r.longitude,
-            address: r.address,
-            addressSimple: r.address_simple,
-            accessToWater: r.access_to_water,
-            distance: r.distance,
-        }));
+        return result.map((r) => {
+            const town = {
+                id: r.shantytown_id,
+                name: r.name,
+                closedAt: r.closed_at !== null ? (r.closed_at.getTime() / 1000) : null,
+                latitude: r.latitude,
+                longitude: r.longitude,
+                address: r.address,
+                addressSimple: r.address_simple,
+                accessToWater: r.access_to_water,
+                distance: r.distance,
+            };
+
+            return { ...town, usename: getUsenameOf(town) };
+        });
     };
 
     return methods;

--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
@@ -30,6 +30,7 @@
                         >
                             {{ town.address_simple }}
                             <span v-if="town.name">« {{ town.name }} »</span>
+                            <span> ({{ town.distance.toFixed(2) }}km)</span>
                         </router-link>
                     </li>
                 </ul>

--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
@@ -21,14 +21,14 @@
                 >
                 <ul class="list-disc ml-4">
                     <li
-                        :key="town.shantytown_id"
+                        :key="town.id"
                         v-for="town in nearbyShantytowns.slice(0, 5)"
                     >
                         <router-link
                             class="link"
                             :to="`/site/${town.shantytown_id}`"
                         >
-                            {{ town.address_simple }}
+                            {{ town.addressSimple || town.address }}
                             <span v-if="town.name">« {{ town.name }} »</span>
                             <span> ({{ town.distance.toFixed(2) }}km)</span>
                         </router-link>
@@ -88,9 +88,8 @@ export default {
             try {
                 const { towns } = await findNearby(latitude, longitude);
                 this.nearbyShantytowns = towns;
-            } catch (err) {
-                console.log(err);
-            }
+                // eslint-disable-next-line no-empty
+            } catch (err) {}
         }
     }
 };

--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
@@ -12,7 +12,7 @@
                     >1 site enregistré</span
                 >
                 <span v-else
-                    >{{ nearbyShantytowns.length }} site sont enregistrés</span
+                    >{{ nearbyShantytowns.length }} sites sont enregistrés</span
                 >
                 <span>
                     dans un rayon de 500 mètres autour de cette adresse.
@@ -22,7 +22,7 @@
                 <ul class="list-disc ml-4">
                     <li
                         :key="town.shantytown_id"
-                        v-for="town in nearbyShantytowns"
+                        v-for="town in nearbyShantytowns.slice(0, 5)"
                     >
                         <router-link
                             class="link"

--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
@@ -28,7 +28,7 @@
                             class="link"
                             :to="`/site/${town.shantytown_id}`"
                         >
-                            {{town.address_simple}}
+                            {{ town.address_simple }}
                             <span v-if="town.name">« {{ town.name }} »</span>
                         </router-link>
                     </li>

--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelLocation.vue
@@ -28,8 +28,7 @@
                             class="link"
                             :to="`/site/${town.shantytown_id}`"
                         >
-                            {{ town.addressSimple || town.address }}
-                            <span v-if="town.name">« {{ town.name }} »</span>
+                            {{ town.usename }}
                             <span> ({{ town.distance.toFixed(2) }}km)</span>
                         </router-link>
                     </li>

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -315,6 +315,10 @@ export default {
         towns() {
             if (this.displayShantytownsLevel) {
                 this.syncTownMarkers();
+
+                // The method syncTownMarkers recreates the layer and make it visible even if it wasn't before
+                // Call onZoomEnd to hide if if necessary
+                this.onZoomEnd();
             }
 
             if (this.loadTerritoryLayers) {
@@ -323,8 +327,6 @@ export default {
                 this.loadDepartementalData();
                 this.loadCityData();
             }
-
-            this.syncTownMarkers();
         },
 
         pois() {

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -682,9 +682,7 @@ export default {
         },
 
         getTownAddress(town) {
-            return town.name
-                ? `${town.address} « ${town.name} »`
-                : town.address;
+            return town.usename;
         },
 
         getTownCoordinates(town) {

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -323,6 +323,8 @@ export default {
                 this.loadDepartementalData();
                 this.loadCityData();
             }
+
+            this.syncTownMarkers();
         },
 
         pois() {
@@ -678,7 +680,9 @@ export default {
         },
 
         getTownAddress(town) {
-            return town.usename;
+            return town.name
+                ? `${town.address} « ${town.name} »`
+                : town.address;
         },
 
         getTownCoordinates(town) {
@@ -743,12 +747,13 @@ export default {
             const coordinates = this.getTownCoordinates(town);
             const color = this.getTownColor(town);
             const waterImage = this.getTownWaterImage(town);
+            const style = town.style ? `style="${town.style}"` : "";
 
             const marker = L.marker(coordinates, {
-                title: town.address,
+                title: address,
                 icon: L.divIcon({
                     className: "leaflet-marker",
-                    html: `<span class="mapPin mapPin--shantytown">
+                    html: `<span class="mapPin mapPin--shantytown" ${style}>
                         <span class="mapPin-wrapper">
                             <span class="mapPin-water"><img src="${waterImage}" /></span>
                             <span class="mapPin-marker" style="background-color: ${color}"></span>

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
@@ -324,6 +324,11 @@ export default {
                 el.scrollIntoView({ behavior: "smooth" });
             }
         }
+    },
+    watch: {
+        "$route.params.id": function() {
+            this.fetchData();
+        }
     }
 };
 </script>

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
@@ -130,10 +130,10 @@
                                     >
                                         <router-link
                                             class="link"
-                                            :to="`/site/${town.shantytown_id}`"
+                                            :to="`/site/${town.id}`"
                                         >
                                             {{
-                                                town.address_simple ||
+                                                town.addressSimple ||
                                                     town.address
                                             }}
                                             <span v-if="town.name"
@@ -158,11 +158,11 @@
                             :towns="[
                                 {
                                     ...town,
-                                    style: `opacity: 1; z-index: 99999`
+                                    style: `opacity: 1`
                                 },
                                 ...nearbyTowns.map(t => ({
                                     ...t,
-                                    style: `opacity: 0.7`
+                                    style: `opacity: 0.8`
                                 }))
                             ]"
                             :default-view="center"
@@ -199,8 +199,8 @@ export default {
     components: { TownDetailsPanel, TownDetailsPanelSection, Map },
     methods: {
         goTo(town) {
-            if (town.shantytown_id) {
-                this.$router.push(`/site/${town.shantytown_id}`);
+            if (town.id) {
+                this.$router.push(`/site/${town.id}`);
             }
         },
         /**
@@ -233,9 +233,7 @@ export default {
                 this.town.longitude
             );
 
-            this.nearbyTowns = towns.filter(
-                town => town.shantytown_id !== this.town.id
-            );
+            this.nearbyTowns = towns.filter(town => town.id !== this.town.id);
             // eslint-disable-next-line no-empty
         } catch (err) {}
     },

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
@@ -132,13 +132,7 @@
                                             class="link"
                                             :to="`/site/${town.id}`"
                                         >
-                                            {{
-                                                town.addressSimple ||
-                                                    town.address
-                                            }}
-                                            <span v-if="town.name"
-                                                >« {{ town.name }} »</span
-                                            >
+                                            {{ town.usename }}
                                             <span>
                                                 ({{
                                                     town.distance.toFixed(2)
@@ -199,7 +193,7 @@ export default {
     components: { TownDetailsPanel, TownDetailsPanelSection, Map },
     methods: {
         goTo(town) {
-            if (town.id) {
+            if (town.id && town.id !== this.town.id) {
                 this.$router.push(`/site/${town.id}`);
             }
         },

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
@@ -139,6 +139,11 @@
                                             <span v-if="town.name"
                                                 >« {{ town.name }} »</span
                                             >
+                                            <span>
+                                                ({{
+                                                    town.distance.toFixed(2)
+                                                }}km)</span
+                                            >
                                         </router-link>
                                     </li>
                                 </ul>

--- a/packages/frontend/src/js/helpers/api/town.js
+++ b/packages/frontend/src/js/helpers/api/town.js
@@ -177,7 +177,9 @@ export function findRelations(townId, query) {
  * GET /towns/findNearby
  */
 export function findNearby(latitude, longitude) {
-    return getApi(`/towns/findNearby?latitude=${latitude}&longitude=${longitude}`);
+    return getApi(
+        `/towns/findNearby?latitude=${latitude}&longitude=${longitude}`
+    );
 }
 
 /**

--- a/packages/frontend/src/js/helpers/api/town.js
+++ b/packages/frontend/src/js/helpers/api/town.js
@@ -174,6 +174,13 @@ export function findRelations(townId, query) {
 }
 
 /**
+ * GET /towns/findNearby
+ */
+export function findNearby(latitude, longitude) {
+    return getApi(`/towns/findNearby?latitude=${latitude}&longitude=${longitude}`);
+}
+
+/**
  * @typedef {Object} Town_Data
  * @property {number} latitude,
  * @property {number} longitude,


### PR DESCRIPTION
## 🧾 Ticket Trello
- https://trello.com/c/22cliTBU/1232-%C3%A9viter-les-doublons-de-site-sur-la-carte-de-la-fiche-dun-site-ajouter-les-sites-%C3%A0-proximit%C3%A9-besoin-de-fait-de-valoriser-le-site
- https://trello.com/c/kXSI8ktu/1237-%C3%A9viter-les-doublons-de-site-lors-de-la-cr%C3%A9ation-de-site-mentionner-sur-la-carte-et-textuellement-la-pr%C3%A9sence-dautres-sites-dans

## 🛠 Description de la PR
- Ajout d'une route `/towns/findNearby?longitude=...&latitude=...`' qui retourne les bidonvilles à proximité. Cette liste est filtré selon les permissions de l'utilisateur
- Sur la fiche d'un site: Ajout d'un encart "Sites à proximité" + Affichage des bidonvilles avec une opacité réduite sur la carto
- Sur la fiche de création d'un site: Ajout d'une alerte textuelle 

**Améliorations possibles:**
Sur la création d'un site, j'aurais aussi aimé ajouter sur la carto les bidonvilles à proximité mais ça rajoute pas mal de travail car il s'agit d'un composant différent pour le moment assez minimaliste

## 📸 Captures d'écran
C'est déployé sur la préprod (tag qa-1237) : https://preprod.resorption-bidonvilles.beta.gouv.fr/site/35


## Création Site
![image](https://user-images.githubusercontent.com/5053593/134920001-64d34971-7064-4be7-aea6-735d3c527f66.png)

## Fiche site
![image](https://user-images.githubusercontent.com/5053593/134918626-40cc8472-7297-47e5-8bd0-be82865b858c.png)
