### PR TITLE
(1234) Feedbacks

### DIFF
--- a/packages/api/server/controllers/userController.js
+++ b/packages/api/server/controllers/userController.js
@@ -302,13 +302,13 @@ module.exports = models => ({
     /**
      * Updates comments about a user
      */
-    async comment(req, res, next) {
+    async setAdminComments(req, res, next) {
         try {
-            await models.user.updateComment(req.params.id, {
+            await models.user.update(req.params.id, {
                 admin_comments: req.body.comment,
             });
             return res.status(200).send({
-                adminComment: req.body.comment,
+                admin_comments: req.body.comment,
             });
         } catch (error) {
             res.status(500).send({

--- a/packages/api/server/loaders/routesLoader.js
+++ b/packages/api/server/loaders/routesLoader.js
@@ -146,12 +146,14 @@ module.exports = (app) => {
         controllers.user.upgrade,
     );
     app.put(
-        '/users/:id/comment',
-        validators.userComments,
+        '/users/:id/admin_comments',
         middlewares.auth.authenticate,
         middlewares.auth.isSuperAdmin,
+        middlewares.charte.check,
         middlewares.appVersion.sync,
-        controllers.user.comment,
+        validators.setUserAdminComments,
+        middlewares.validation,
+        controllers.user.setAdminComments,
     );
     app.get(
         '/activation-tokens/:token/check',

--- a/packages/api/server/middlewares/validators/index.js
+++ b/packages/api/server/middlewares/validators/index.js
@@ -12,7 +12,7 @@ const inviteShantytownActor = require('./shantytownActors/inviteShantytownActor'
 const invite = require('./invite');
 const createShantytownComment = require('./shantytownComment/create');
 const activityList = require('./activity/list');
-const userComments = require('./userComments');
+const setUserAdminComments = require('./setUserAdminComments');
 
 module.exports = {
     closeTown,
@@ -35,5 +35,5 @@ module.exports = {
     activity: {
         list: activityList,
     },
-    userComments,
+    setUserAdminComments,
 };

--- a/packages/api/server/middlewares/validators/setUserAdminComments.js
+++ b/packages/api/server/middlewares/validators/setUserAdminComments.js
@@ -5,18 +5,24 @@ const userModel = require('#server/models/userModel')(sequelize);
 module.exports = [
 
     body('comment')
+        .optional({ nullable: true })
+        .isString().bail()
+        .withMessage('Le commentaire est invalide')
         .trim(),
+
+    body('comment')
+        .customSanitizer(value => value || null),
 
     param('id')
         .toInt()
         .isInt().bail()
-        .withMessage('L\'identifiant du site est invalide')
+        .withMessage('L\'identifiant de l\'utilisateur est invalide')
         .custom(async (value) => {
             let user = null;
             try {
                 user = await userModel.findOne(value, { auth: true });
             } catch (error) {
-                throw new Error('Erreur lors du contrôle de l\'existence de l\'utlisateur à partir de so identifiant');
+                throw new Error('Erreur lors du contrôle de l\'existence de l\'utlisateur à partir de son identifiant');
             }
 
             if (user === null) {

--- a/packages/api/server/models/userModel.js
+++ b/packages/api/server/models/userModel.js
@@ -558,6 +558,7 @@ module.exports = () => {
             const allowedProperties = [
                 'first_name', 'last_name', 'position', 'phone', 'password', 'defaultExport', 'fk_status',
                 'last_version', 'last_changelog', 'charte_engagement_signee', 'last_access',
+                'admin_comments',
             ];
             const propertiesToColumns = {
                 first_name: 'first_name',
@@ -571,6 +572,7 @@ module.exports = () => {
                 last_changelog: 'last_changelog',
                 charte_engagement_signee: 'charte_engagement_signee',
                 last_access: 'last_access',
+                admin_comments: 'admin_comments',
             };
             const setClauses = [];
             const replacements = {};
@@ -601,29 +603,6 @@ module.exports = () => {
                 {
                     replacements: Object.assign(replacements, {
                         userId,
-                    }),
-                    transaction,
-                },
-            );
-
-            if (rowCount === 0) {
-                throw new Error(`The user #${userId} does not exist`);
-            }
-        },
-
-        updateComment: async (userId, comment, transaction = undefined) => {
-            const replacements = {};
-            const [, { rowCount }] = await database.query(
-                `UPDATE
-                    users
-                SET
-                    admin_comments = :commentValue
-                WHERE
-                    user_id = :userId`,
-                {
-                    replacements: Object.assign(replacements, {
-                        userId,
-                        commentValue: comment.admin_comments,
                     }),
                     transaction,
                 },

--- a/packages/frontend/src/js/helpers/api/user.js
+++ b/packages/frontend/src/js/helpers/api/user.js
@@ -246,9 +246,9 @@ export function acceptCharte(
 /**
  * POST /users/:id/comment
  */
-export function comment(userId, commentValue) {
-    return putApi(`/users/${userId}/comment`, {
-        comment: commentValue
+export function setAdminComments(userId, comment) {
+    return putApi(`/users/${userId}/admin_comments`, {
+        comment
     });
 }
 


### PR DESCRIPTION
- renommer la route `/users/:id/comment` en `/users/:id/admin_comments` pour respecter le nom de la colonne en BDD (et être plus explicite)
- globalement renommer les composants API pour être hyper explicites : le validateur devient setUserAdminComments, le contrôleur devient setAdminComments, le paramètre attendu dans le body devient "admin_comments" etc.
- ajout du middleware manquant "middlewares.validation" pour que le validator fonctionne
- ajout du middleware manquant "middlewares.charte.check"
- correction du validator setUserAdminComments pour : assurer que 'admin_comments' est bien une string + la convertir en NULL si elle est vide
- utilisation du modèle userModel.update plutôt que de créer une nouvelle méthode updateComment (ça fait moins de code et ça homogénéise)
- amélioration générale du composant UserValidateComment