### PR TITLE
#minor (756) - Modifier les filtres de la liste des sites fermés

### DIFF
--- a/packages/frontend/src/js/app/pages/TownsList/ClosingSolutionsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/ClosingSolutionsList.vue
@@ -39,14 +39,19 @@
 </template>
 
 <script>
+import { get as getConfig } from "#helpers/api/config";
+
 export default {
     props: {
         shantytownClosingSolutions: {
             type: Array
-        },
-        closingSolutions: {
-            type: Array
         }
+    },
+    data() {
+        const { closing_solutions: closingSolutions } = getConfig();
+        return {
+            closingSolutions
+        };
     },
     methods: {
         getClosingSolutionLabel(id) {

--- a/packages/frontend/src/js/app/pages/TownsList/ClosingSolutionsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/ClosingSolutionsList.vue
@@ -1,0 +1,63 @@
+<template>
+    <div>
+        <div
+            v-for="shantytownClosingSolution in shantytownClosingSolutions"
+            :key="shantytownClosingSolution.id"
+        >
+            <div v-if="showClosingSolutionDetails" class="mb-4">
+                <div class="flex items-top customAlign">
+                    <Icon icon="home" class="text-lg" />
+                    <div class="font-bold ml-2">
+                        {{
+                            getClosingSolutionLabel(
+                                shantytownClosingSolution.id
+                            )
+                        }}
+                    </div>
+                </div>
+                <div class="ml-8">
+                    - {{ shantytownClosingSolution.peopleAffected }} personne{{
+                        shantytownClosingSolution.peopleAffected > 1 ? "s" : " "
+                    }}
+                </div>
+                <div
+                    v-if="shantytownClosingSolution.householdsAffected !== null"
+                >
+                    <div class="ml-8">
+                        -
+                        {{ shantytownClosingSolution.householdsAffected }}
+                        ménage{{
+                            shantytownClosingSolution.householdsAffected > 1
+                                ? "s"
+                                : " "
+                        }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        shantytownClosingSolutions: {
+            type: Array
+        },
+        closingSolutions: {
+            type: Array
+        }
+    },
+    methods: {
+        getClosingSolutionLabel(id) {
+            return this.closingSolutions.find(x => x.id === id).label;
+        },
+        showClosingSolutionDetails() {
+            return (
+                this.shantytownClosingSolution.peopleAffected !== null &&
+                this.shantytownClosingSolution.householdsAffected !== null
+            );
+        }
+    }
+};
+</script>

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -122,7 +122,7 @@
                         </div>
                     </div>
                     <!-- third column -->
-                    <div>
+                    <div v-if="showLivingConditionDetails">
                         <div>
                             <TownCardIcon
                                 :value="shantytown.accessToWater"
@@ -355,6 +355,9 @@ export default {
                 this.shantytown.closedAt &&
                 this.shantytown.closedWithSolutions === "yes"
             );
+        },
+        showLivingConditionDetails() {
+            return !(this.isSolved || this.isClosed);
         }
     }
 };

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -43,10 +43,10 @@
                     </div>
                 </div>
                 <!-- Site fermé ou résorbé ? -->
-                <div class="px-6" v-if="this.isClosed">
+                <div class="px-6" v-if="isClosed(shantytown)">
                     Fermé le {{ formatDate(shantytown.closedAt, "d/m/y") }}
                 </div>
-                <div class="px-6" v-else-if="this.isSolved">
+                <div class="px-6" v-else-if="isSolved(shantytown)">
                     Résorbé le {{ formatDate(shantytown.closedAt, "d/m/y") }}
                 </div>
                 <!-- Fin site fermé ou résorbé ? -->
@@ -159,7 +159,7 @@
                         </div>
                     </div>
                     <!-- third column - closed shantytowns -->
-                    <div v-esle>
+                    <div v-else>
                         <ClosingSolutionsList
                             :shantytownClosingSolutions="
                                 shantytown.closingSolutions
