### PR TITLE
#minor (1257) débordement constaté sur commentaires de sites

### DIFF
--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsComments.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsComments.vue
@@ -4,7 +4,7 @@
             {{ comments.length }} message{{ comments.length > 1 ? "s" : "" }}
         </div>
         <CommentBlock
-            class="whitespace-pre"
+            class="pre-line"
             v-for="comment in sortedComments"
             :key="comment.id"
             :id="`message${comment.id}`"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/SVMFGvge/XXX

## 🛠 Description de la PR
- Changement de classe pour la zone de commentaire : `whitespace-pre`remplacé par `pre-line`

## 📸 Captures d'écran
Avant:
![image](https://user-images.githubusercontent.com/50863659/137358016-b536a0fb-44f5-4802-bb4d-ca400bd40295.png)

Après:
![image](https://user-images.githubusercontent.com/50863659/137358387-2e7f09ec-ce32-4443-a701-673a6fb6db6b.png)

## 🚨 Notes pour la mise en production
- Ràs