### PR TITLE
#patch (1213) Ajout d'un lien de désabonnement aux récaps hebdos

### DIFF
--- a/packages/api/db/migrations/001213-001-alter-users-add-column-subscribed_to_summary.js
+++ b/packages/api/db/migrations/001213-001-alter-users-add-column-subscribed_to_summary.js
@@ -1,0 +1,13 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.addColumn(
+        'users',
+        'subscribed_to_summary',
+        {
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+        },
+    ),
+
+    down: queryInterface => queryInterface.removeColumn('users', 'subscribed_to_summary'),
+};

--- a/packages/api/server/controllers/userController.js
+++ b/packages/api/server/controllers/userController.js
@@ -232,6 +232,7 @@ module.exports = models => ({
 
         const {
             first_name: firstName, last_name: lastName, email, phone, position,
+            subscribed_to_summary: subscribedToSummary,
         } = req.body;
         const user = await models.user.findOne(userId, { auth: true });
 
@@ -252,6 +253,7 @@ module.exports = models => ({
             email,
             phone,
             position,
+            subscribed_to_summary: subscribedToSummary,
         };
 
         if (req.body.password) {
@@ -267,6 +269,7 @@ module.exports = models => ({
                 first_name: firstName,
                 last_name: lastName,
                 departement: user.departement,
+                subscribed_to_summary: subscribedToSummary,
             });
         } catch (error) {
             res.status(500).send({

--- a/packages/api/server/mails/src/activity_summary.mjml
+++ b/packages/api/server/mails/src/activity_summary.mjml
@@ -33,5 +33,11 @@
         </mj-section>
 
         <mj-include path='common/footer.mjml' />
+
+        <mj-section>
+            <mj-column>
+                <mj-text mj-class='text-sm font-italic pt-4'>Pour ne plus recevoir ces récapitulatifs hebdomadaires, veuillez <a href="{{var:frontUrl}}/mon-compte?{{var:utm}}" class="link">le signaler dans votre espace "Mon compte"</a>.</mj-text>
+            </mj-column>
+        </mj-section>
     </mj-body>
 </mjml>

--- a/packages/api/server/mails/src/common/summary_full_activities.mjml
+++ b/packages/api/server/mails/src/common/summary_full_activities.mjml
@@ -1,50 +1,46 @@
-<mj-section>
-    <mj-column>
-        <mj-raw>{% if summary.new_shantytowns_length > 1 %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.new_shantytowns_length }} nouveaux sites</mj-text>
-        <mj-raw>{% else %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.new_shantytowns_length }} nouveau site</mj-text>
-        <mj-raw>{% endif %}</mj-raw>
-        <mj-raw>{% for shantytown in summary.new_shantytowns %}</mj-raw>
-        <mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site" class="link">{{ shantytown.usename }}</a></mj-text>
-        <mj-raw>{% endfor %}</mj-raw>
+<mj-raw>{% if summary.new_shantytowns_length > 1 %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.new_shantytowns_length }} nouveaux sites</mj-text>
+<mj-raw>{% else %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.new_shantytowns_length }} nouveau site</mj-text>
+<mj-raw>{% endif %}</mj-raw>
+<mj-raw>{% for shantytown in summary.new_shantytowns %}</mj-raw>
+<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site" class="link">{{ shantytown.usename }}</a></mj-text>
+<mj-raw>{% endfor %}</mj-raw>
 
-        <mj-raw>{% if summary.closed_shantytowns_length > 1 %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.closed_shantytowns_length }} sites fermés</mj-text>
-        <mj-raw>{% else %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.closed_shantytowns_length }} site fermé</mj-text>
-        <mj-raw>{% endif %}</mj-raw>
-        <mj-raw>{% for shantytown in summary.closed_shantytowns %}</mj-raw>
-        <mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme" class="link">{{ shantytown.usename }}</a></mj-text>
-        <mj-raw>{% endfor %}</mj-raw>
+<mj-raw>{% if summary.closed_shantytowns_length > 1 %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.closed_shantytowns_length }} sites fermés</mj-text>
+<mj-raw>{% else %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.closed_shantytowns_length }} site fermé</mj-text>
+<mj-raw>{% endif %}</mj-raw>
+<mj-raw>{% for shantytown in summary.closed_shantytowns %}</mj-raw>
+<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme" class="link">{{ shantytown.usename }}</a></mj-text>
+<mj-raw>{% endfor %}</mj-raw>
 
