### PR TITLE
#minor (1271) Ajouter/masquer colonnes dans export sites

### DIFF
--- a/packages/api/db/migrations/20211110-01-insert-owner-permissions.js
+++ b/packages/api/db/migrations/20211110-01-insert-owner-permissions.js
@@ -1,0 +1,48 @@
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'INSERT INTO entities(name) VALUES(\'shantytown_owner\')',
+            {
+                transaction,
+            },
+        )
+            .then(() => queryInterface.sequelize.query(
+                'INSERT INTO features(name, fk_entity) VALUES(\'access\', \'shantytown_owner\')',
+                {
+                    transaction,
+                },
+            ))
+            .then(() => queryInterface.sequelize.query(
+                `INSERT INTO permissions(fk_role_regular, fk_role_admin, fk_entity, fk_feature, allowed, fk_geographic_level)
+                VALUES
+                    (NULL, 'national_admin', 'shantytown_owner', 'access', true, 'nation'),
+                    (NULL, 'local_admin', 'shantytown_owner', 'access', true, 'local'),
+                    ('direct_collaborator', NULL, 'shantytown_owner', 'access', true, 'local')`,
+                {
+                    transaction,
+                },
+            )),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'DELETE FROM permissions WHERE fk_entity = \'shantytown_owner\' AND fk_feature = \'access\' AND (fk_role_regular = \'direct_collaborator\' OR fk_role_admin IN (\'local_admin\', \'national_admin\'))',
+            {
+                transaction,
+            },
+        )
+            .then(() => queryInterface.sequelize.query(
+                'DELETE FROM features WHERE name = \'access\' AND fk_entity = \'shantytown_owner\'',
+                {
+                    transaction,
+                },
+            ))
+            .then(() => queryInterface.sequelize.query(
+                'DELETE FROM entities WHERE name = \'shantytown_owner\'',
+                {
+                    transaction,
+                },
+            )),
+    ),
+
+};

