### PR TITLE
#patch (1261) Permettre de chercher des sites par nom d'intervenant

### DIFF
--- a/packages/frontend/src/js/app/components/ui/Form/input/TextInput.vue
+++ b/packages/frontend/src/js/app/components/ui/Form/input/TextInput.vue
@@ -24,6 +24,7 @@
                     v-bind="filteredProps"
                     :class="classes"
                     :data-cy-field="cypressName"
+                    @blur="$emit('blur')"
                 />
                 <InputIcon
                     position="after"
@@ -98,6 +99,12 @@ export default {
         },
         disabled: {
             type: Boolean
+        },
+        inputClasses: {
+            tyoe: Array,
+            default() {
+                return [];
+            }
         }
     },
     computed: {
@@ -109,8 +116,14 @@ export default {
             };
 
             return {
-                state: [...getInputClasses("state", inputOptions)],
-                default: getInputClasses("default", inputOptions)
+                state: [
+                    ...getInputClasses("state", inputOptions),
+                    ...this.inputClasses
+                ],
+                default: [
+                    ...getInputClasses("default", inputOptions),
+                    ...this.inputClasses
+                ]
             }[this.variant];
         }
     },

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -17,6 +17,26 @@
                     :value="filters.location"
                     @blur="handleSearchBlur"
                 />
+                <h1 class="text-display-md text-center mb-4">
+                    ou un intervenant
+                </h1>
+                <div class="searchbox m-auto flex">
+                    <TextInput
+                        v-model="filters.actor"
+                        class="flex-grow"
+                        placeholder="Nom d'un intervenant"
+                        :inputClasses="['rounded-full shadow-sm']"
+                        @blur="handleActorBlur"
+                    />
+                    <div>
+                        <Button
+                            class="rounded-full ml-2"
+                            size="sm"
+                            @click="handleActorBlur"
+                            >Rechercher</Button
+                        >
+                    </div>
+                </div>
             </PrivateContainer>
         </div>
         <PrivateContainer class="pt-10">
@@ -383,6 +403,13 @@
     </PrivateLayout>
 </template>
 
+<style scoped>
+.searchbox {
+    max-width: 530px;
+    min-width: 530px;
+}
+</style>
+
 <script>
 import getSince from "#app/pages/TownsList/getSince";
 import ActivityCard from "#app/components/ActivityCard/ActivityCard.vue";