-        <mj-raw>{% if summary.updated_shantytowns_length > 1 %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.updated_shantytowns_length }} sites mis à jour</mj-text>
-        <mj-raw>{% else %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.updated_shantytowns_length }} site mis à jour</mj-text>
-        <mj-raw>{% endif %}</mj-raw>
-        <mj-raw>{% for shantytown in summary.updated_shantytowns %}</mj-raw>
-        <mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour" class="link">{{ shantytown.usename }}</a></mj-text>
-        <mj-raw>{% endfor %}</mj-raw>
+<mj-raw>{% if summary.updated_shantytowns_length > 1 %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.updated_shantytowns_length }} sites mis à jour</mj-text>
+<mj-raw>{% else %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.updated_shantytowns_length }} site mis à jour</mj-text>
+<mj-raw>{% endif %}</mj-raw>
+<mj-raw>{% for shantytown in summary.updated_shantytowns %}</mj-raw>
+<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour" class="link">{{ shantytown.usename }}</a></mj-text>
+<mj-raw>{% endfor %}</mj-raw>
 
-        <mj-raw>{% if summary.new_comments_length > 1 %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.new_comments_length }} messages dans le journal du site</mj-text>
-        <mj-raw>{% else %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.new_comments_length }} message dans le journal du site</mj-text>
-        <mj-raw>{% endif %}</mj-raw>
-        <mj-raw>{% for comment in summary.new_comments %}</mj-raw>
-        <mj-text><a href="{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}" class="link">{{ comment.shantytownUsename }}</a></mj-text>
-        <mj-raw>{% endfor %}</mj-raw>
+<mj-raw>{% if summary.new_comments_length > 1 %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.new_comments_length }} messages dans le journal du site</mj-text>
+<mj-raw>{% else %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.new_comments_length }} message dans le journal du site</mj-text>
+<mj-raw>{% endif %}</mj-raw>
+<mj-raw>{% for comment in summary.new_comments %}</mj-raw>
+<mj-text><a href="{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}" class="link">{{ comment.shantytownUsename }}</a></mj-text>
+<mj-raw>{% endfor %}</mj-raw>
 
-        <mj-raw>{% if summary.new_users_length > 1 %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.new_users_length }} nouveaux utilisateurs</mj-text>
-        <mj-raw>{% else %}</mj-raw>
-        <mj-text mj-class='font-bold pt-2'>{{ summary.new_users_length }} nouvel utilisateur</mj-text>
-        <mj-raw>{% endif %}</mj-raw>
-        <mj-raw>{% for user in summary.new_users %}</mj-raw>
-        <mj-text><a href="{{var:frontUrl}}/annuaire/{{user.organizationId}}?{{var:utm}}-nouvel-utilisateur" class="link">{{ user.name }}</a></mj-text>
-        <mj-raw>{% endfor %}</mj-raw>
+<mj-raw>{% if summary.new_users_length > 1 %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.new_users_length }} nouveaux utilisateurs</mj-text>
+<mj-raw>{% else %}</mj-raw>
+<mj-text mj-class='font-bold pt-2'>{{ summary.new_users_length }} nouvel utilisateur</mj-text>
+<mj-raw>{% endif %}</mj-raw>
+<mj-raw>{% for user in summary.new_users %}</mj-raw>
+<mj-text><a href="{{var:frontUrl}}/annuaire/{{user.organizationId}}?{{var:utm}}-nouvel-utilisateur" class="link">{{ user.name }}</a></mj-text>
+<mj-raw>{% endfor %}</mj-raw>
 
-        <mj-include path="summary_footer.mjml" />
-    </mj-column>
-</mj-section>
+<mj-include path="summary_footer.mjml" />

--- a/packages/api/server/middlewares/validators/editUser.js
+++ b/packages/api/server/middlewares/validators/editUser.js
@@ -48,4 +48,8 @@ module.exports = [
 
             return true;
         }),
+
+    body('subscribed_to_summary')
+        .notEmpty().bail().withMessage('Le champ "Abonnement au récapitulatif hebdomadaire" est obligatoire')
+        .isBoolean().bail().withMessage('Le champ "Abonnement au récapitulatif hebdomadaire" est invalide'),
 ];

--- a/packages/api/server/models/userModel/index.js
+++ b/packages/api/server/models/userModel/index.js
@@ -94,6 +94,7 @@ function serializeUser(user, latestCharte, filters, permissionMap) {
             },
         },
         charte_engagement_a_jour: latestCharte === null || user.charte_engagement_signee === latestCharte,
+        subscribed_to_summary: user.subscribed_to_summary,
         is_admin: user.is_admin,
         role: user.role_name || user.organization_type_role_name,
         role_id: user.role || user.organization_type_role,
