### PR TITLE
#patch (1292) corrige le bouton "Définir comme intervenant"

### DIFF
--- a/packages/api/server/controllers/userController.js
+++ b/packages/api/server/controllers/userController.js
@@ -998,4 +998,27 @@ module.exports = models => ({
 
         return res.status(200).send({});
     },
+
+    /**
+     * Set user's role_regular
+     */
+    async setUserRoleRegular(req, res, next) {
+        const { roleregular } = req.body;
+        try {
+            const user = await models.user.findOne(req.params.id);
+            if (user && user.role !== 'Intervenant') {
+                await models.user.setUserRoleRegular(req.params.id, roleregular.id);
+            }
+        } catch (error) {
+            res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la mise à jour de l\'utilisateur',
+                    developer_message: error.message,
+                },
+            });
+            return next(error);
+        }
+
+        return res.status(200).send({});
+    },
 });

--- a/packages/api/server/loaders/expressLoader.js
+++ b/packages/api/server/loaders/expressLoader.js
@@ -28,7 +28,7 @@ function asyncHandler(fn) {
 function asyncExpress() {
     const app = express();
 
-    const methods = ['get', 'post', 'put', 'delete'];
+    const methods = ['get', 'post', 'put', 'delete', 'patch'];
     methods.forEach((methodName) => {
         const originalMethod = app[methodName];
         app[methodName] = (...args) => {

--- a/packages/api/server/loaders/routesLoader.js
+++ b/packages/api/server/loaders/routesLoader.js
@@ -111,6 +111,34 @@ module.exports = (app) => {
         middlewares.validation,
         controllers.user.create,
     );
+    app.patch(
+        '/users/:id',
+        middlewares.auth.authenticate,
+        middlewares.auth.isSuperAdmin,
+        middlewares.charte.check,
+        middlewares.appVersion.sync,
+        validators.setUserRoleRegular,
+        middlewares.validation,
+        async (req, res, next) => {
+            // parse body to check the requested operation
+            let controller;
+            switch (req.body.operation) {
+                case 'replace':
+                    switch (req.body.path) {
+                        case '/set_user_role_regular':
+                            controller = controllers.user.setUserRoleRegular;
+                            break;
+                        default:
+                            return res.status(404).send({});
+                    }
+                    break;
+                default:
+                    return res.status(404).send({});
+            }
+            // route to proper controller
+            return controller(req, res, next);
+        },
+    );
     app.post(
         '/contact',
         validators.createContact,

--- a/packages/api/server/middlewares/validators/index.js
+++ b/packages/api/server/middlewares/validators/index.js
@@ -14,6 +14,7 @@ const createShantytownComment = require('./shantytownComment/create');
 const activityList = require('./activity/list');
 const findNearbyTowns = require('./findNearbyTowns');
 const setUserAdminComments = require('./setUserAdminComments');
+const setUserRoleRegular = require('./setUserRoleRegular');
 
 module.exports = {
     closeTown,
@@ -38,4 +39,5 @@ module.exports = {
         list: activityList,
     },
     setUserAdminComments,
+    setUserRoleRegular,
 };

--- a/packages/api/server/middlewares/validators/setUserRoleRegular.js
+++ b/packages/api/server/middlewares/validators/setUserRoleRegular.js
@@ -1,0 +1,49 @@
+/* eslint-disable newline-per-chained-call */
+const { body, param } = require('express-validator');
+const { sequelize } = require('#db/models');
+const roleModel = require('#server/models/roleModel')(sequelize);
+const userModel = require('#server/models/userModel')(sequelize);
+
+module.exports = [
+    param('id')
+        .toInt()
+        .isInt().bail().withMessage('L\'identifiant de l\'utilisateur est invalide')
+        .custom(async (value, { req }) => {
+            let user;
+            try {
+                user = await userModel.findOne(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la recherche de l\'utilisateur en base de données');
+            }
+
+            if (user === null) {
+                throw new Error('L\'utilisateur à mettre à jour est introuvable en base de données');
+            }
+
+            if (user.role === req.body.rolename) {
+                throw new Error('Cet utilisateur a déjà le rôle qu\'on souhaite lui assigner');
+            }
+
+            return true;
+        }),
+    body('rolename')
+        .custom(async (value, { req }) => {
+            let regular_role;
+            try {
+                regular_role = await roleModel.findOneByName(value);
+            } catch (error) {
+                throw new Error('Impossible de retrouver le rôle concerné en base de données');
+            }
+
+            if (regular_role === null) {
+                throw new Error('Le rôle associé à l\'utilisateur n\'existe pas');
+            }
+
+            if (regular_role.type !== 'regular') {
+                throw new Error('Le rôle associé à l\'utilisateur n\'est pas autorisé');
+            }
+
+            req.body.roleregular = regular_role;
+            return true;
+        }),
+];

--- a/packages/api/server/models/roleModel/findOneByName.js
+++ b/packages/api/server/models/roleModel/findOneByName.js
@@ -1,0 +1,22 @@
+const { sequelize } = require('#db/models');
+
+module.exports = async (name) => {
+    const role = await sequelize.query(
+        `SELECT
+            roles.role_id AS id,
+            roles.name AS "name",
+            roles.type AS type
+        FROM
+            roles
+        WHERE 
+            UPPER(name) = UPPER(:name)`,
+        {
+            type: sequelize.QueryTypes.SELECT,
+            replacements: {
+                name,
+            },
+        },
+    );
+
+    return role.length > 0 ? role[0] : null;
+};

--- a/packages/api/server/models/roleModel/index.js
+++ b/packages/api/server/models/roleModel/index.js
@@ -1,7 +1,9 @@
 const findAll = require('./findAll');
 const findOne = require('./findOne');
+const findOneByName = require('./findOneByName');
 
 module.exports = () => ({
     findAll,
     findOne,
+    findOneByName,
 });

--- a/packages/api/server/models/userModel/index.js
+++ b/packages/api/server/models/userModel/index.js
@@ -22,6 +22,7 @@ const listExport = require('./listExport');
 const setPermissionOptions = require('./setPermissionOptions');
 const update = require('./update');
 const upgradeLocalAdmin = require('./upgradeLocalAdmin');
+const setUserRoleRegular = require('./setUserRoleRegular');
 
 module.exports = () => ({
     create,
@@ -48,4 +49,5 @@ module.exports = () => ({
     setPermissionOptions,
     update,
     upgradeLocalAdmin,
+    setUserRoleRegular,
 });

--- a/packages/api/server/models/userModel/setUserRoleRegular.js
+++ b/packages/api/server/models/userModel/setUserRoleRegular.js
@@ -1,0 +1,18 @@
+const { sequelize } = require('#db/models');
+
+module.exports = async (userId, roleRegular) => {
+    await sequelize.query(
+        `UPDATE 
+            USERS 
+        SET
+            fk_role_regular = :roleRegular
+        WHERE
+            user_id = :userId`,
+        {
+            replacements: {
+                userId,
+                roleRegular,
+            },
+        },
+    );
+};

--- a/packages/frontend/src/js/app/pages/UserValidate/index.vue
+++ b/packages/frontend/src/js/app/pages/UserValidate/index.vue
@@ -58,7 +58,7 @@
                         "
                         class="mr-4"
                         variant="primaryText"
-                        @click="setIntervenant"
+                        @click="setRoleRegularAsIntervenant"
                         :loading="validation.loading === 'intervenant'"
                         >Définir comme « Intervenant »</Button
                     >
@@ -183,9 +183,9 @@ import {
     get,
     remove,
     sendActivationLink,
-    updateLocalAdmin
+    updateLocalAdmin,
+    setUserRoleRegular
 } from "#helpers/api/user";
-import { update as updateOrganization } from "#helpers/api/organization";
 import { notify } from "#helpers/notificationHelper";
 
 let permissions;
@@ -507,7 +507,7 @@ export default {
             this.validation.loading = null;
         },
 
-        async setIntervenant() {
+        async setRoleRegularAsIntervenant() {
             if (this.validation.loading) {
                 return;
             }
@@ -515,7 +515,7 @@ export default {
             // eslint-disable-next-line no-alert
             if (
                 !window.confirm(
-                    "Êtes-vous sûr de vouloir accorder le statut d'intervenant à cet utilisateur et à tous les membres de la structure ?"
+                    "Êtes-vous sûr de vouloir accorder le statut d'intervenant à cet utilisateur ?"
                 )
             ) {
                 return;
@@ -525,9 +525,7 @@ export default {
             this.validation.error = null;
 
             try {
-                await updateOrganization(this.user.organization.id, {
-                    intervenant: true
-                });
+                await setUserRoleRegular(this.$route.params.id, "intervenant");
                 window.location.reload();
             } catch ({ user_message: error }) {
                 this.validation.error = error;

--- a/packages/frontend/src/js/helpers/api/user.js
+++ b/packages/frontend/src/js/helpers/api/user.js
@@ -1,5 +1,11 @@
 import { unload as unloadConfig } from "#helpers/api/config";
-import { postApi, putApi, getApi, deleteApi } from "#helpers/api/main";
+import {
+    postApi,
+    putApi,
+    patchApi,
+    getApi,
+    deleteApi
+} from "#helpers/api/main";
 
 /**
  * Sends a login request for the given user
@@ -238,6 +244,17 @@ export function acceptCharte(
 export function setAdminComments(userId, comment) {
     return putApi(`/users/${userId}/admin_comments`, {
         comment
+    });
+}
+
+/**
+ * PATCH /users/:id
+ */
+export async function setUserRoleRegular(userId, rolename) {
+    return patchApi(`/users/${userId}`, {
+        operation: "replace",
+        path: "/set_user_role_regular",
+        rolename
     });
 }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/l4cJC9kj

## 🛠 Description de la PR
**Côté API**
 - ajout d'une méthode `setUserRoleRegular` à `userModel`
- ajout d'une méthode `findOneByName` à `roleModel`
- Ajout d'un fichiers de règles de validation `setUserRoleRegular` avant la mise à jour du champ `role_regular`de l'entité `user`
      - Vérifie que l'identifiant de l'utilisateur correspond bien à un enregistrement de la table `users`
      - Vérifie que le rôle à assigner n'est pas déjà celui de l'utilisateur à mettre à jour
- Ajout d'une méthode `patch(/users/:id)` aux routes
 
**Côté Frontend**
- Ajout d'une méthode `PATCH` `setUserRoleRegular` au API helper `users`
- la méthode `setIntervenant` a été renommée `setRoleRegularAsIntervenant` et implémenter de façon à mettre à jour le `regular_role`du `user`et non plus de l'`organization` à laquelle il/elle appartient.

## 🚨 Notes pour la mise en production
- Ràs