--- a/packages/api/db/seeders/000004-qa-01-users.js
+++ b/packages/api/db/seeders/000004-qa-01-users.js
@@ -187,7 +187,7 @@ const users = [
         organization: {
             name: 'QA intervenant',
             abbreviation: 'QA intervenant',
-            type: 31, // intervenant
+            type: 8, // association
             region: null,
             departement: 33,
             epci: null,

--- a/packages/api/db/seeders/000004-qa-02-shantytowns.js
+++ b/packages/api/db/seeders/000004-qa-02-shantytowns.js
@@ -16,7 +16,8 @@ const shantytowns = [
         address: 'Bordeaux',
         city: '33063', // Bordeaux
         fieldType: 1, // inconnu
-        ownerType: 1, // inconnu
+        ownerType: 2, // privé
+        owner: 'John Doe',
         electricityType: 1, // inconnu
     },
 ];

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -1097,6 +1097,26 @@ module.exports = (models) => {
                     width: COLUMN_WIDTHS.SMALL,
                 },
 
+                // New Fields issue/1271
+                // hasPlan?
+                hasPlan: {
+                    title: 'Le site fait-il l’objet d’un dispositif ?',
+                    data: ({ plans }) => (plans.length > 0 ? 'oui' : 'non'),
+                    width: COLUMN_WIDTHS.SMALL,
+                },
+
+                resorptionTarget: {
+                    title: 'Site avec objectif de résorption ?',
+                    data: ({ resorptionTarget }) => {
+                        if (resorptionTarget === null) {
+                            return null;
+                        }
+
+                        return resorptionTarget;
+                    },
+                    width: COLUMN_WIDTHS.SMALL,
+                },
+
             };
 
             closingSolutions.forEach(({ id: solutionId }) => {
@@ -1157,6 +1177,8 @@ module.exports = (models) => {
                     properties.fieldType,
                     properties.builtAt,
                     properties.declaredAt,
+                    properties.hasPlan,
+                    properties.resorptionTarget,
                 ],
             };
 
@@ -1167,8 +1189,10 @@ module.exports = (models) => {
             }
 
             if (options.indexOf('owner') !== -1) {
-                section.properties.push(properties.ownerType);
-                section.properties.push(properties.owner);
+                if (['local_admin', 'national_admin', 'direct_collaborator'].includes(req.user.role_id)) {
+                    section.properties.push(properties.ownerType);
+                    section.properties.push(properties.owner);
+                }
             }
 
             sections.push(section);

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -1188,11 +1188,9 @@ module.exports = (models) => {
                 section.properties.push(properties.status);
             }
 
-            if (options.indexOf('owner') !== -1) {
-                if (['local_admin', 'national_admin', 'direct_collaborator'].includes(req.user.role_id)) {
-                    section.properties.push(properties.ownerType);
-                    section.properties.push(properties.owner);
-                }
+            if (options.indexOf('owner') !== -1 && req.user.isAllowedTo('access', 'shantytown_owner')) {
+                section.properties.push(properties.ownerType);
+                section.properties.push(properties.owner);
             }
 
             sections.push(section);

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -1097,8 +1097,6 @@ module.exports = (models) => {
                     width: COLUMN_WIDTHS.SMALL,
                 },
 
-                // New Fields issue/1271
-                // hasPlan?
                 hasPlan: {
                     title: 'Le site fait-il l’objet d’un dispositif ?',
                     data: ({ plans }) => (plans.length > 0 ? 'oui' : 'non'),

--- a/packages/api/server/middlewares/validators/common/writeTown.js
+++ b/packages/api/server/middlewares/validators/common/writeTown.js
@@ -233,6 +233,10 @@ module.exports = mode => ([
      ********************************************************************************************* */
     body('owner')
         .customSanitizer((value, { req }) => {
+            if (!req.user.isAllowedTo('access', 'shantytown_owner')) {
+                return null;
+            }
+
             if (!req.body.owner_type_full || req.body.owner_type_full.label === 'Inconnu') {
                 return null;
             }
@@ -240,7 +244,7 @@ module.exports = mode => ([
             return value;
         })
         .optional({ nullable: true })
-        .if((value, { req }) => req.body.owner_type_full && req.body.owner_type_full.label !== 'Inconnu')
+        .if((value, { req }) => req.user.isAllowedTo('access', 'shantytown_owner') && req.body.owner_type_full && req.body.owner_type_full.label !== 'Inconnu')
         .isString().bail().withMessage('Le champ "Identité du propriétaire" est invalide')
         .trim(),
 

--- a/packages/api/server/models/shantytownModel/_common/serializeShantytown.js
+++ b/packages/api/server/models/shantytownModel/_common/serializeShantytown.js
@@ -73,7 +73,6 @@ module.exports = (town, userPermissions) => {
         accessToWater: town.accessToWater,
         waterComments: town.waterComments,
         trashEvacuation: town.trashEvacuation,
-        owner: town.owner,
         censusStatus: town.censusStatus,
         censusConductedBy: town.censusConductedBy,
         censusConductedAt: fromDateToTimestamp(town.censusConductedAt),
@@ -161,6 +160,14 @@ module.exports = (town, userPermissions) => {
             policeRequestedAt: fromDateToTimestamp(town.policeRequestedAt),
             policeGrantedAt: fromDateToTimestamp(town.policeGrantedAt),
             bailiff: town.bailiff,
+        });
+    }
+
+    if (userPermissions.shantytown_owner
+        && userPermissions.shantytown_owner.access
+        && userPermissions.shantytown_owner.access.allowed === true) {
+        Object.assign(serializedTown, {
+            owner: town.owner,
         });
     }
 

--- a/packages/api/server/models/shantytownModel/update.js
+++ b/packages/api/server/models/shantytownModel/update.js
@@ -222,6 +222,7 @@ module.exports = async (editor, shantytownId, data, argTransaction = undefined) 
     ]);
 
     // now, update the shantytown
+    const accessKeys = ['owner'];
     const justiceKeys = [
         'owner_complaint',
         'justice_procedure',
@@ -234,7 +235,7 @@ module.exports = async (editor, shantytownId, data, argTransaction = undefined) 
         'police_granted_at',
         'bailiff',
     ];
-    const { commonData, justiceData } = Object.keys(data).reduce(
+    const { commonData, justiceData, ownerData } = Object.keys(data).reduce(
         (acc, key) => {
             if (['social_origins', 'closing_solutions'].includes(key)) { // ignore social_origins, they are a special case
                 return acc;
@@ -247,6 +248,18 @@ module.exports = async (editor, shantytownId, data, argTransaction = undefined) 
                         ...acc.justiceData,
                         [key]: data[key],
                     },
+                    ownerData: acc.ownerData,
+                };
+            }
+
+            if (accessKeys.includes(key)) {
+                return {
+                    commonData: acc.commonData,
+                    justiceData: acc.justiceData,
+                    ownerData: {
+                        ...acc.ownerData,
+                        [key]: data[key],
+                    },
                 };
             }
 
@@ -256,9 +269,10 @@ module.exports = async (editor, shantytownId, data, argTransaction = undefined) 
                     [key]: data[key],
                 },
                 justiceData: acc.justiceData,
+                ownerData: acc.ownerData,
             };
         },
-        { commonData: {}, justiceData: {} },
+        { commonData: {}, justiceData: {}, ownerData: {} },
     );
 
     const updatedTown = Object.assign(
@@ -269,6 +283,9 @@ module.exports = async (editor, shantytownId, data, argTransaction = undefined) 
         },
         editor.isAllowedTo('access', 'shantytown_justice')
             ? justiceData
+            : {},
+        editor.isAllowedTo('access', 'shantytown_owner')
+            ? ownerData
             : {},
     );
 

