### PR TITLE
#minor (1254) ajouter un filtre sur la nuance d'accès à l'eau 'A améliorer'

### DIFF
--- a/packages/api/server/models/shantytownModel/_common/getWaterAccessConditions.js
+++ b/packages/api/server/models/shantytownModel/_common/getWaterAccessConditions.js
@@ -1,0 +1,32 @@
+const getWaterHandWashAccessPopulationRatio = require('./getWaterHandWashAccessPopulationRatio');
+
+
+/**
+ * Computes the waterAccessConditions field of the given shantytown
+ * @param {Object} shantytown
+ *
+ * @returns {string || null}
+ */
+module.exports = (shantytown) => {
+    if (shantytown.accessToWater) {
+        const waterHandWashAccessPopulationRatio = getWaterHandWashAccessPopulationRatio(shantytown.populationTotal, shantytown.waterHandWashAccessNumber);
+        if (
+            !shantytown.waterPotable
+            || !shantytown.waterContinuousAccess
+            || !shantytown.waterPublicPoint
+            || !shantytown.waterDistance
+            || shantytown.waterDistance !== '0-20'
+            || shantytown.waterRoadsToCross === null
+            || shantytown.waterRoadsToCross
+            || !shantytown.waterEveryoneHasAccess
+            || shantytown.waterStagnantWater === null
+            || shantytown.waterStagnantWater
+            || !shantytown.waterHandWashAccess
+            || waterHandWashAccessPopulationRatio > 20
+        ) {
+            return 'toImprove';
+        }
+        return 'true';
+    }
+    return shantytown.accessToWater === false ? 'false' : null;
+};

--- a/packages/api/server/models/shantytownModel/_common/getWaterHandWashAccessPopulationRatio.js
+++ b/packages/api/server/models/shantytownModel/_common/getWaterHandWashAccessPopulationRatio.js
@@ -1,0 +1,1 @@
+module.exports = (populationTotal, waterHandWashAccessNumber) => (populationTotal && waterHandWashAccessNumber ? Math.floor(Number(populationTotal) / Number(waterHandWashAccessNumber)) : null);

--- a/packages/api/server/models/shantytownModel/_common/serializeShantytown.js
+++ b/packages/api/server/models/shantytownModel/_common/serializeShantytown.js
@@ -1,5 +1,7 @@
 const getAddressSimpleOf = require('./getAddressSimpleOf');
 const getUsenameOf = require('./getUsenameOf');
