### PR TITLE
#patch (1231) getDepartementWatchers become getLocationWatchers

### DIFF
--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -128,8 +128,16 @@ module.exports = (models) => {
 
                 // Send a notification to all users of the related departement
                 try {
-                    const { departement } = req.body.shantytown;
-                    const watchers = await userModel.getDepartementWatchers(departement.code, true);
+                    const {
+                        departement, city, region, epci,
+                    } = req.body.shantytown;
+                    const watchers = await userModel.getLocationWatchers({
+                        type: 'city',
+                        region,
+                        departement,
+                        epci,
+                        city,
+                    }, true);
                     watchers
                         .filter(({ user_id }) => user_id !== req.user.id) // do not send an email to the user who closed the town
                         .forEach((watcher) => {

--- a/packages/api/server/models/userModel/index.js
+++ b/packages/api/server/models/userModel/index.js
@@ -911,7 +911,7 @@ module.exports = () => {
         },
     );
 
-    model.getDepartementWatchers = async (departementCode, applyBlacklist = false) => {
+    model.getLocationWatchers = async (location, applyBlacklist = false) => {
         const users = await database.query(
             `SELECT
                 u.user_id,
@@ -921,13 +921,18 @@ module.exports = () => {
             FROM localized_organizations lo
             LEFT JOIN users u ON u.fk_organization = lo.organization_id
             WHERE
-                (lo.location_type != 'region' AND lo.departement_code = :departementCode)
+                (
+                    (lo.location_type = 'departement' AND lo.departement_code = :departementCode)
+                    OR
+                    ((lo.location_type = 'epci' OR lo.location_type = 'city') AND lo.epci_code = :epciCode)
+                )
                 AND u.fk_status = 'active'
                 AND lo.active = TRUE`,
             {
                 type: database.QueryTypes.SELECT,
                 replacements: {
-                    departementCode,
+                    departementCode: location.departement.code,
+                    epciCode: location.epci.code,
                 },
             },
         );

--- a/packages/api/server/services/shantytown/create.js
+++ b/packages/api/server/services/shantytown/create.js
@@ -4,7 +4,7 @@ const {
 } = require('#db/models');
 const { mattermost } = require('#server/config');
 const { triggerShantytownCreationAlert } = require('#server/utils/mattermost');
-const { getDepartementWatchers } = require('#server/models/userModel')(sequelize);
+const { getLocationWatchers } = require('#server/models/userModel')(sequelize);
 const { sendUserShantytownDeclared } = require('#server/mails/mails');
 
 module.exports = async (townData, user) => {
@@ -119,7 +119,7 @@ module.exports = async (townData, user) => {
 
     // Send a notification to all users of the related departement
     try {
-        const watchers = await getDepartementWatchers(townData.city.departement.code, true);
+        const watchers = await getLocationWatchers(townData.city, true);
         watchers
             .filter(({ user_id }) => user_id !== user.id) // do not send an email to the user who created the town
             .forEach((watcher) => {

--- a/packages/api/test/suites/server/controllers/townController/close.spec.js
+++ b/packages/api/test/suites/server/controllers/townController/close.spec.js
@@ -24,14 +24,14 @@ describe.only('townController.close()', () => {
         shantytownUpdate: undefined,
         shantytownFindOne: undefined,
         triggerShantytownCloseAlert: undefined,
-        getDepartementWatchers: undefined,
+        getLocationWatchers: undefined,
         sendUserShantytownClosed: undefined,
     };
     beforeEach(() => {
         dependencies.shantytownUpdate = sinon.stub(models.shantytown, 'update');
         dependencies.shantytownFindOne = sinon.stub(models.shantytown, 'findOne');
         dependencies.triggerShantytownCloseAlert = sinon.stub(mattermostUtils, 'triggerShantytownCloseAlert');
-        dependencies.getDepartementWatchers = sinon.stub(userModel, 'getDepartementWatchers');
+        dependencies.getLocationWatchers = sinon.stub(userModel, 'getLocationWatchers');
         dependencies.sendUserShantytownClosed = sinon.stub(mails, 'sendUserShantytownClosed');
     });
     afterEach(() => {
@@ -43,6 +43,25 @@ describe.only('townController.close()', () => {
         let output;
         let res;
         beforeEach(async () => {
+            const location = {
+                city: {
+                    name: 'Chatou',
+                    code: '78146',
+                },
+                epci: {
+                    code: '200058519',
+                    name: 'CA Saint-Germain Boucles de Seine',
+                },
+                departement: {
+                    name: 'Yvelines',
+                    code: '78',
+                },
+                region: {
+                    name: 'Île-de-France',
+                    code: '11',
+                },
+            };
+
             input = {
                 params: { id: 1 },
 
@@ -54,13 +73,9 @@ describe.only('townController.close()', () => {
                         { id: 1, people_affected: 10, households_affected: 5 },
                         { id: 2, people_affected: 20, households_affected: 10 },
                     ],
-
                     shantytown: {
                         id: 1,
-                        departement: {
-                            name: 'Yvelines',
-                            code: '78',
-                        },
+                        ...location,
                         closedAt: null,
                     }, // @todo: remplacer par une donnée générée via utils/shantytown dès que cet utils sera mergé dans develop...
                 },
@@ -76,16 +91,13 @@ describe.only('townController.close()', () => {
                 ],
                 shantytown: {
                     id: 1,
-                    departement: {
-                        name: 'Yvelines',
-                        code: '78',
-                    },
+                    ...location,
                     closedAt: input.body.closed_at.getTime() / 1000,
                 }, // @todo: remplacer par une donnée générée via utils/shantytown dès que cet utils sera mergé dans develop...
             };
 
-            dependencies.getDepartementWatchers
-                .withArgs('78', true)
+            dependencies.getLocationWatchers
+                .withArgs({ type: 'city', ...location }, true)
                 .resolves(output.watchers);
             dependencies.shantytownFindOne
                 .withArgs(input.user, 1)


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/OUGIrOGS/1231

## 🛠 Description de la PR
`getDepartementWatchers()` devient `getLocationWatchers()` et la requête SQL se base désormais à la fois sur l'EPCI et le département pour récupérer la liste des utilisateurs à notifier d'une ouverture/fermeture de site.

La règle devient que l'on notifie :
    - tous les utilisateurs de niveau epci et city qui font partie de l'epci du site concerné
    - tous les utilisateurs de niveau departement qui font partie du departement du site concerné

## 🚨 Notes pour la mise en production
Ø