### PR TITLE
#patch (1295) Correction de l'envoi du mail récap' hebdo

### DIFF
--- a/packages/api/server/loaders/agendaJobsLoader.ts
+++ b/packages/api/server/loaders/agendaJobsLoader.ts
@@ -13,10 +13,10 @@ import { sendActivitySummary } from '#server/config';
 export default (agenda) => {
     agenda.define(
         'send_activity_summary',
-        async (job) => {
+        async () => {
             if (sendActivitySummary) {
-                const now = moment().utcOffset(2);
-                await activitySummary.sendAll(now.day(), now.month(), now.year());
+                const now = moment().utcOffset(2).subtract(7, 'days');
+                await activitySummary.sendAll(now.date(), now.month(), now.year());
             }
         }
     );


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/iCjHOQPK/1295

## 🛠 Description de la PR
La date générée automatiquement pour le récap hebdo était incorrecte à deux égards :
1. le job agenda demandait à envoyer un récap pour la semaine courante au lieu de la semaine passée !
2. la date générée était de toute façon invalide car au lieu du jour, c'était le numéro du jour dans la semaine qui était utilisé (le lundi étant le 1, on demandait systématiquement l'envoi du récap pour le 1/MM/YYYY)