### PR TITLE
#patch (1262) Correction de l'affichage du bandeau "crédits" sur la carte

### DIFF
--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -456,6 +456,7 @@ export default {
          * @returns {undefined}
          */
         setupMapControls() {
+            this.map.attributionControl.setPosition("bottomleft");
             this.setupZoomControl();
             this.setupLayersControl();
             this.setupPrintControl();


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/FZy6nfVh/1262

## 🛠 Description de la PR
En forçant le bandeau d'attribution à se mettre en bas à gauche au lieu de en bas à droite tout se règle tout seul. La raison est que à gauche il n'y a que des contrôles "custom" alors qu'à droite c'est le contrôle natif de zoom.
En mettant le bandeau à gauche, tous les contrôles s'empilent bien et leaflet fait attention par défaut à ce que le zoom n'empiète pas sur l'attribution.

## 📸 Captures d'écran
- sur la carto principale
![Capture d’écran 2021-10-19 à 15 53 10](https://user-images.githubusercontent.com/1801091/137924640-68c4b4c9-4472-48bf-a9d4-4af433948902.png)
- sur la carto d'un site
![Capture d’écran 2021-10-19 à 15 53 16](https://user-images.githubusercontent.com/1801091/137924702-291e4e8a-cf84-43e7-a18b-bf651b517871.png)