### PR TITLE
#patch (1299) Création du profil de droit 'Observateur externe'

### DIFF
--- a/packages/api/db/migrations/20211206-insert-table-roles_regular-add-external_observator.js
+++ b/packages/api/db/migrations/20211206-insert-table-roles_regular-add-external_observator.js
@@ -1,0 +1,85 @@
+const permissions = {
+    roles_regular: {
+        external_observator: {
+            shantytown: {
+                list: { level: 'local', data: { data_justice: false } },
+                read: { level: 'local', data: { data_justice: false } },
+            },
+            plan: {
+                list: { level: 'local', data: { data_finances: false } },
+                read: { level: 'local', data: { data_finances: false } },
+            },
+            shantytown_comment: {
+                list: { level: 'local', data: {} },
+            },
+            covid_comment: {
+                list: { level: 'local', data: {} },
+            },
+        },
+    },
+};
+
+module.exports = {
+
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.bulkInsert(
+            'roles_regular',
+            [
+                { role_id: 'external_observator', name: 'Observateur externe' },
+            ],
+            { transaction },
+        )
+            .then(async () => {
+                const p = Object.keys(permissions).reduce((promises, roleType) => {
+                    Object.keys(permissions[roleType]).forEach((roleId) => {
+                        Object.keys(permissions[roleType][roleId]).forEach((entity) => {
+                            Object.keys(permissions[roleType][roleId][entity]).forEach((feature) => {
+                                promises.push(
+                                    queryInterface.sequelize.query(
+                                        `INSERT INTO
+                                            permissions(fk_role_admin, fk_role_regular, fk_feature, fk_entity, allowed, fk_geographic_level)
+                                        VALUES
+                                            (:adminId, :regularId, :feature, :entity, TRUE, :level)
+                                        RETURNING permission_id`,
+                                        {
+                                            transaction,
+                                            replacements: {
+                                                adminId: roleType === 'roles_admin' ? roleId : null,
+                                                regularId: roleType === 'roles_regular' ? roleId : null,
+                                                feature,
+                                                entity,
+                                                level: permissions[roleType][roleId][entity][feature].level,
+                                            },
+                                        },
+                                    ),
+                                );
+                            });
+                        });
+                    });
+
+                    return promises;
+                }, []);
+
+                return Promise.all(p);
+            }),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.bulkDelete(
+            'permissions',
+            {
+                fk_role_regular: 'external_observator',
+            },
+            {
+                transaction,
+            },
+        )
+            .then(() => queryInterface.bulkDelete(
+                'roles_regular',
+                [
+                    { role_id: 'external_observator', name: 'Observateur externe' },
+                ],
+                { transaction },
+            )),
+    ),
+};