@@ -279,6 +279,7 @@ import flagFR from "./assets/fr.png";
 import flagExtraCommunautaires from "./assets/extra-communautaires.png";
 import formatDateSinceActivity from "./formatDateSinceActivity";
 import { formatLivingConditions } from "#app/pages/TownDetails/formatLivingConditions";
+import { isSolved, isClosed } from "./common/SolvedOrClosed";
 
 export default {
     props: {
@@ -333,7 +334,9 @@ export default {
             }
 
             return origin;
-        }
+        },
+        isSolved,
+        isClosed
     },
     computed: {
         isOpen() {
@@ -358,20 +361,8 @@ export default {
                 this.shantytown.updatedAt
             )}`;
         },
-        isClosed() {
-            return (
-                this.shantytown.closedAt &&
-                this.shantytown.closedWithSolutions !== "yes"
-            );
-        },
-        isSolved() {
-            return (
-                this.shantytown.closedAt &&
-                this.shantytown.closedWithSolutions === "yes"
-            );
-        },
         showLivingConditionDetails() {
-            return !(this.isSolved || this.isClosed);
+            return !(isSolved(this.shantytown) || isClosed(this.shantytown));
         }
     }
 };

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -164,7 +164,6 @@
                             :shantytownClosingSolutions="
                                 shantytown.closingSolutions
                             "
-                            :closingSolutions="closingSolutions"
                         ></ClosingSolutionsList>
                     </div>
                     <!-- fourth column -->
@@ -288,9 +287,6 @@ export default {
         },
         hasJusticePermission: {
             type: Boolean
-        },
-        closingSolutions: {
-            type: Array
         }
     },
     data() {

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -92,11 +92,11 @@
                                 <span v-if="shantytown.populationTotal >= 25">
                                     <Icon icon="male" />{{ " " }}</span
                                 >
-                                <span v-if="shantytown.populationTotal >= 75"
-                                    ><Icon icon="male" />{{ " " }}</span
+                                <span v-if="shantytown.populationTotal >= 75">
+                                    <Icon icon="male" />{{ " " }}</span
                                 >
-                                <span v-if="shantytown.populationTotal >= 100"
-                                    ><Icon icon="male"
+                                <span v-if="shantytown.populationTotal >= 100">
+                                    <Icon icon="male"
                                 /></span>
                             </div>
                         </div>
@@ -121,7 +121,7 @@
                             </div>
                         </div>
                     </div>
-                    <!-- third column -->
+                    <!-- third column - open shantytowns -->
                     <div v-if="showLivingConditionDetails">
                         <div>
                             <TownCardIcon
@@ -157,6 +157,15 @@
                                 >prev. incendie</TownCardIcon
                             >
                         </div>
+                    </div>
+                    <!-- third column - closed shantytowns -->
+                    <div v-esle>
+                        <ClosingSolutionsList
+                            :shantytownClosingSolutions="
+                                shantytown.closingSolutions
+                            "
+                            :closingSolutions="closingSolutions"
+                        ></ClosingSolutionsList>
                     </div>
                     <!-- fourth column -->
                     <div v-if="hasJusticePermission">
@@ -264,6 +273,7 @@
 
 <script>
 import TownCardIcon from "./TownCardIcon";
+import ClosingSolutionsList from "./ClosingSolutionsList";
 import flagEU from "./assets/eu.png";
 import flagFR from "./assets/fr.png";
 import flagExtraCommunautaires from "./assets/extra-communautaires.png";
@@ -277,6 +287,9 @@ export default {
         },
         hasJusticePermission: {
             type: Boolean
+        },
+        closingSolutions: {
+            type: Array
         }
     },
     data() {
@@ -286,7 +299,8 @@ export default {
         };
     },
     components: {
-        TownCardIcon
+        TownCardIcon,
+        ClosingSolutionsList
     },
     methods: {
         /**

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -212,6 +212,7 @@
                             ]"
                         />
                         <CustomFilter
+                            v-if="filters.status === 'open'"
                             title="Conditions de vie"
                             class="mr-2 mb-2"
                             :value="filters.conditions"
@@ -256,6 +257,21 @@
                                 </div>
                             </template>
                         </CustomFilter>
+                        <CustomFilter
+                            v-if="filters.status === 'close'"
+                            title="Cause de la fermeture"
+                            class="mr-2 mb-2"
+                            :value="filters.closingSolution"
+                            @input="
+                                val => updateFilters('closingSolution', val)
+                            "
+                            :options="
+                                closingSolutions.map(f => ({
+                                    label: f.label,
+                                    value: f.id
+                                }))
+                            "
+                        />
                         <CustomFilter
                             v-if="hasJusticePermission"
                             title="Procédure judiciaire"
@@ -398,11 +414,13 @@ export default {
     },
     data() {
         const { field_types: fieldTypes } = getConfig();
+        const { closing_solutions: closingSolutions } = getConfig();
         const permission = getPermission("shantytown_justice.access");
 
         return {
             hasJusticePermission: permission !== null,
             fieldTypes,
+            closingSolutions,
             exportIsVisible: false,
             printMode: false,
             sortOptions: {

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -351,7 +351,6 @@
                         :key="shantytown.id"
                         :shantytown="shantytown"
                         :hasJusticePermission="hasJusticePermission"
-                        :closingSolutions="closingSolutions"
                         class="mb-6"
                     />
                     <div

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -452,16 +452,8 @@ export default {
                         label: `Date de fermeture`
                     },
                     {
-                        value: `builtAt`,
-                        label: `Date d'installation`
-                    },
-                    {
                         value: `updatedAt`,
                         label: `Date d'actualisation`
-                    },
-                    {
-                        value: `declaredAt`,
-                        label: `Date de signalement`
                     }
                 ]
             }

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -273,6 +273,23 @@
                             "
                         />
                         <CustomFilter