--- a/packages/api/server/services/shantytown/create.js
+++ b/packages/api/server/services/shantytown/create.js
@@ -37,7 +37,6 @@ module.exports = async (townData, user) => {
             ownerType: townData.owner_type,
             city: townData.citycode,
             createdBy: user.id,
-            owner: townData.owner,
             declaredAt: townData.declared_at,
             censusStatus: townData.census_status,
             censusConductedAt: townData.census_conducted_at,
@@ -89,6 +88,11 @@ module.exports = async (townData, user) => {
                         policeRequestedAt: townData.police_requested_at,
                         policeGrantedAt: townData.police_granted_at,
                         bailiff: townData.bailiff,
+                    }
+                    : {},
+                user.isAllowedTo('access', 'shantytown_owner')
+                    ? {
+                        owner: townData.owner,
                     }
                     : {},
             ),

--- a/packages/frontend/cypress/fixtures/permissions.js
+++ b/packages/frontend/cypress/fixtures/permissions.js
@@ -5,7 +5,8 @@ const defaultPermissions = {
         create: false,
         close: false,
         readPrivateComments: false,
-        hideJustice: false
+        hideJustice: false,
+        hideOwner: true
     },
     plan: {
         create: false,
@@ -26,7 +27,8 @@ const localAdminPermissions = {
         edit: true,
         create: true,
         close: true,
-        readPrivateComments: true
+        readPrivateComments: true,
+        hideOwner: false
     },
     plan: {
         create: true,
@@ -92,7 +94,8 @@ module.exports = {
                 readOutsideTerritory: true,
                 create: true,
                 close: true,
-                readPrivateComments: true
+                readPrivateComments: true,
+                hideOwner: false
             },
             plan: {
                 ...defaultPermissions.shantytown,
@@ -106,8 +109,7 @@ module.exports = {
             ...defaultPermissions,
             shantytown: {
                 ...defaultPermissions.shantytown,
-                edit: false,
-                hideJustice: true
+                edit: false
             }
         },
         territory: "Gironde"

--- a/packages/frontend/cypress/integration/permissions.spec.js
+++ b/packages/frontend/cypress/integration/permissions.spec.js
@@ -125,6 +125,20 @@ describe("Permissions tests", () => {
                             cy.get("#judicial").should("exist");
                         });
                     }
+
+                    if (userPermissions.shantytown.hideOwner) {
+                        it(`L'utilisateur ${key} ne doit pas pouvoir lire le nom du propriétaire`, () => {
+                            cy.url().should("include", TEST_URL);
+                            cy.get("[data-cy-data='owner']").should(
+                                "not.exist"
+                            );
+                        });
+                    } else {
+                        it(`L'utilisateur ${key} doit pouvoir lire le nom du propriétaire`, () => {
+                            cy.url().should("include", TEST_URL);
+                            cy.get("[data-cy-data='owner']").should("exist");
+                        });
+                    }
                 });
 
                 describe(`L'utilisateur ${key} ne doit voir que certaines informations sur la liste des sites`, () => {

--- a/packages/frontend/src/js/app/components/TownForm/TownForm.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownForm.vue
@@ -62,6 +62,7 @@
                         class="mt-10 townPanelShadow"
                         id="judicial"
                         v-model="town.judicial"
+                        v-if="hasJusticePermission"
                     ></TownFormPanelJudicial>
 
                     <div class="mt-8 text-right italic text-red font-bold">
@@ -99,7 +100,7 @@ import TownFormPanelLivingConditions from "./TownFormPanelLivingConditions";
 import TownFormPanelJudicial from "./TownFormPanelJudicial";
 import TownFormLeftColumn from "./TownFormLeftColumn";
 import TownFormErrorLog from "./TownFormErrorLog";
-import { get as getConfig } from "#helpers/api/config";
+import { get as getConfig, hasPermission } from "#helpers/api/config";
 import { add, edit } from "#helpers/api/town";
 import { notify } from "#helpers/notificationHelper";
 
@@ -316,6 +317,10 @@ export default {
             }
 
             return `/site/${this.data.id}`;
+        },
+
+        hasJusticePermission() {
+            return hasPermission("shantytown_justice.access");
         }
     },
 

