### PR TITLE
#patch (1305) Correction du bug d'accès à la page d'un dispositif

### DIFF
--- a/packages/frontend/src/js/helpers/tabHelper.js
+++ b/packages/frontend/src/js/helpers/tabHelper.js
@@ -4,8 +4,7 @@ export function open(url) {
     if (tab === null || tab.closed) {
         tab = window.open(url, "_blank");
     } else {
-        tab.location = url;
-        tab.location.reload();
+        tab.location.assign(url);
         tab.focus();
     }
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/HeVoxheu/1305-bug-sur-la-page-des-dispositifs-pour-acc%C3%A9der-%C3%A0-la-page-dun-dispositif

## 🛠 Description de la PR
Lorsqu'une seconde fenêtre affichant un dispositif est déjà ouverte, et que l'on clique sur un autre dispositif sur la première page, la seconde est désormais bien actualisée avec le nouveau dispositif.

## 📸 Captures d'écran


## 🚨 Notes pour la mise en production