+                            v-if="filters.status === 'close'"
+                            title="Résorbé / fermé"
+                            class="mr-2 mb-2"
+                            :value="filters.solvedOrClosed"
+                            @input="val => updateFilters('solvedOrClosed', val)"
+                            :options="[
+                                {
+                                    value: 'closed',
+                                    label: 'Fermé'
+                                },
+                                {
+                                    value: 'solved',
+                                    label: 'Résorbé'
+                                }
+                            ]"
+                        />
+                        <CustomFilter
                             v-if="hasJusticePermission"
                             title="Procédure judiciaire"
                             class="mr-2 mb-2"

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -334,6 +334,7 @@
                         :key="shantytown.id"
                         :shantytown="shantytown"
                         :hasJusticePermission="hasJusticePermission"
+                        :closingSolutions="closingSolutions"
                         class="mb-6"
                     />
                     <div

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -479,7 +479,7 @@ export default {
         },
         onClickCloseTab() {
             this.updateFilters("status", "close");
-            this.updateSort("cityName");
+            this.updateSort("closedAt");
         },
         onClickOpenTab() {
             this.updateFilters("status", "open");

--- a/packages/frontend/src/js/app/pages/TownsList/common/SolvedOrClosed.js
+++ b/packages/frontend/src/js/app/pages/TownsList/common/SolvedOrClosed.js
@@ -1,0 +1,7 @@
+export function isClosed(shantytown) {
+    return shantytown.closedAt && shantytown.closedWithSolutions !== "yes";
+}
+
+export function isSolved(shantytown) {
+    return shantytown.closedAt && shantytown.closedWithSolutions === "yes";
+}

--- a/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
+++ b/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
@@ -1,3 +1,5 @@
+import { isSolved, isClosed } from "./common/SolvedOrClosed";
+
 export function filterShantytowns(shantytowns, filters) {
     return shantytowns.filter(shantytown => {
         if (filters.status === "open" && shantytown.status !== "open") {
@@ -58,6 +60,13 @@ export function filterShantytowns(shantytowns, filters) {
         if (
             filters.closingSolution.length > 0 &&
             !checkClosingSolutions(shantytown, filters.closingSolution)
+        ) {
+            return false;
+        }
+
+        if (
+            filters.solvedOrClosed.length > 0 &&
+            !checkSolvedOrClosed(shantytown, filters.solvedOrClosed)
         ) {
             return false;
         }
@@ -210,12 +219,25 @@ function checkJustice(shantytown, filters) {
  */
 function checkClosingSolutions(shantytown, filters) {
     const closingSolutionsIds = shantytown.closingSolutions.map(function(
-        closingSol
+        closingSolution
     ) {
-        return closingSol.id;
+        return closingSolution.id;
     });
 
     return closingSolutionsIds.some(e => filters.includes(e));
+}
+
+/**
+ * Filter on "solved or closed ?"
+ */
+function checkSolvedOrClosed(shantytown, filters) {
+    if (filters.includes("solved") && isSolved(shantytown)) {
+        return true;
+    }
+    if (filters.includes("closed") && isClosed(shantytown)) {
+        return true;
+    }
+    return false;
 }
 
 /**

--- a/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
+++ b/packages/frontend/src/js/app/pages/TownsList/filterShantytowns.js
@@ -56,6 +56,13 @@ export function filterShantytowns(shantytowns, filters) {
         }
 
         if (
+            filters.closingSolution.length > 0 &&
+            !checkClosingSolutions(shantytown, filters.closingSolution)
+        ) {
+            return false;
+        }
+
+        if (
             filters.actors.length > 0 &&
             !checkActors(shantytown, filters.actors)
         ) {
@@ -196,6 +203,19 @@ function checkJustice(shantytown, filters) {
 
         return value === null;
     });
+}
+
+/**
+ * Filter on closing solutions
+ */
+function checkClosingSolutions(shantytown, filters) {
+    const closingSolutionsIds = shantytown.closingSolutions.map(function(
+        closingSol
+    ) {
+        return closingSol.id;
+    });
+
+    return closingSolutionsIds.some(e => filters.includes(e));
 }
 
 /**

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -37,6 +37,7 @@ export default new Vuex.Store({
                 origin: [],
                 conditions: [],
                 closingSolution: [],
+                solvedOrClosed: [],
                 status: "open",
                 location: null,
                 actors: [],

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -36,6 +36,7 @@ export default new Vuex.Store({
                 justice: [],
                 origin: [],
                 conditions: [],
+                closingSolution: [],
                 status: "open",
                 location: null,
                 actors: [],
@@ -127,7 +128,11 @@ export default new Vuex.Store({
         async fetchTowns({ commit }) {
             commit("setLoading", true);
             try {
-                const { user, field_types: fieldTypes } = getConfig();
+                const {
+                    user,
+                    field_types: fieldTypes
+                    // closing_solutions: closingSolutions
+                } = getConfig();
 
                 if (
                     user.organization.location.type !== "nation" &&

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -128,11 +128,7 @@ export default new Vuex.Store({
         async fetchTowns({ commit }) {
             commit("setLoading", true);
             try {
-                const {
-                    user,
-                    field_types: fieldTypes
-                    // closing_solutions: closingSolutions
-                } = getConfig();
+                const { user, field_types: fieldTypes } = getConfig();
 
                 if (
                     user.organization.location.type !== "nation" &&


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/cO6so71N

## 🛠 Description de la PR
- retirer la colonne + le filtre "conditions de vie"
- ajouter la colonne + le filtre "cause de la fermeture"
- dans le tri par "date", conserver "date de fermeture" et "date d'actualisation", par défaut trier par la date de fermeture
- ajouter le filtre "résorbé" vs "fermé"

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/138131428-5fd003b8-b029-4959-a6d8-541f89c12d01.png)


## 🚨 Notes pour la mise en production
- Ràs