### PR TITLE
#patch (1247) Ajout de la commune dans le mail récap'

### DIFF
--- a/packages/api/server/mails/dist/activity_summary.html
+++ b/packages/api/server/mails/dist/activity_summary.html
@@ -190,7 +190,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}, {{ shantytown.city }}</a></div>
     
                 </td>
               </tr>
@@ -214,7 +214,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}, {{ shantytown.city }}</a></div>
     
                 </td>
               </tr>
@@ -238,7 +238,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}, {{ shantytown.city }}</a></div>
     
                 </td>
               </tr>
@@ -262,7 +262,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}" class="link" style="color: #000091; text-decoration: none;">{{ comment.shantytownUsename }}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}" class="link" style="color: #000091; text-decoration: none;">{{ comment.shantytownUsename }}, {{ comment.city }}</a></div>
     
                 </td>
               </tr>
@@ -334,7 +334,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}, {{ shantytown.city }}</a></div>
     
                 </td>
               </tr>
@@ -358,7 +358,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}, {{ shantytown.city }}</a></div>
     
                 </td>
               </tr>
@@ -382,7 +382,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour" class="link" style="color: #000091; text-decoration: none;">{{ shantytown.usename }}, {{ shantytown.city }}</a></div>
     
                 </td>
               </tr>
@@ -406,7 +406,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}" class="link" style="color: #000091; text-decoration: none;">{{ comment.shantytownUsename }}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}" class="link" style="color: #000091; text-decoration: none;">{{ comment.shantytownUsename }}, {{ comment.city }}</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/activity_summary.text
+++ b/packages/api/server/mails/dist/activity_summary.text
@@ -6,28 +6,28 @@ Semaine du {{ var:from }} au {{ var:to }}
 {% else %}
 {{ summary.new_shantytowns_length }} nouveau site
 {% endif %}{% for shantytown in summary.new_shantytowns %}