@@ -477,6 +504,9 @@ export default {
         };
     },
     methods: {
+        handleActorBlur() {
+            this.onChangePage(1);
+        },
         handleSearchBlur(data) {
             this.$trackMatomoEvent("Liste des sites", "Recherche");
 

--- a/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
+++ b/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
@@ -136,9 +136,14 @@ function checkOrigin(shantytown, filters) {
 }
 
 function checkSearch(shantytown, search) {
+    const plainActors = shantytown.actors
+        .map(({ first_name, last_name }) => `${first_name} ${last_name}`)
+        .join(" ");
+
     return (
         !!shantytown.name?.match(new RegExp(search, "ig")) ||
-        !!shantytown.address?.match(new RegExp(search, "ig"))
+        !!shantytown.address?.match(new RegExp(search, "ig")) ||
+        !!plainActors.match(new RegExp(search, "ig"))
     );
 }
 

--- a/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
+++ b/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
@@ -1,92 +1,96 @@
 import { isSolved, isClosed } from "./common/SolvedOrClosed";
 
 export function filterShantytowns(shantytowns, filters) {
-    return shantytowns.filter(shantytown => {
-        if (filters.status === "open" && shantytown.status !== "open") {
-            return false;
-        }
+    return shantytowns
+        .filter(shantytown => {
+            if (filters.status === "open" && shantytown.status !== "open") {
+                return false;
+            }
 
-        if (filters.status === "close" && shantytown.status === "open") {
-            return false;
-        }
+            if (filters.status === "close" && shantytown.status === "open") {
+                return false;
+            }
 
-        if (filters.location && !checkLocation(shantytown, filters)) {
-            return false;
-        }
+            if (filters.location && !checkLocation(shantytown, filters)) {
+                return false;
+            }
 
-        if (
-            !filters.location &&
-            filters.search &&
-            !checkSearch(shantytown, filters.search)
-        ) {
-            return false;
-        }
+            if (
+                !filters.location &&
+                filters.search &&
+                !checkSearch(shantytown, filters.search)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.fieldType.length > 0 &&
-            !checkFieldType(shantytown, filters.fieldType)
-        ) {
-            return false;
-        }
+            if (
+                filters.fieldType.length > 0 &&
+                !checkFieldType(shantytown, filters.fieldType)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.population.length > 0 &&
-            !checkPopulation(shantytown, filters.population)
-        ) {
-            return false;
-        }
+            if (
+                filters.population.length > 0 &&
+                !checkPopulation(shantytown, filters.population)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.justice.length > 0 &&
-            !checkJustice(shantytown, filters.justice)
-        ) {
-            return false;
-        }
+            if (
+                filters.justice.length > 0 &&
+                !checkJustice(shantytown, filters.justice)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.origin.length > 0 &&
-            !checkOrigin(shantytown, filters.origin)
-        ) {
-            return false;
-        }
+            if (
+                filters.origin.length > 0 &&
+                !checkOrigin(shantytown, filters.origin)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.conditions.length > 0 &&
-            !checkConditions(shantytown, filters.conditions)
-        ) {
-            return false;
-        }
+            if (
+                filters.conditions.length > 0 &&
+                !checkConditions(shantytown, filters.conditions)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.closingSolution.length > 0 &&
-            !checkClosingSolutions(shantytown, filters.closingSolution)
-        ) {
-            return false;
-        }
+            if (
+                filters.closingSolution.length > 0 &&
+                !checkClosingSolutions(shantytown, filters.closingSolution)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.solvedOrClosed.length > 0 &&
-            !checkSolvedOrClosed(shantytown, filters.solvedOrClosed)
-        ) {
-            return false;
-        }
+            if (
+                filters.solvedOrClosed.length > 0 &&
+                !checkSolvedOrClosed(shantytown, filters.solvedOrClosed)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.actors.length > 0 &&
-            !checkActors(shantytown, filters.actors)
-        ) {
-            return false;
-        }
+            if (
+                filters.actors.length > 0 &&
+                !checkActors(shantytown, filters.actors)
+            ) {
+                return false;
+            }
 
-        if (
-            filters.target.length > 0 &&
-            !checkTarget(shantytown, filters.target)
-        ) {
-            return false;
-        }
+            if (
+                filters.target.length > 0 &&
+                !checkTarget(shantytown, filters.target)
+            ) {
+                return false;
+            }
 
-        return true;
-    });
+            return true;
+        })
+        .filter(shantytown => {
+            return checkActorSearch(shantytown, filters.actor);
+        });
 }
 
 function checkConditions(shantytown, filters) {
@@ -135,15 +139,21 @@ function checkOrigin(shantytown, filters) {
     return filteredArray.length;
 }
 
-function checkSearch(shantytown, search) {
+function checkActorSearch(shantytown, search) {
     const plainActors = shantytown.actors
-        .map(({ first_name, last_name }) => `${first_name} ${last_name}`)
+        .map(
+            ({ first_name, last_name, organization: { name: org } }) =>
+                `${first_name} ${last_name} ${org}`
+        )
         .join(" ");
 
+    return !!plainActors.match(new RegExp(search, "ig"));
+}
+
+function checkSearch(shantytown, search) {
     return (
         !!shantytown.name?.match(new RegExp(search, "ig")) ||
-        !!shantytown.address?.match(new RegExp(search, "ig")) ||
-        !!plainActors.match(new RegExp(search, "ig"))
+        !!shantytown.address?.match(new RegExp(search, "ig"))
     );
 }
 

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -40,6 +40,7 @@ export default new Vuex.Store({
                 solvedOrClosed: [],
                 status: "open",
                 location: null,
+                actor: "",
                 actors: [],
                 target: [],
                 search: ""


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/7AU9qvQH/1261

## 🛠 Description de la PR
Le changement est facile à lire en revanche grosse réserve personnelle sur cette fonctionnalité.

J'ai mis mes réserves sur Mattermost, que je repartage ici : je pense qu'il manque un travail en terme d'UI pour que cette fonctionnalité soit intéressante. Sachant que le filtre se fait soit par adresse soit par nom d'intervenant avec ce changement, on ne comprend pas pourquoi tel ou tel site ressort et ça crée de la confusion.
Par ailleurs, on n'indique nulle part que rechercher par nom d'intervenant, c'est possible donc probablement incompréhensible pour l'utilisateur lambda et on manque de place dans la barre de recherche pour indiquer ce cas particulier.

## 📸 Captures d'écran
![Capture d’écran 2021-11-02 à 16 42 20](https://user-images.githubusercontent.com/1801091/139880315-f0734e98-a718-4a0f-ac1e-b2fe6a23ae5d.png)