### PR TITLE
#patch (1264) Distinguer les sites ouverts des sites fermés sur la cartographie

### DIFF
--- a/packages/frontend/src/css/v1/index.scss
+++ b/packages/frontend/src/css/v1/index.scss
@@ -361,6 +361,17 @@
     display: flex;
     align-items: center;
 
+    &.mapPin--closed {
+        &::before {
+            content: '';
+            position: absolute;
+            box-shadow: 0 0 20px 10px rgba(255, 0, 0, 0.8);
+            width: 100%;
+            height: 100%;
+            left: 50%;
+        }
+    }
+
     .mapPin-wrapper {
       border-radius: 50%;
       flex-shrink: 0;

--- a/packages/frontend/src/css/v1/index.scss
+++ b/packages/frontend/src/css/v1/index.scss
@@ -363,12 +363,19 @@
 
     &.mapPin--closed {
         &::before {
-            content: '';
+            content: "x";
             position: absolute;
-            box-shadow: 0 0 20px 10px rgba(255, 0, 0, 0.8);
-            width: 100%;
-            height: 100%;
-            left: 50%;
+            z-index: 50;
+            right: -20px;
+            top: 0;
+            width: 13px;
+            height: 13px;
+            line-height: 10px;
+            font-size: 1em;
+            background: black;
+            color: white;
+            text-align: center;
+            border-radius: 50%;
         }
     }
 

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -753,7 +753,9 @@ export default {
                 title: address,
                 icon: L.divIcon({
                     className: "leaflet-marker",
-                    html: `<span class="mapPin mapPin--shantytown" ${style}>
+                    html: `<span class="mapPin mapPin--${
+                        town.status === "open" ? "open" : "closed"
+                    } mapPin--shantytown" ${style}>
                         <span class="mapPin-wrapper">
                             <span class="mapPin-water"><img src="${waterImage}" /></span>
                             <span class="mapPin-marker" style="background-color: ${color}"></span>

--- a/packages/frontend/src/js/app/components/quickview/quickview.pug
+++ b/packages/frontend/src/js/app/components/quickview/quickview.pug
@@ -1,7 +1,7 @@
 <div v-bind:class="{ active }">
     <div class="shadow"></div>
 
-    <simplebar class="quickview" ref="quickviewPanel" data-simplebar-auto-hide="false">
+    <simplebar class="quickview" v-bind:class="{ 'quickview--closed': town && town.status !== 'open' }" ref="quickviewPanel" data-simplebar-auto-hide="false">
         <header class="quickview-header" v-if="town">
             <div class="quickview-actions">
                 <button type="button" class="actionButton mr-2" @click="showTown">Voir le site</button>

--- a/packages/frontend/src/js/app/components/quickview/quickview.scss
+++ b/packages/frontend/src/js/app/components/quickview/quickview.scss
@@ -146,6 +146,27 @@
         }
     }
 
+    .quickview {
+        &.quickview--closed {
+            .quickview-header:before {
+                position: absolute;
+                pointer-events: none;
+                content: "";
+                background: linear-gradient(
+                    to left bottom,
+                    transparent 50%,
+                    currentColor 49.8%,
+                    currentColor 50.2%,
+                    transparent 50%
+                );
+                left: 0;
+                right: 0;
+                top: 0;
+                bottom: 0;
+            }
+        }
+    }
+
     .active {
         .shadow {
             visibility: visible;
@@ -156,5 +177,4 @@
             right: 0;
         }
     }
-
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JMD3odGQ/1264

## 🛠 Description de la PR
- en attente de validation côté produit : la demande était de jouer sur l'opacité mais l'effet ne marchait pas bien. J'ai proposé un halo de couleur, puis finalement une petite pastille noire avec une croix dedans. C'est cette dernière que propose cette PR
- ajout d'une ligne qui barre en diagonale la quickview des sites fermés

Note : quand on scrolle sur la quickview d'un site fermé, la barre diagonale ne suit pas. C'est "volontaire" dans le sens où je n'ai pas réussi à faire mieux et que je ne voulais pas passer trop de temps inutilement sur un cas aussi spécifique (et je pense très peu vu).

## 📸 Captures d'écran
- pastille noire :
![Capture d’écran 2021-10-20 à 09 47 38](https://user-images.githubusercontent.com/1801091/138050885-5b51589b-8ef5-47f1-9d62-aeb177acf469.png)
- quickview d'un site fermé :
![Capture d’écran 2021-10-19 à 16 22 20](https://user-images.githubusercontent.com/1801091/137930397-7db9a7c9-c040-410c-a8f7-fd152aad593b.png)