+const getWaterAccessConditions = require('./getWaterAccessConditions');
+const getWaterHandWashAccessPopulationRatio = require('./getWaterHandWashAccessPopulationRatio');
 
 function fromDateToTimestamp(date) {
     return date !== null ? (new Date(`${date}T00:00:00`).getTime() / 1000) : null;
@@ -71,6 +73,8 @@ module.exports = (town, permission) => {
         accessToSanitary: town.accessToSanitary,
         sanitaryComments: town.sanitaryComments,
         accessToWater: town.accessToWater,
+        waterAccessConditions: getWaterAccessConditions(town),
+        waterHandWashAccessPopulationRatio: getWaterHandWashAccessPopulationRatio(town.populationTotal, town.waterHandWashAccessNumber),
         waterComments: town.waterComments,
         trashEvacuation: town.trashEvacuation,
         owner: town.owner,

--- a/packages/api/server/models/shantytownModel/_common/serializeShantytown.js
+++ b/packages/api/server/models/shantytownModel/_common/serializeShantytown.js
@@ -1,7 +1,6 @@
 const getAddressSimpleOf = require('./getAddressSimpleOf');
 const getUsenameOf = require('./getUsenameOf');
 const getWaterAccessConditions = require('./getWaterAccessConditions');
-const getWaterHandWashAccessPopulationRatio = require('./getWaterHandWashAccessPopulationRatio');
 
 function fromDateToTimestamp(date) {
     return date !== null ? (new Date(`${date}T00:00:00`).getTime() / 1000) : null;
@@ -74,7 +73,6 @@ module.exports = (town, permission) => {
         sanitaryComments: town.sanitaryComments,
         accessToWater: town.accessToWater,
         waterAccessConditions: getWaterAccessConditions(town),
-        waterHandWashAccessPopulationRatio: getWaterHandWashAccessPopulationRatio(town.populationTotal, town.waterHandWashAccessNumber),
         waterComments: town.waterComments,
         trashEvacuation: town.trashEvacuation,
         owner: town.owner,

--- a/packages/frontend/src/js/app/pages/dashboard/dashboard.js
+++ b/packages/frontend/src/js/app/pages/dashboard/dashboard.js
@@ -81,7 +81,7 @@ export default {
                             icon: { id: "tint", color: "00a0e3" }
                         },
                         {
-                            value: null,
+                            value: "toImprove",
                             label: "A améliorer",
                             checked: true,
                             icon: { id: "tint", color: "ff6f4c" }

--- a/packages/frontend/src/js/app/pages/dashboard/dashboard.js
+++ b/packages/frontend/src/js/app/pages/dashboard/dashboard.js
@@ -73,7 +73,6 @@ export default {
                     faIcon: "tint",
                     label: "Accès à l'eau",
                     id: "waterAccessConditions",
-                    // id: "accessToWater",
                     options: [
                         {
                             value: "true",
@@ -221,7 +220,6 @@ export default {
                                 .map(option => option.value);
                             visibleTowns = visibleTowns.filter(
                                 town =>
-                                    //                                    allowed.indexOf(town.accessToWater) !== -1
                                     allowed.indexOf(
                                         town.waterAccessConditions
                                     ) !== -1

--- a/packages/frontend/src/js/app/pages/dashboard/dashboard.js
+++ b/packages/frontend/src/js/app/pages/dashboard/dashboard.js
@@ -81,6 +81,12 @@ export default {
                             icon: { id: "tint", color: "00a0e3" }
                         },
                         {
+                            value: null,
+                            label: "A améliorer",
+                            checked: true,
+                            icon: { id: "tint", color: "ff6f4c" }
+                        },
+                        {
                             value: false,
                             label: "Non",
                             checked: true,

--- a/packages/frontend/src/js/app/pages/dashboard/dashboard.js
+++ b/packages/frontend/src/js/app/pages/dashboard/dashboard.js
@@ -72,23 +72,23 @@ export default {
                 {
                     faIcon: "tint",
                     label: "Accès à l'eau",
-                    // id: "waterAccessConditions",
-                    id: "accessToWater",
+                    id: "waterAccessConditions",
+                    // id: "accessToWater",
                     options: [
                         {
-                            value: true,
+                            value: "true",
                             label: "Oui",
                             checked: true,
                             icon: { id: "tint", color: "00a0e3" }
                         },
-                        // {
-                        //     value: "toImprove",
-                        //     label: "A améliorer",
-                        //     checked: true,
-                        //     icon: { id: "tint", color: "ff6f4c" }
-                        // },
                         {
-                            value: false,
+                            value: "toImprove",
+                            label: "A améliorer",
+                            checked: true,
+                            icon: { id: "tint", color: "ff6f4c" }
+                        },
+                        {
+                            value: "false",
                             label: "Non",
                             checked: true,
                             icon: { id: "tint-slash", color: "ADB9C9" }
@@ -221,7 +221,10 @@ export default {
                                 .map(option => option.value);
                             visibleTowns = visibleTowns.filter(
                                 town =>
-                                    allowed.indexOf(town.accessToWater) !== -1
+                                    //                                    allowed.indexOf(town.accessToWater) !== -1
+                                    allowed.indexOf(
+                                        town.waterAccessConditions
+                                    ) !== -1
                             );
                         }
                         break;

--- a/packages/frontend/src/js/app/pages/dashboard/dashboard.js
+++ b/packages/frontend/src/js/app/pages/dashboard/dashboard.js
@@ -72,6 +72,7 @@ export default {
                 {
                     faIcon: "tint",
                     label: "Accès à l'eau",
+                    // id: "waterAccessConditions",
                     id: "accessToWater",
                     options: [
                         {
@@ -80,12 +81,12 @@ export default {
                             checked: true,
                             icon: { id: "tint", color: "00a0e3" }
                         },
-                        {
-                            value: "toImprove",
-                            label: "A améliorer",
-                            checked: true,
-                            icon: { id: "tint", color: "ff6f4c" }
-                        },
+                        // {
+                        //     value: "toImprove",
+                        //     label: "A améliorer",
+                        //     checked: true,
+                        //     icon: { id: "tint", color: "ff6f4c" }
+                        // },
                         {
                             value: false,
                             label: "Non",
@@ -211,15 +212,13 @@ export default {
         },
         visibleTowns() {
             let visibleTowns = this.towns;
-
             this.allowedFilters.forEach(filterGroup => {
                 switch (filterGroup.id) {
-                    case "accessToWater":
+                    case "waterAccessConditions":
                         {
                             const allowed = filterGroup.options
                                 .filter(option => option.checked)
                                 .map(option => option.value);
-
                             visibleTowns = visibleTowns.filter(
                                 town =>
                                     allowed.indexOf(town.accessToWater) !== -1


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/C6gzosom

## 🛠 Description de la PR
- Jusqu'à présent, le filtre de l'accès à l'eau sur la carto permettait de visualiser 3 états (Oui  => champ `access_to_water` à `true` ; Non => champ `access_to_water` à `false` ; Inconnu => champ `access_to_water` à `Null`)
On ajoute un état `à améliorer` qui correspond à la valeur `true` dans le champ `access_to_water` + au moins un champ détaillant l'accès à l'eau non renseigné ou avec une valeur correspondant à un aspect à améliorer.

**Côté API:**
- Ajout d'une propriété `waterAccessConditions` à `serializedTown`
- Ajout d'une méthode `getWaterAccessConditions` à `shantyTownsModels`
- Ajout d'une méthode `getWaterHandWashAccessPopulationRatio` à `shantyTownsModels`

**Côté Frontend::**
- Remplacement de `access_to_water` par `waterAccessConditions` pour filtrer le type d'accès à l'eau sur le dashboard 
- Ajout d'une case à cocher `A améliorer` sur le filtre d'accès à l'eau du dashboard
- Remplacement de `access_to_water`par `waterAccessConditions` dans la méthode *computed* `visibleTowns`
- Ajout d'une icône `water-to-improve.png`

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/136931051-95877983-a204-453c-9e0c-894527f66638.png)


## 🚨 Notes pour la mise en production
- Ràs