--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelCharacteristics.vue
@@ -31,7 +31,7 @@
                 ref="ownerType"
             ></InputOwnerType>
             <InputOwner
-                v-if="!ownerTypeIsUnknown"
+                v-if="!ownerTypeIsUnknown && hasOwnerPermission"
                 v-model="input.owner"
             ></InputOwner>
         </FormParagraph>
@@ -45,6 +45,7 @@ import InputFieldType from "./inputs/InputFieldType.vue";
 import InputDetailedAddress from "./inputs/InputDetailedAddress.vue";
 import InputOwnerType from "./inputs/InputOwnerType.vue";
 import InputOwner from "./inputs/InputOwner.vue";
+import { hasPermission } from "#helpers/api/config";
 
 export default {
     components: {
@@ -65,18 +66,31 @@ export default {
 
     data() {
         return {
+            isMounted: false,
             input: this.value
         };
     },
 
+    mounted() {
+        this.isMounted = true;
+    },
+
     computed: {
         ownerTypeIsUnknown() {
+            if (!this.isMounted) {
+                return true;
+            }
+
             const value = this.input.owner_type;
             if (this.$refs.ownerType === undefined) {
                 return true;
             }
 
             return this.$refs.ownerType.isUnknown(value);
+        },
+
+        hasOwnerPermission() {
+            return hasPermission("shantytown_owner.access");
         }
     }
 };

--- a/packages/frontend/src/js/app/components/export2/Export.vue
+++ b/packages/frontend/src/js/app/components/export2/Export.vue
@@ -68,7 +68,7 @@
 
 <script>
 import { open } from "#helpers/api/main";
-import { get as getConfig, getPermission } from "#helpers/api/config";
+import { getPermission } from "#helpers/api/config";
 import Checkbox from "#app/components/ui/Form/input/Checkbox";
 import { VUE_APP_API_URL } from "#src/js/env.js";
 
@@ -79,9 +79,6 @@ export default {
         closedTowns: Boolean
     },
     data() {
-        const { user } = getConfig();
-        const userRole = user.role_id;
-
         return {
             existingOptions: [
                 {
@@ -135,8 +132,7 @@ export default {
                     }
                 }
             ],
-            options: [],
-            userRole
+            options: []
         };
     },
     computed: {

--- a/packages/frontend/src/js/app/components/export2/Export.vue
+++ b/packages/frontend/src/js/app/components/export2/Export.vue
@@ -68,7 +68,7 @@
 
 <script>
 import { open } from "#helpers/api/main";
-import { getPermission } from "#helpers/api/config";
+import { get as getConfig, getPermission } from "#helpers/api/config";
 import Checkbox from "#app/components/ui/Form/input/Checkbox";
 import { VUE_APP_API_URL } from "#src/js/env.js";
 
@@ -79,6 +79,9 @@ export default {
         closedTowns: Boolean
     },
     data() {
+        const { user } = getConfig();
+        const userRole = user.role_id;
+
         return {
             existingOptions: [
                 {
@@ -128,12 +131,20 @@ export default {
                     }
                 }
             ],
-            options: []
+            options: [],
+            userRole
         };
     },
     computed: {
         title() {
             return this.closedTowns ? "fermés" : "existants";
+        },
+        displayOwnerOption() {
+            return [
+                "national_admin",
+                "local_admin",
+                "direct_collaborator"
+            ].includes(this.userRole);
         },
         availableOptions() {
             return this.existingOptions
@@ -152,7 +163,14 @@ export default {
                             `${permission.entity}.${permission.feature}`
                         ) !== null
                     );
-                });
+                })
+                .filter(option =>
+                    option.id === "owner"
+                        ? this.displayOwnerOption
+                            ? option
+                            : null
+                        : option
+                );
         }
     },
     methods: {

--- a/packages/frontend/src/js/app/components/export2/Export.vue
+++ b/packages/frontend/src/js/app/components/export2/Export.vue
@@ -91,7 +91,11 @@ export default {
                 },
                 {
                     id: "owner",
-                    label: "Propriétaire"
+                    label: "Propriétaire",
+                    permission: {
+                        entity: "shantytown_owner",
+                        feature: "access"
+                    }
                 },
                 {
                     id: "life_conditions",
@@ -139,13 +143,6 @@ export default {
         title() {
             return this.closedTowns ? "fermés" : "existants";
         },
-        displayOwnerOption() {
-            return [
-                "national_admin",
-                "local_admin",
-                "direct_collaborator"
-            ].includes(this.userRole);
-        },
         availableOptions() {
             return this.existingOptions
                 .filter(
@@ -163,14 +160,7 @@ export default {
                             `${permission.entity}.${permission.feature}`
                         ) !== null
                     );
-                })
-                .filter(option =>
-                    option.id === "owner"
-                        ? this.displayOwnerOption
-                            ? option
-                            : null
-                        : option
-                );
+                });
         }
     },
     methods: {

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
@@ -152,11 +152,7 @@ import TownDetailsPanelLivingConditions from "./TownDetailsPanelLivingConditions
 import TownDetailsPanelJudicial from "./TownDetailsPanelJudicial";
 import TownDetailsPanelPlans from "./TownDetailsPanelPlans";
 import TownDetailsPanelActors from "./TownDetailsPanelActors";
-import {
-    get as getConfig,
-    hasPermission,
-    getPermission
-} from "#helpers/api/config";
+import { get as getConfig, getPermission } from "#helpers/api/config";
 import TownDetailsNewComment from "./TownDetailsNewComment";
 import TownDetailsComments from "./TownDetailsComments";
 import TownDetailsNewCommentLeftColumn from "./TownDetailsNewCommentLeftColumn";
@@ -244,7 +240,6 @@ export default {
         this.fetchData();
     },
     methods: {
-        hasPermission,
         openActorThemes(variant = "default") {
             this.actorThemesOpen = true;
             this.actorThemesVariant = variant;

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsLeftColumn.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsLeftColumn.vue
@@ -64,7 +64,6 @@
 
 <script>
 import LeftColumnNavLink from "#app/pages/TownDetails/ui/LeftColumnNavLink";
-import { hasPermission } from "#helpers/api/config";
 
 export default {
     components: { LeftColumnNavLink },
@@ -85,7 +84,6 @@ export default {
         };
     },
     methods: {
-        hasPermission,
         // Force scroll even if hash is already present in url
         scrollFix(to) {
             if (to === this.$route.hash) {

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
@@ -100,7 +100,10 @@
                         </div>
                     </TownDetailsPanelSection>
                     <TownDetailsPanelSection
-                        v-if="town.ownerType.label !== 'Inconnu'"
+                        v-if="
+                            town.ownerType.label !== 'Inconnu' &&
+                                hasPermission('shantytown_owner.access')
+                        "
                     >
                         <div class="grid grid-cols-2">
                             <div class="font-bold">
@@ -178,6 +181,7 @@ import TownDetailsPanelSection from "./ui/TownDetailsPanelSection.vue";
 import formatDateSince from "../TownsList/formatDateSince";
 import { notify } from "#helpers/notificationHelper";
 import { findNearby } from "#helpers/api/town";
+import { hasPermission } from "#helpers/api/config";
 
 export default {
     props: {
@@ -192,6 +196,7 @@ export default {
     },
     components: { TownDetailsPanel, TownDetailsPanelSection, Map },
     methods: {
+        hasPermission,
         goTo(town) {
             if (town.id && town.id !== this.town.id) {
                 this.$router.push(`/site/${town.id}`);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kB3MV39C

## 🛠 Description de la PR
- Ajout de deux propriétés pour l'export des sites:
     - hasPlan: indiquant si le site fait l'objet d'un dispositif
     - resorptionTarget: indiquant si le site fait l'objet d'un objectif de résorption
- Ajout dans le fichier d'export des sites :
     - d'une colonne "Objectifs résorption"
     - d'une colonne "dispositif (oui/non)
- Affichage du choix de l'option "Propriétaire" uniquement pour les utilisateurs ayant le rôle de 
     - administrateur national
     - administrateur local
     - correspondant

## 📸 Captures d'écran
Choix des options avec un rôle **non admin**, **non correspondant**:
![image](https://user-images.githubusercontent.com/50863659/139465837-deead04e-918a-4bd9-b6cc-2f3b5728caff.png)

## 🚨 Notes pour la mise en production
- Ràs