### PR TITLE
#patch (1277) Automatisation des traitements récurrents en BdD : export TB

### DIFF
--- a/packages/api/server/controllers/statsController.js
+++ b/packages/api/server/controllers/statsController.js
@@ -176,14 +176,14 @@ module.exports = models => ({
                 plans,
                 resorbedShantytowns,
                 shantytowns,
-                users] = await Promise.all([
+                users,
+            ] = await Promise.all([
                 models.stats.averageCompletionPercentageByDepartement(),
                 models.stats.numberOfPeopleByDepartement(),
                 models.stats.numberOfPlansByDepartement(),
                 models.stats.numberOfResorbedShantytownByDepartement(),
                 models.stats.numberOfShantytownByDepartement(),
                 models.stats.numberOfUsersByDepartement(),
-
             ]);
 
             const result = Object.values(groupByKey([

--- a/packages/api/server/loaders/routesLoader.js
+++ b/packages/api/server/loaders/routesLoader.js
@@ -566,6 +566,8 @@ module.exports = (app) => {
         '/statistics/export',
         middlewares.auth.authenticate,
         middlewares.auth.isSuperAdmin,
+        middlewares.charte.check,
+        middlewares.appVersion.sync,
         controllers.stats.export,
     );
 

--- a/packages/api/server/loaders/routesLoader.js
+++ b/packages/api/server/loaders/routesLoader.js
@@ -562,6 +562,13 @@ module.exports = (app) => {
         },
     );
 
+    app.get(
+        '/statistics/export',
+        middlewares.auth.authenticate,
+        middlewares.auth.isSuperAdmin,
+        controllers.stats.export,
+    );
+
     app.post(
         '/statistics/directory-views',
         middlewares.auth.authenticate,

--- a/packages/api/server/models/statsModel/_common/averageCompletion.js
+++ b/packages/api/server/models/statsModel/_common/averageCompletion.js
@@ -1,0 +1,42 @@
+
+// Used by averageCompletionPercentage and averageCompletionPercentageByDepartement
+module.exports = departement => `
+    (SELECT
+      c.fk_departement,
+      ((CASE WHEN (SELECT regexp_matches(s.address, '^(.+) [0-9]+ [^,]+,? [0-9]+,? [^, ]+(,.+)?$'))[1] IS NOT NULL THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN ft.label <> 'Inconnu' THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN ot.label <> 'Inconnu' THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN s.census_status IS NOT NULL THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN s.population_total IS NOT NULL THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN s.population_couples IS NOT NULL THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN s.population_minors IS NOT NULL THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN s.population_total IS NOT NULL AND s.population_total >= 10 AND (SELECT COUNT(*) FROM shantytown_origins WHERE fk_shantytown = s.shantytown_id) > 0 THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN et.label <> 'Inconnu' THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN s.access_to_water IS NOT NULL THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN s.access_to_sanitary IS NOT NULL THEN 1 ELSE 0 END)
+      +
+      (CASE WHEN s.trash_evacuation IS NOT NULL THEN 1 ELSE 0 END))::FLOAT / 12.0 AS pourcentage_completion
+    FROM
+      shantytowns s
+    LEFT JOIN
+      cities c ON s.fk_city = c.code
+    LEFT JOIN
+      field_types ft ON s.fk_field_type = ft.field_type_id
+    LEFT JOIN
+      owner_types ot ON s.fk_owner_type = ot.owner_type_id
+    LEFT JOIN
+      electricity_types et ON s.fk_electricity_type = et.electricity_type_id
+    WHERE
+        s.closed_at IS NULL
+        ${departement ? `AND c.fk_departement = '${departement}'` : ''}
+    ) AS tmp`;

--- a/packages/api/server/models/statsModel/averageCompletionPercentage.js
+++ b/packages/api/server/models/statsModel/averageCompletionPercentage.js
@@ -1,49 +1,12 @@
 const { sequelize } = require('#db/models');
+const averageCompletionQuery = require('./_common/averageCompletion');
 
 module.exports = async (departement) => {
     const rows = await sequelize.query(
         `SELECT
             AVG(pourcentage_completion)
         FROM
-        (SELECT
-            c.fk_departement,
-            ((CASE WHEN (SELECT regexp_matches(s.address, '^(.+) [0-9]+ [^,]+,? [0-9]+,? [^, ]+(,.+)?$'))[1] IS NOT NULL THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN ft.label <> 'Inconnu' THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN ot.label <> 'Inconnu' THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN s.census_status IS NOT NULL THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN s.population_total IS NOT NULL THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN s.population_couples IS NOT NULL THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN s.population_minors IS NOT NULL THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN s.population_total IS NOT NULL AND s.population_total >= 10 AND (SELECT COUNT(*) FROM shantytown_origins WHERE fk_shantytown = s.shantytown_id) > 0 THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN et.label <> 'Inconnu' THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN s.access_to_water IS NOT NULL THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN s.access_to_sanitary IS NOT NULL THEN 1 ELSE 0 END)
-            +
-            (CASE WHEN s.trash_evacuation IS NOT NULL THEN 1 ELSE 0 END))::FLOAT / 12.0 AS pourcentage_completion
-        FROM
-            shantytowns s
-        LEFT JOIN
-            cities c ON s.fk_city = c.code
-        LEFT JOIN
-            field_types ft ON s.fk_field_type = ft.field_type_id
-        LEFT JOIN
-            owner_types ot ON s.fk_owner_type = ot.owner_type_id
-        LEFT JOIN
-            electricity_types et ON s.fk_electricity_type = et.electricity_type_id
-        WHERE
-            s.closed_at IS NULL
-            ${departement ? `AND c.fk_departement = '${departement}'` : ''}
-        ) AS tmp
+        ${averageCompletionQuery(departement)}
         `,
         {
             type: sequelize.QueryTypes.SELECT,

--- a/packages/api/server/models/statsModel/averageCompletionPercentageByDepartement.js
+++ b/packages/api/server/models/statsModel/averageCompletionPercentageByDepartement.js
@@ -1,0 +1,14 @@
+const { sequelize } = require('#db/models');
+const averageCompletionQuery = require('./_common/averageCompletion');
+
+module.exports = async () => sequelize.query(
+    `SELECT
+            fk_departement, AVG(pourcentage_completion)
+            FROM
+            ${averageCompletionQuery()}    
+            GROUP BY fk_departement
+            ORDER BY fk_departement`,
+    {
+        type: sequelize.QueryTypes.SELECT,
+    },
+);

--- a/packages/api/server/models/statsModel/index.js
+++ b/packages/api/server/models/statsModel/index.js
@@ -1,4 +1,5 @@
 const averageCompletionPercentage = require('./averageCompletionPercentage');
+const averageCompletionPercentageByDepartement = require('./averageCompletionPercentageByDepartement');
 const meanTimeBeforeClosingDeclaration = require('./meanTimeBeforeClosingDeclaration');
 const meanTimeBeforeCreationDeclaration = require('./meanTimeBeforeCreationDeclaration');
 const numberOfActiveUsers = require('./numberOfActiveUsers');
@@ -12,18 +13,24 @@ const numberOfNewShantytownsPerMonth = require('./numberOfNewShantytownsPerMonth
 const numberOfNewUsersPerMonth = require('./numberOfNewUsersPerMonth');
 const numberOfOpenShantytownsAtMonth = require('./numberOfOpenShantytownsAtMonth');
 const numberOfPeople = require('./numberOfPeople');
+const numberOfPeopleByDepartement = require('./numberOfPeopleByDepartement');
 const numberOfPlans = require('./numberOfPlans');
+const numberOfPlansByDepartement = require('./numberOfPlansByDepartement');
 const numberOfResorbedShantytown = require('./numberOfResorbedShantytown');
+const numberOfResorbedShantytownByDepartement = require('./numberOfResorbedShantytownByDepartement');
 const numberOfResorbedShantytownsPerMonth = require('./numberOfResorbedShantytownsPerMonth');
 const numberOfReviewedComments = require('./numberOfReviewedComments');
 const numberOfShantytown = require('./numberOfShantytown');
+const numberOfShantytownByDepartement = require('./numberOfShantytownByDepartement');
 const numberOfShantytownOperations = require('./numberOfShantytownOperations');
 const numberOfUsers = require('./numberOfUsers');
+const numberOfUsersByDepartement = require('./numberOfUsersByDepartement');
 const numberOfUsersAtMonth = require('./numberOfUsersAtMonth');
 const populationTotal = require('./populationTotal');
 
 module.exports = () => ({
     averageCompletionPercentage,
+    averageCompletionPercentageByDepartement,
     meanTimeBeforeClosingDeclaration,
     meanTimeBeforeCreationDeclaration,
     numberOfActiveUsers,
@@ -37,13 +44,18 @@ module.exports = () => ({
     numberOfNewUsersPerMonth,
     numberOfOpenShantytownsAtMonth,
     numberOfPeople,
+    numberOfPeopleByDepartement,
     numberOfPlans,
+    numberOfPlansByDepartement,
     numberOfResorbedShantytown,
+    numberOfResorbedShantytownByDepartement,
     numberOfResorbedShantytownsPerMonth,
     numberOfReviewedComments,
     numberOfShantytown,
+    numberOfShantytownByDepartement,
     numberOfShantytownOperations,
     numberOfUsers,
+    numberOfUsersByDepartement,
     numberOfUsersAtMonth,
     populationTotal,
 });

--- a/packages/api/server/models/statsModel/numberOfPeopleByDepartement.js
+++ b/packages/api/server/models/statsModel/numberOfPeopleByDepartement.js
@@ -1,0 +1,15 @@
+const { sequelize } = require('#db/models');
+
+module.exports = async () => sequelize.query(
+    `
+        SELECT SUM(population_total) AS total, fk_departement 
+        FROM shantytowns 
+        LEFT JOIN cities AS city ON shantytowns.fk_city = city.code
+        WHERE closed_at IS NULL
+        GROUP BY fk_departement
+        ORDER BY fk_departement
+        `,
+    {
+        type: sequelize.QueryTypes.SELECT,
+    },
+);

--- a/packages/api/server/models/statsModel/numberOfPlansByDepartement.js
+++ b/packages/api/server/models/statsModel/numberOfPlansByDepartement.js
@@ -1,0 +1,15 @@
+const { sequelize } = require('#db/models');
+
+module.exports = async () => sequelize.query(
+    `
+        SELECT COUNT(*) AS total, fk_departement
+        FROM plans2
+        LEFT JOIN plan_departements on plan_departements.fk_plan = plans2.plan_id
+        WHERE closed_at IS NULL
+        GROUP BY fk_departement
+        ORDER BY fk_departement
+        `,
+    {
+        type: sequelize.QueryTypes.SELECT,
+    },
+);

--- a/packages/api/server/models/statsModel/numberOfResorbedShantytownByDepartement.js
+++ b/packages/api/server/models/statsModel/numberOfResorbedShantytownByDepartement.js
@@ -1,0 +1,17 @@
+const { sequelize } = require('#db/models');
+
+module.exports = async () => sequelize.query(
+    `
+        SELECT COUNT(*) AS total, fk_departement
+        FROM shantytowns 
+        LEFT JOIN cities AS city ON shantytowns.fk_city = city.code
+        WHERE closed_at IS NOT NULL
+        AND closed_with_solutions='yes'
+        AND shantytowns.created_at > '2019-01-01'
+        GROUP BY fk_departement
+        ORDER BY fk_departement
+        `,
+    {
+        type: sequelize.QueryTypes.SELECT,
+    },
+);

--- a/packages/api/server/models/statsModel/numberOfShantytownByDepartement.js
+++ b/packages/api/server/models/statsModel/numberOfShantytownByDepartement.js
@@ -1,0 +1,15 @@
+const { sequelize } = require('#db/models');
+
+module.exports = async () => sequelize.query(
+    `
+        SELECT COUNT(*) AS total, fk_departement
+        FROM shantytowns 
+        LEFT JOIN cities AS city ON shantytowns.fk_city = city.code
+        WHERE closed_at IS NULL
+        GROUP BY fk_departement
+        ORDER BY fk_departement
+        `,
+    {
+        type: sequelize.QueryTypes.SELECT,
+    },
+);

--- a/packages/api/server/models/statsModel/numberOfUsersByDepartement.js
+++ b/packages/api/server/models/statsModel/numberOfUsersByDepartement.js
@@ -1,0 +1,15 @@
+const { sequelize } = require('#db/models');
+
+module.exports = async () => sequelize.query(
+    `
+      SELECT COUNT(*), departement_code as fk_departement 
+      FROM users
+      LEFT JOIN localized_organizations on users.fk_organization = localized_organizations.organization_id
+      WHERE fk_status = 'active'
+      GROUP BY fk_departement
+      ORDER BY fk_departement
+        `,
+    {
+        type: sequelize.QueryTypes.SELECT,
+    },
+);

--- a/packages/frontend/src/js/helpers/api/stats.js
+++ b/packages/frontend/src/js/helpers/api/stats.js
@@ -9,4 +9,11 @@ export function all(departement) {
     return getApi(`/stats/${departement ? `${departement}` : ""}`);
 }
 
+/**
+ * GET /users/export
+ */
+export function exportStats() {
+    return getApi("/statistics/export");
+}
+
 export default all;

--- a/packages/frontend/src/js/helpers/api/stats.js
+++ b/packages/frontend/src/js/helpers/api/stats.js
@@ -10,7 +10,7 @@ export function all(departement) {
 }
 
 /**
- * GET /users/export
+ * GET /statistics/export
  */
 export function exportStats() {
     return getApi("/statistics/export");


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/y02qhUSz/1277-automatisation-des-traitements-r%C3%A9currents-en-bdd-export-tb

## 🛠 Description de la PR
Permettre aux admin d'exporter les données du tableau de bord (à minima complétion des sites par territoire) : proposition de reprendre les chiffres clé (habitants, sites, résorption, dispositifs, utilisateurs, complétion)

J'ai mis sur mattermost un exemple du CSV exporté

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/5053593/139864080-58eaab84-3b8b-4f70-8e02-c3823ec86e14.png)