### PR TITLE
#patch (1269) Ajout permission shantytown_comment.listPrivate au role direct_collaborator

### DIFF
--- a/packages/api/db/migrations/20211013-direct-collaborator-add-shantytown_comment_listPrivate-permission.js
+++ b/packages/api/db/migrations/20211013-direct-collaborator-add-shantytown_comment_listPrivate-permission.js
@@ -1,0 +1,24 @@
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'INSERT INTO permissions(fk_role_regular, fk_entity, fk_feature, allowed, fk_geographic_level) VALUES (\'direct_collaborator\', \'shantytown_comment\', \'listPrivate\', true, \'local\')',
+            {
+                transaction,
+            },
+        ),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            `DELETE FROM permissions 
+             WHERE
+               fk_role_regular = 'direct_collaborator'
+               AND fk_entity = 'shantytown_comment'
+               AND fk_feature = 'listPrivate';`,
+            {
+                transaction,
+            },
+        ),
+    ),
+
+};


### PR DESCRIPTION
## 🛠 Description de la PR
Ajout d'une permission pour que les préféctures et structures avec le role de `direct_collaborator` aient accès aux commentaires privés