### PR TITLE
#minor (1272) Suppression du terme "métropolitaine"

### DIFF
--- a/packages/frontend/src/js/app/components/TownForm/inputs/InputTrashCansOnSite.vue
+++ b/packages/frontend/src/js/app/components/TownForm/inputs/InputTrashCansOnSite.vue
@@ -1,6 +1,6 @@
 <template>
     <SubQuestionWrapper
-        label="Combien de poubelles / benes sont à proximité immédiate du site (moins de 100 mètres) ?"
+        label="Combien de poubelles / bennes sont à proximité immédiate du site (moins de 100 mètres) ?"
         withoutMargin
     >
         <InlineTextInput

--- a/packages/frontend/src/js/app/pages/History/History.vue
+++ b/packages/frontend/src/js/app/pages/History/History.vue
@@ -198,7 +198,7 @@ export default {
 
         getLocationName() {
             if (this.locationType === "nation") {
-                return "France métropolitaine";
+                return "France";
             }
 
             return (

--- a/packages/frontend/src/js/app/pages/OrganizationList/index.vue
+++ b/packages/frontend/src/js/app/pages/OrganizationList/index.vue
@@ -180,7 +180,7 @@ export default {
                 return `« ${searchFilter} »`;
             }
 
-            return `France métropolitaine`;
+            return `France`;
         },
         filteredOrganizations() {
             return this.directoryFilteredItems;

--- a/packages/frontend/src/js/app/pages/PrivateStats/LeftColumn.vue
+++ b/packages/frontend/src/js/app/pages/PrivateStats/LeftColumn.vue
@@ -6,9 +6,7 @@
 
         <div>
             <div>
-                <LeftColumnLink :to="`/statistiques/`"
-                    >France métropolitaine</LeftColumnLink
-                >
+                <LeftColumnLink :to="`/statistiques/`">France</LeftColumnLink>
             </div>
             <div v-for="option in departements" :key="option.code">
                 <LeftColumnLink :to="`/statistiques/${option.code}`"

--- a/packages/frontend/src/js/app/pages/PrivateStats/index.vue
+++ b/packages/frontend/src/js/app/pages/PrivateStats/index.vue
@@ -291,7 +291,7 @@ export default {
                 d => d.code === this.$route.params.code
             );
 
-            return territory || { name: "France métropolitaine" };
+            return territory || { name: "France" };
         },
 
         shantytownsEvolutionData() {

--- a/packages/frontend/src/js/app/pages/PublicStats/index.vue
+++ b/packages/frontend/src/js/app/pages/PublicStats/index.vue
@@ -38,7 +38,7 @@
                     <StatsBlock
                         :title="numberOfDepartements"
                         icon="flag"
-                        subtitle="départements de France métropolitaine"
+                        subtitle="départements de France"
                     />
                     <StatsBlock
                         :title="numberOfNewUsers.total"

--- a/packages/frontend/src/js/app/pages/PublicStats/index.vue
+++ b/packages/frontend/src/js/app/pages/PublicStats/index.vue
@@ -38,7 +38,7 @@
                     <StatsBlock
                         :title="numberOfDepartements"
                         icon="flag"
-                        subtitle="départements de France"
+                        subtitle="départements"
                     />
                     <StatsBlock
                         :title="numberOfNewUsers.total"

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -649,7 +649,7 @@ export default {
                 return `« ${this.filters.search} »`;
             }
 
-            return `France métropolitaine`;
+            return `France`;
         },
         nbPages() {
             return Math.ceil(this.filteredShantytowns.length / PER_PAGE);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/PBh3gaG8

## 🛠 Description de la PR
- Suppression du terme "métropolitaine" dans l'expression "France métropolitaine" affichée sur les pages de stats publiques et privées.

## 📸 Captures d'écran
- Pas de capture (use of fewer resources to conserve energy and the environment) ;-)

## 🚨 Notes pour la mise en production
- Ràs