-{{ shantytown.usename }}
+{{ shantytown.usename }}, {{ shantytown.city }}
 [{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site]
 {% endfor %}{% if summary.closed_shantytowns_length > 1 %}
 {{ summary.closed_shantytowns_length }} sites fermés
 {% else %}
 {{ summary.closed_shantytowns_length }} site fermé
 {% endif %}{% for shantytown in summary.closed_shantytowns %}
-{{ shantytown.usename }}
+{{ shantytown.usename }}, {{ shantytown.city }}
 [{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme]
 {% endfor %}{% if summary.updated_shantytowns_length > 1 %}
 {{ summary.updated_shantytowns_length }} sites mis à jour
 {% else %}
 {{ summary.updated_shantytowns_length }} site mis à jour
 {% endif %}{% for shantytown in summary.updated_shantytowns %}
-{{ shantytown.usename }}
+{{ shantytown.usename }}, {{ shantytown.city }}
 [{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour]
 {% endfor %}{% if summary.new_comments_length > 1 %}
 {{ summary.new_comments_length }} messages dans le journal du site
 {% else %}
 {{ summary.new_comments_length }} message dans le journal du site
 {% endif %}{% for comment in summary.new_comments %}
-{{ comment.shantytownUsename }}
+{{ comment.shantytownUsename }}, {{ comment.city }}
 [{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}]
 {% endfor %}{% if summary.new_users_length > 1 %}
 {{ summary.new_users_length }} nouveaux utilisateurs
@@ -47,28 +47,28 @@ Me connecter [{{var:connexionUrl}}]
 {% else %}
 {{ summary.new_shantytowns_length }} nouveau site
 {% endif %}{% for shantytown in summary.new_shantytowns %}
-{{ shantytown.usename }}
+{{ shantytown.usename }}, {{ shantytown.city }}
 [{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site]
 {% endfor %}{% if summary.closed_shantytowns_length > 1 %}
 {{ summary.closed_shantytowns_length }} sites fermés
 {% else %}
 {{ summary.closed_shantytowns_length }} site fermé
 {% endif %}{% for shantytown in summary.closed_shantytowns %}
-{{ shantytown.usename }}
+{{ shantytown.usename }}, {{ shantytown.city }}
 [{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme]
 {% endfor %}{% if summary.updated_shantytowns_length > 1 %}
 {{ summary.updated_shantytowns_length }} sites mis à jour
 {% else %}
 {{ summary.updated_shantytowns_length }} site mis à jour
 {% endif %}{% for shantytown in summary.updated_shantytowns %}
-{{ shantytown.usename }}
+{{ shantytown.usename }}, {{ shantytown.city }}
 [{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour]
 {% endfor %}{% if summary.new_comments_length > 1 %}
 {{ summary.new_comments_length }} messages dans le journal du site
 {% else %}
 {{ summary.new_comments_length }} message dans le journal du site
 {% endif %}{% for comment in summary.new_comments %}
-{{ comment.shantytownUsename }}
+{{ comment.shantytownUsename }}, {{ comment.city }}
 [{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}]
 {% endfor %}{% if summary.new_users_length > 1 %}
 {{ summary.new_users_length }} nouveaux utilisateurs

--- a/packages/api/server/mails/src/common/summary_full_activities.mjml
+++ b/packages/api/server/mails/src/common/summary_full_activities.mjml
@@ -4,7 +4,7 @@
 <mj-text mj-class='font-bold pt-2'>{{ summary.new_shantytowns_length }} nouveau site</mj-text>
 <mj-raw>{% endif %}</mj-raw>
 <mj-raw>{% for shantytown in summary.new_shantytowns %}</mj-raw>
-<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site" class="link">{{ shantytown.usename }}</a></mj-text>
+<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-nouveau-site" class="link">{{ shantytown.usename }}, {{ shantytown.city }}</a></mj-text>
 <mj-raw>{% endfor %}</mj-raw>
 
 <mj-raw>{% if summary.closed_shantytowns_length > 1 %}</mj-raw>
@@ -13,7 +13,7 @@
 <mj-text mj-class='font-bold pt-2'>{{ summary.closed_shantytowns_length }} site fermé</mj-text>
 <mj-raw>{% endif %}</mj-raw>
 <mj-raw>{% for shantytown in summary.closed_shantytowns %}</mj-raw>
-<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme" class="link">{{ shantytown.usename }}</a></mj-text>
+<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-ferme" class="link">{{ shantytown.usename }}, {{ shantytown.city }}</a></mj-text>
 <mj-raw>{% endfor %}</mj-raw>
 
 <mj-raw>{% if summary.updated_shantytowns_length > 1 %}</mj-raw>
@@ -22,7 +22,7 @@
 <mj-text mj-class='font-bold pt-2'>{{ summary.updated_shantytowns_length }} site mis à jour</mj-text>
 <mj-raw>{% endif %}</mj-raw>
 <mj-raw>{% for shantytown in summary.updated_shantytowns %}</mj-raw>
-<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour" class="link">{{ shantytown.usename }}</a></mj-text>
+<mj-text><a href="{{var:frontUrl}}/site/{{shantytown.id}}?{{var:utm}}-site-mis-a-jour" class="link">{{ shantytown.usename }}, {{ shantytown.city }}</a></mj-text>
 <mj-raw>{% endfor %}</mj-raw>
 
 <mj-raw>{% if summary.new_comments_length > 1 %}</mj-raw>
@@ -31,7 +31,7 @@
 <mj-text mj-class='font-bold pt-2'>{{ summary.new_comments_length }} message dans le journal du site</mj-text>
 <mj-raw>{% endif %}</mj-raw>
 <mj-raw>{% for comment in summary.new_comments %}</mj-raw>
-<mj-text><a href="{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}" class="link">{{ comment.shantytownUsename }}</a></mj-text>
+<mj-text><a href="{{var:frontUrl}}/site/{{comment.shantytownId}}?{{var:utm}}-nouveau-message#message{{comment.id}}" class="link">{{ comment.shantytownUsename }}, {{ comment.city }}</a></mj-text>
 <mj-raw>{% endfor %}</mj-raw>
 
 <mj-raw>{% if summary.new_users_length > 1 %}</mj-raw>

--- a/packages/api/server/models/activityModel/get.ts
+++ b/packages/api/server/models/activityModel/get.ts
@@ -15,6 +15,7 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
             activities AS (
             SELECT
                 t."activityType",
+                t."city",
                 t."departement",
                 t."shantytownId",
                 t."shantytownName",
@@ -29,6 +30,7 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
                 (
                 SELECT
                     'new_shantytowns' AS "activityType",
+                    c.name            AS "city",
                     c.fk_departement  AS "departement",
                     s.shantytown_id   AS "shantytownId",
                     s.name            AS "shantytownName",
@@ -49,6 +51,7 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
                 (
                 SELECT
                     'closed_shantytowns' AS "activityType",
+                    c.name               AS "city",
                     c.fk_departement     AS "departement",
                     s.shantytown_id      AS "shantytownId",
                     s.name               AS "shantytownName",
@@ -69,6 +72,7 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
                 (
                 SELECT
                     'updated_shantytowns' AS "activityType",
+                    c.name                AS "city",
                     c.fk_departement      AS "departement",
                     history.shantytown_id AS "shantytownId",
                     shantytowns.name      AS "shantytownName",
@@ -97,6 +101,7 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
                 (
                 SELECT
                     'new_comments'           AS "activityType",
+                    c.name                   AS "city",
                     c.fk_departement         AS "departement",
                     s.shantytown_id          AS "shantytownId",
                     s.name                   AS "shantytownName",
@@ -119,6 +124,7 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
                 (
                 SELECT
                     'new_users'         AS "activityType",
+                    NULL::varchar       AS "city",
                     lo.departement_code AS "departement",
                     NULL::bigint        AS "shantytownId",
                     NULL::varchar       AS "shantytownName",
@@ -228,12 +234,14 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
         if (row.activityType === 'new_comments') {
             summary = {
                 id: row.shantytownCommentId,
+                city: row.city,
                 shantytownId,
                 shantytownUsename: shantytownUsename,
             };
         } else {
             summary = {
                 id: shantytownId,
+                city: row.city,
                 usename: shantytownUsename,
             };
         }

--- a/packages/api/server/models/activityModel/types/ActivityDepartementalSummary.ts
+++ b/packages/api/server/models/activityModel/types/ActivityDepartementalSummary.ts
@@ -1,10 +1,12 @@
 interface ShantytownSummary {
     id: number,
+    city: string,
     usename: string
 }
 
 interface ShantytownCommentSummary {
     id: number,
+    city: string,
     shantytownId: number,
     shantytownUsename: string
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/iO59HLTp/1247

## 🛠 Description de la PR
Rien de spécial, on get la commune dans la requête SQL et on l'affiche dans le mail.

## 📸 Captures d'écran
![Capture d’écran 2021-10-06 à 14 17 49](https://user-images.githubusercontent.com/1801091/136200553-3589ee0a-96db-4a75-a7ec-51df61e52f26.png)