--- a/packages/api/db/migrations/20211206-insert-table-roles_regular-add-external_observator.js
+++ b/packages/api/db/migrations/20211206-insert-table-roles_regular-add-external_observator.js
@@ -1,24 +1,19 @@
 const permissions = {
-    roles_regular: {
-        external_observator: {
-            shantytown: {
-                list: { level: 'local', data: { data_justice: false } },
-                read: { level: 'local', data: { data_justice: false } },
-            },
-            plan: {
-                list: { level: 'local', data: { data_finances: false } },
-                read: { level: 'local', data: { data_finances: false } },
-            },
-            shantytown_comment: {
-                list: { level: 'local', data: {} },
-            },
-            covid_comment: {
-                list: { level: 'local', data: {} },
-            },
-        },
+    shantytown: {
+        list: { level: 'local' },
+        read: { level: 'local' },
+    },
+    plan: {
+        list: { level: 'local' },
+        read: { level: 'local' },
+    },
+    shantytown_comment: {
+        list: { level: 'local' },
+    },
+    covid_comment: {
+        list: { level: 'local' },
     },
 };
-
 module.exports = {
 
     up: queryInterface => queryInterface.sequelize.transaction(
@@ -30,31 +25,25 @@ module.exports = {
             { transaction },
         )
             .then(async () => {
-                const p = Object.keys(permissions).reduce((promises, roleType) => {
-                    Object.keys(permissions[roleType]).forEach((roleId) => {
-                        Object.keys(permissions[roleType][roleId]).forEach((entity) => {
-                            Object.keys(permissions[roleType][roleId][entity]).forEach((feature) => {
-                                promises.push(
-                                    queryInterface.sequelize.query(
-                                        `INSERT INTO
-                                            permissions(fk_role_admin, fk_role_regular, fk_feature, fk_entity, allowed, fk_geographic_level)
+                const p = Object.keys(permissions).reduce((promises, entity) => {
+                    Object.keys(permissions[entity]).forEach((feature) => {
+                        promises.push(
+                            queryInterface.sequelize.query(
+                                `INSERT INTO
+                                            permissions(fk_role_regular, fk_feature, fk_entity, allowed, fk_geographic_level)
                                         VALUES
-                                            (:adminId, :regularId, :feature, :entity, TRUE, :level)
+                                            ('external_observator', :feature, :entity, TRUE, :level)
                                         RETURNING permission_id`,
-                                        {
-                                            transaction,
-                                            replacements: {
-                                                adminId: roleType === 'roles_admin' ? roleId : null,
-                                                regularId: roleType === 'roles_regular' ? roleId : null,
-                                                feature,
-                                                entity,
-                                                level: permissions[roleType][roleId][entity][feature].level,
-                                            },
-                                        },
-                                    ),
-                                );
-                            });
-                        });
+                                {
+                                    transaction,
+                                    replacements: {
+                                        feature,
+                                        entity,
+                                        level: permissions[entity][feature].level,
+                                    },
+                                },
+                            ),
+                        );
                     });
 
                     return promises;

--- a/packages/api/db/migrations/20211214-delete-permission-create-shantytown-association.js
+++ b/packages/api/db/migrations/20211214-delete-permission-create-shantytown-association.js
@@ -1,0 +1,22 @@
+module.exports = {
+
+    up: queryInterface => queryInterface.bulkDelete(
+        'permissions',
+        {
+            fk_role_regular: 'association',
+            fk_feature: 'create',
+            fk_entity: 'shantytown',
+        },
+    ),
+
+    down: queryInterface => queryInterface.bulkInsert(
+        'permissions',
+        [{
+            fk_role_regular: 'association',
+            fk_feature: 'create',
+            fk_entity: 'shantytown',
+            allowed: true,
+            fk_geographic_level: 'local',
+        }],
+    ),
+};

--- a/packages/api/db/seeders/000004-qa-01-users.js
+++ b/packages/api/db/seeders/000004-qa-01-users.js
@@ -253,6 +253,20 @@ const users = [
         },
         options: [],
     },
+    {
+        user: generate({
+            email: 'qa-external-observator@resorption-bidonvilles.beta.gouv.fr',
+            password: 'fabnum',
+            first_name: 'QA',
+            last_name: 'external observator',
+            fk_role: null,
+            phone: '00 00 00 00 00',
+            position: 'qa',
+            fk_role_regular: 'external_observator',
+        }),
+        organization: 40760, // dihal
+        options: [],
+    },
 ];
 
 module.exports = {

--- a/packages/api/db/seeders/000004-qa-01-users.js
+++ b/packages/api/db/seeders/000004-qa-01-users.js
@@ -170,7 +170,7 @@ const users = [
             position: 'qa',
             fk_role_regular: 'direct_collaborator',
         }),
-        organization: 31, // Prefecture de département gironde
+        organization: 'Préfecture de département - Gironde',
         options: [],
     },
     {
@@ -206,7 +206,7 @@ const users = [
             position: 'qa',
             fk_role_regular: 'national_establisment',
         }),
-        organization: 40760, // dihal
+        organization: 'Délégation Interministérielle à l\'Hébergement et à l\'Accès au Logement',
         options: [],
     },
     {
@@ -264,7 +264,15 @@ const users = [
             position: 'qa',
             fk_role_regular: 'external_observator',
         }),
-        organization: 40760, // dihal
+        organization: {
+            name: 'QA external_observator',
+            abbreviation: 'QA external_observator',
+            type: 8, // association
+            region: null,
+            departement: 33,
+            epci: null,
+            city: null,
+        },
         options: [],
     },
 ];
@@ -276,6 +284,17 @@ module.exports = {
             if (typeof user.organization === 'object') {
                 const [[{ id }]] = await create(user.organization.name, user.organization.abbreviation, user.organization.type, user.organization.region, user.organization.departement, user.organization.epci, user.organization.city, true);
                 fk_organization = id;
+            } else if (typeof user.organization === 'string') {
+                const [[{ organization_id }]] = await queryInterface.sequelize.query(
+                    `SELECT organization_id from organizations
+                    WHERE name = :organization_name;`,
+                    {
+                        replacements: {
+                            organization_name: user.organization,
+                        },
+                    },
+                );
+                fk_organization = organization_id;
             } else {
                 fk_organization = user.organization;
             }

--- a/packages/api/server/permissions_description.js
+++ b/packages/api/server/permissions_description.js
@@ -89,6 +89,15 @@ module.exports = {
             { id: 'hide_justice', label: 'Masquer les procédures judiciaires' },
         ],
     },
+    external_observator: {
+        description: 'L\'accès observateur externe permet à l\'utilisateur de connaître la situation d\'un site et d\'accéder aux informations des dispositifs',
+        national_permissions: [],
+        local_permissions: [
+            [{ type: 'view', label: 'Consulter les %sites%', comments: null }],
+            [{ type: 'view', label: 'Consulter les %dispositifs%', comments: null }],
+        ],
+        options: [],
+    },
     local_admin: {
         description: '',
         national_permissions: [],

--- a/packages/frontend/cypress/fixtures/permissions.js
+++ b/packages/frontend/cypress/fixtures/permissions.js
@@ -164,6 +164,6 @@ module.exports = {
                 hideJustice: true
             }
         },
-        territory: "National"
+        territory: "Gironde"
     }
 };

--- a/packages/frontend/cypress/fixtures/permissions.js
+++ b/packages/frontend/cypress/fixtures/permissions.js
@@ -154,5 +154,16 @@ module.exports = {
             }
         },
         territory: "Bordeaux"
+    },
+    externalObservator: {
+        permissions: {
+            ...defaultPermissions,
+            shantytown: {
+                ...defaultPermissions.shantytown,
+                edit: false,
+                hideJustice: true
+            }
+        },
+        territory: "National"
     }
 };

--- a/packages/frontend/cypress/fixtures/users.json
+++ b/packages/frontend/cypress/fixtures/users.json
@@ -46,5 +46,9 @@
     "nationalAdmin": {
         "email": "qa-national-admin@resorption-bidonvilles.beta.gouv.fr",
         "password": "fabnum"
+    },
+    "externalObservator": {
+        "email": "qa-external-observator@resorption-bidonvilles.beta.gouv.fr",
+        "password": "fabnum"
     }
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/cmGaCddP/1299-cr%C3%A9ation-dun-nouveau-profil-de-droits-r%C3%B4le

## 🛠 Description de la PR
-Création d'une migration ajoutant une ligne dans la table roles-regular correspondant au nouveau profil de droit 'Observateur externe'
Dans la même migration, ajout des permissions correspondantes 

-Affichage des paramètres d'accès pour un utilisateur ayant le rôle 'Observateur externe'.
## 📸 Captures d'écran
<img width="831" alt="Capture d’écran 2021-12-06 à 14 07 43" src="https://user-images.githubusercontent.com/94321132/144851425-fa335332-6668-45cd-adcc-b6476630e6d9.png">

## 🚨 Notes pour la mise en production
Migration à faire tourner