### PR TITLE
#minor (1183) - affichage des sites fermés sur la carte

### DIFF
--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -391,9 +391,10 @@ export default {
         countNumberOfTowns() {
             this.numberOfShantytownsBy = this.towns.reduce(
                 (acc, obj) => {
-                    if (obj.closedAt !== null) {
-                        return acc;
-                    }
+                    // Following code deactivated to show closed shantytons
+                    // if (obj.closedAt !== null) {
+                    //     return acc;
+                    // }
 
                     if (acc.departements[obj.departement.code] === undefined) {
                         acc.departements[obj.departement.code] = {

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -311,15 +311,15 @@ export default {
 
     watch: {
         towns() {
+            if (this.displayShantytownsLevel) {
+                this.syncTownMarkers();
+            }
+
             if (this.loadTerritoryLayers) {
                 this.countNumberOfTowns();
                 this.loadRegionalData();
                 this.loadDepartementalData();
                 this.loadCityData();
-
-                if (this.displayShantytownsLevel) {
-                    this.syncTownMarkers();
-                }
             }
         },
 

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -311,13 +311,15 @@ export default {
 
     watch: {
         towns() {
-            this.countNumberOfTowns();
-            if (this.displayShantytownsLevel) {
-                this.syncTownMarkers();
-            } else {
+            if (this.loadTerritoryLayers) {
+                this.countNumberOfTowns();
                 this.loadRegionalData();
                 this.loadDepartementalData();
                 this.loadCityData();
+
+                if (this.displayShantytownsLevel) {
+                    this.syncTownMarkers();
+                }
             }
         },
 

--- a/packages/frontend/src/js/app/components/quickview/quickview.pug
+++ b/packages/frontend/src/js/app/components/quickview/quickview.pug
@@ -4,7 +4,7 @@
     <simplebar class="quickview" ref="quickviewPanel" data-simplebar-auto-hide="false">
         <header class="quickview-header" v-if="town">
             <div class="quickview-actions">
-                <button type="button" class="actionButton" @click="showTown">Voir le site</button>
+                <button type="button" class="actionButton mr-2" @click="showTown">Voir le site</button>
                 <a href="#" @click="$emit('outside-click')"><svg class="icon icon-cross"><use xlink:href="#round-cross"></use></svg></a>
             </div>
             <h1 class="quickview-title"><a @click="showTown">{{ town.address.split(/[0-9]{5}/)[0].replace(/[0-9]/g, '').replace(/,/g, ' ').replace(/\s{2,}/g, ' ') }}</a></h1>

--- a/packages/frontend/src/js/app/pages/dashboard/dashboard.scss
+++ b/packages/frontend/src/js/app/pages/dashboard/dashboard.scss
@@ -88,36 +88,36 @@
         stroke:grey;
         stroke-width: 2;
     }
+}
 
-    .circle {
-        border-color: rgba(181, 226, 140, 0.6);
-        background-color: rgba(158, 199, 134, 0.6);
-        background-clip: padding-box;
-        display: table-cell;
-        text-align: center;
-        vertical-align: middle;
-        border-radius: 50%;
-        border-style: solid;
-        border-width: 5px;
-        font-family: Arial, Helvetica, sans-serif;
-        color: black;
-        -webkit-print-color-adjust: exact !important;
-        color-adjust: exact;
-    }
+.circle {
+    border-color: rgba(181, 226, 140, 0.6);
+    background-color: rgba(158, 199, 134, 0.8);
+    background-clip: padding-box;
+    display: table-cell;
+    text-align: center;
+    vertical-align: middle;
+    border-radius: 50%;
+    border-style: solid;
+    border-width: 5px;
+    font-family: Arial, Helvetica, sans-serif;
+    color: black;
+    -webkit-print-color-adjust: exact !important;
+    color-adjust: exact;
+}
 
-    .circle.region {
-        font-size: 16px;
-    }
+.circle.region {
+    font-size: 16px;
+}
 
-    .circle.dept {
-        font-size: 10px;
-    }
+.circle.dept {
+    font-size: 10px;
+}
 
-    .circle.city {
-        border-color: rgba(199, 119, 56, 0.6);
-        background-color: rgba(218, 119, 59, 0.8);
-        font-size: 10px;
-    }
+.circle.city {
+    border-color: rgba(199, 119, 56, 0.6);
+    background-color: rgba(218, 119, 59, 0.8);
+    font-size: 10px;
 }
 
 .preprint {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/G4aFyEnC

## 🛠 Description de la PR
- Améliore la synchro entre les critères de visualistion de la carte des sites et les choix de l'utilisateurs.
- Petite correction d'UI pour la quicqview d'un site (espace entre bouton "Voir le site" et icône de fermeture de la quickview).

## 📸 Captures d'écran
- Exemple du critère "Sites disparus" au niveau départemental
![image](https://user-images.githubusercontent.com/50863659/134953299-bb7b16bb-fe30-40ab-bf0b-a3de551aba60.png)

## 🚨 Notes pour la mise en production
- Ràs