@@ -226,6 +227,7 @@ module.exports = () => {
                 users.last_version,
                 users.last_changelog,
                 users.charte_engagement_signee,
+                users.subscribed_to_summary,
                 CASE WHEN users.fk_role IS NULL THEN FALSE
                     ELSE TRUE
                 END AS is_admin,

--- a/packages/api/server/models/userModel/index.js
+++ b/packages/api/server/models/userModel/index.js
@@ -589,6 +589,7 @@ module.exports = () => {
             const allowedProperties = [
                 'first_name', 'last_name', 'position', 'phone', 'password', 'defaultExport', 'fk_status',
                 'last_version', 'last_changelog', 'charte_engagement_signee', 'last_access',
+                'subscribed_to_summary',
             ];
             const propertiesToColumns = {
                 first_name: 'first_name',
@@ -602,6 +603,7 @@ module.exports = () => {
                 last_changelog: 'last_changelog',
                 charte_engagement_signee: 'charte_engagement_signee',
                 last_access: 'last_access',
+                subscribed_to_summary: 'subscribed_to_summary',
             };
             const setClauses = [];
             const replacements = {};
@@ -613,7 +615,7 @@ module.exports = () => {
                     if (property === 'defaultExport' && values[property]) {
                         replacements[property] = values[property].replace(/\s/g, '') || null;
                     } else {
-                        replacements[property] = values[property] || null;
+                        replacements[property] = values[property] !== undefined ? values[property] : null;
                     }
                 }
             });

--- a/packages/api/server/models/userModel/index.js
+++ b/packages/api/server/models/userModel/index.js
@@ -506,6 +506,9 @@ module.exports = () => {
                     {
                         fk_status: ['active'],
                     },
+                    {
+                        subscribed_to_summary: true,
+                    },
                 ],
                 {},
             );

--- a/packages/frontend/src/js/app/pages/Account/AccountEdit/AccountEdit.vue
+++ b/packages/frontend/src/js/app/pages/Account/AccountEdit/AccountEdit.vue
@@ -84,6 +84,25 @@
                     </PasswordInfo>
                 </div>
 
+                <CheckableGroup
+                    label="Je souhaite recevoir le récapitulatif hebdomadaire par courriel"
+                    direction="vertical"
+                    withoutMargin
+                >
+                    <Radio
+                        label="oui"
+                        v-model="edit.subscribed_to_summary"
+                        :checkValue="true"
+                        type="checkbox"
+                    ></Radio>
+                    <Radio
+                        label="non"
+                        v-model="edit.subscribed_to_summary"
+                        :checkValue="false"
+                        type="checkbox"
+                    ></Radio>
+                </CheckableGroup>
+
                 <div v-if="error" class="text-error">
                     {{ error }}
                 </div>
@@ -118,7 +137,8 @@ export default {
                 last_name: this.user.last_name || "",
                 position: this.user.position || "",
                 phone: this.user.phone || "",
-                password: ""
+                password: "",
+                subscribed_to_summary: this.user.subscribed_to_summary === true
             }
         };
     },

--- a/packages/frontend/src/js/app/pages/Account/AccountRead/AccountRead.vue
+++ b/packages/frontend/src/js/app/pages/Account/AccountRead/AccountRead.vue
@@ -51,8 +51,8 @@
                     <div>
                         Si vous souhaitez changer de courriel, écrivez-nous à
                         <a
-                            href="mailto:contact@resorption-bodonvilles.beta.gouv.fr"
-                            >contact@resorption-bodonvilles.beta.gouv.fr</a
+                            href="mailto:contact@resorption-bidonvilles.beta.gouv.fr"
+                            >contact@resorption-bidonvilles.beta.gouv.fr</a
                         >
                     </div>
                     <div>

--- a/packages/frontend/src/js/app/pages/Account/AccountRead/AccountRead.vue
+++ b/packages/frontend/src/js/app/pages/Account/AccountRead/AccountRead.vue
@@ -42,6 +42,11 @@
                 <AccountReadLabel label="Téléphone">
                     {{ user.phone }}
                 </AccountReadLabel>
+                <AccountReadLabel
+                    label="Abonné(e) au récapitulatif hebdomadaire"
+                >
+                    {{ user.subscribed_to_summary ? "Oui" : "Non" }}
+                </AccountReadLabel>
 
                 <div class="mt-8" v-if="!$route.params.id">
                     <div class="font-bold">


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/o0DKgsxd/1213

## 🛠 Description de la PR
Ajout d'un lien de désabonnement aux mails de récap hebdo, qui pointe vers la page "Mon compte" depuis laquelle on peut faire ce paramétrage.

Ce changement implique l'ajout d'une colonne users.subscribed_to_summary.

## 📸 Captures d'écran
- lien dans les mails :
![Uploading Capture d’écran 2021-09-27 à 17.51.05.png…]()
- page Mon compte (vue lecture)
![Capture d’écran 2021-09-27 à 17 51 40](https://user-images.githubusercontent.com/1801091/134942399-75932b0d-c070-4c80-9561-c04ae2a87a20.png)
- page Mon compte (vue édition)
![Capture d’écran 2021-09-27 à 17 51 58](https://user-images.githubusercontent.com/1801091/134942443-59d47b27-ba64-459e-bbe9-df4ec506a74a.png)

## 🚨 Notes pour la mise en production
Faire la migration