### PR TITLE
#patch (1239) Fix computation of history card date

### DIFF
--- a/packages/frontend/src/js/app/pages/History/History.vue
+++ b/packages/frontend/src/js/app/pages/History/History.vue
@@ -107,10 +107,6 @@ export default {
             ) {
                 const item = this.currentPageItems[i];
                 const date = new Date(item.date * 1000);
-                date.setHours(0);
-                date.setMinutes(0);
-                date.setSeconds(0);
-                date.setMilliseconds(0);
                 const dateStr = `${date.getDate()}${date.getMonth()}${date.getFullYear()}`;
 
                 // si cet item n'est pas à la même date que le précédent on crée un nouveau groupe


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/LOu6ZElY/1239

## 🛠 Description de la PR
Le problème venait du fait que l'on reset l'heure de la date deux fois :
- une première fois en mettant l'heure à 00:00:00:00
- puis une seconde fois en mettant l'heure UTC (important !) à 0, ce qui revenait à retirer deux heures selon notre timezone

La conséquence c'est que aujourd'hui devenait hier. :)

## 📸 Captures d'écran
- Avant :
![Capture d’écran 2021-10-19 à 16 34 47](https://user-images.githubusercontent.com/1801091/137932290-6fcebe18-76e6-4d8a-b25c-903b1053b102.png)
- Après :
![Capture d’écran 2021-10-19 à 16 34 08](https://user-images.githubusercontent.com/1801091/137932203-e6ce465c-cfea-48dc-93a7-fd0cf168fd4b.png)