### PR TITLE
#patch (1241) Afficher le taux de complétion sur la fiche d’un site et sur la liste des sites

### DIFF
--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -624,6 +624,8 @@ module.exports = (database) => {
     const shantytownActorModel = require('#server/models/shantytownActorModel')(database);
     // eslint-disable-next-line global-require
     const planShantytownModel = require('#server/models/planShantytownModel')(database);
+    // eslint-disable-next-line global-require
+    const statsModel = require('#server/models/statsModel')(database);
 
     async function getComments(user, shantytownIds, covid = false) {
         const comments = shantytownIds.reduce((acc, id) => Object.assign({}, acc, {
@@ -691,29 +693,7 @@ module.exports = (database) => {
             `
             SELECT
                 s.shantytown_id,
-                ((CASE WHEN (SELECT regexp_matches(s.address, '^(.+) [0-9]+ [^,]+,? [0-9]+,? [^, ]+(,.+)?$'))[1] IS NOT NULL THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN ft.label <> 'Inconnu' THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN ot.label <> 'Inconnu' THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN s.census_status IS NOT NULL THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN s.population_total IS NOT NULL THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN s.population_couples IS NOT NULL THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN s.population_minors IS NOT NULL THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN s.population_total IS NOT NULL AND s.population_total >= 10 AND (SELECT COUNT(*) FROM shantytown_origins WHERE fk_shantytown = s.shantytown_id) > 0 THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN et.label <> 'Inconnu' THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN s.access_to_water IS NOT NULL THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN s.access_to_sanitary IS NOT NULL THEN 1 ELSE 0 END)
-                +
-                (CASE WHEN s.trash_evacuation IS NOT NULL THEN 1 ELSE 0 END))::FLOAT / 12.0 AS completion
+                ${statsModel.averageCompletionCalc} AS completion
             FROM
                 shantytowns s
             LEFT JOIN

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -30,7 +30,7 @@
                 Mis à jour le
                 {{ formatDate(town.updatedAt, "d/m/y") }}
             </div>
-            <div class="flex items-center uppercase text-sm ">
+            <div class="flex items-center uppercase text-sm mr-4">
                 <CompletionTag :completion="town.completion" />
             </div>
             <div class="flex items-center uppercase text-sm mr-4">

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -30,6 +30,9 @@
                 Mis à jour le
                 {{ formatDate(town.updatedAt, "d/m/y") }}
             </div>
+            <div class="flex items-center uppercase text-sm ">
+                <CompletionTag :completion="town.completion" />
+            </div>
             <div class="flex items-center uppercase text-sm mr-4">
                 <Tag variant="highlight" v-if="town.resorptionTarget">
                     Objectif résorption
@@ -99,8 +102,10 @@
 
 <script>
 import { get as getConfig, getPermission } from "#helpers/api/config";
+import CompletionTag from "#app/pages/TownsList/CompletionTag";
 
 export default {
+    components: { CompletionTag },
     props: {
         town: {
             type: Object

--- a/packages/frontend/src/js/app/pages/TownsList/CompletionTag.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/CompletionTag.vue
@@ -1,0 +1,18 @@
+<template>
+    <Tag
+        :class="['text-xs uppercase text-primary', isHover ? 'shadow-md' : '']"
+    >
+        Site completé à
+        {{ Math.floor(completion * 100).toFixed(0) }}%
+    </Tag>
+</template>
+
+<script>
+export default {
+    props: {
+        completion: {
+            type: Number
+        }
+    }
+};
+</script>

--- a/packages/frontend/src/js/app/pages/TownsList/CompletionTag.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/CompletionTag.vue
@@ -1,9 +1,15 @@
 <template>
     <Tag
-        :class="['text-xs uppercase text-primary', isHover ? 'shadow-md' : '']"
+        :class="[
+            'text-xs uppercase text-primary relative',
+        ]"
     >
         Site completé à
         {{ Math.floor(completion * 100).toFixed(0) }}%
+        <div
+            :class="['absolute', 'bg-info', 'h-px', 'bottom-0', 'left-0']"
+            :style="{ width: Math.floor(completion * 100) + '%' }"
+        ></div>
     </Tag>
 </template>
 

--- a/packages/frontend/src/js/app/pages/TownsList/CompletionTag.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/CompletionTag.vue
@@ -1,6 +1,6 @@
 <template>
     <Tag :class="['text-xs uppercase text-primary relative']">
-        Site completé à
+        Site complété à
         {{ Math.floor(completion * 100).toFixed(0) }}%
         <div
             :class="['absolute', 'bg-info', 'h-px', 'bottom-0', 'left-0']"

--- a/packages/frontend/src/js/app/pages/TownsList/CompletionTag.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/CompletionTag.vue
@@ -1,9 +1,5 @@
 <template>
-    <Tag
-        :class="[
-            'text-xs uppercase text-primary relative',
-        ]"
-    >
+    <Tag :class="['text-xs uppercase text-primary relative']">
         Site completé à
         {{ Math.floor(completion * 100).toFixed(0) }}%
         <div

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -19,6 +19,10 @@
                     >
                         {{ lastUpdate }}
                     </Tag>
+                    <CompletionTag
+                        class="ml-4"
+                        :completion="shantytown.completion"
+                    />
                     <Tag
                         :class="['ml-4 py-1 px-3', isHover ? 'shadow-md' : '']"
                         variant="highlight"
@@ -268,6 +272,7 @@ import flagFR from "./assets/fr.png";
 import flagExtraCommunautaires from "./assets/extra-communautaires.png";
 import formatDateSinceActivity from "./formatDateSinceActivity";
 import { formatLivingConditions } from "#app/pages/TownDetails/formatLivingConditions";
+import CompletionTag from "#app/pages/TownsList/CompletionTag";
 
 export default {
     props: {
@@ -285,6 +290,7 @@ export default {
         };
     },
     components: {
+        CompletionTag,
         TownCardIcon
     },
     methods: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/F8cNoax1/1241-quickwin-afficher-le-taux-de-compl%C3%A9tion-sur-la-fiche-dun-site-et-sur-la-liste-des-sites

## 📸 Captures d'écran

## Liste site
![image](https://user-images.githubusercontent.com/5053593/135230673-e11982c4-c9ca-40b9-96aa-e9c7b92c3eed.png)

## Fiche site
![image](https://user-images.githubusercontent.com/5053593/135231101-5054fa6f-4f5b-4b55-8ace-4633f5acb919.png)
