### PR TITLE
#patch (1307) L'historique de modification d'un site n'affiche pas correctement les changements sur le champ "Origines"

### DIFF
--- a/packages/api/server/models/shantytownModel/_common/query.js
+++ b/packages/api/server/models/shantytownModel/_common/query.js
@@ -18,18 +18,18 @@ function getBaseSql(table, whereClause = null, order = null) {
     return `
         WITH
             shantytown_computed_origins AS (SELECT
-                shantytown_id AS fk_shantytown,
+                s.${tables.origin_foreign_key} AS fk_shantytown,
                 string_to_array(array_to_string(array_agg(soo.social_origin_id::VARCHAR || '|' || soo.label), ','), ',') AS origins
             FROM "${tables.shantytowns}" s
             LEFT JOIN "${tables.shantytown_origins}" so ON so.fk_shantytown = s.${tables.origin_foreign_key}
             LEFT JOIN social_origins soo ON so.fk_social_origin = soo.social_origin_id
-            GROUP BY s.shantytown_id)
+            GROUP BY s.${tables.origin_foreign_key})
         SELECT
             ${Object.keys(SQL.selection).map(key => `${key} AS "${SQL.selection[key]}"`).join(',')},
             sco.origins AS "socialOrigins"
         FROM "${tables.shantytowns}" AS shantytowns
         ${SQL.joins.map(({ table: t, on }) => `LEFT JOIN ${t} ON ${on}`).join('\n')}
-        LEFT JOIN shantytown_computed_origins sco ON sco.fk_shantytown = shantytowns.shantytown_id
+        LEFT JOIN shantytown_computed_origins sco ON sco.fk_shantytown = shantytowns.${tables.origin_foreign_key}
         ${whereClause !== null ? `WHERE ${whereClause}` : ''}
         ${order !== null ? `ORDER BY ${order}` : ''}
     `;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/pTboaFzC/1307-lhistorique-de-modification-dun-site-naffiche-pas-correctement-les-changements-sur-le-champ-origines

## 🛠 Description de la PR
la requête getBaseSql dans le fichier query.js comportait une erreur : selon la valeur table passée en paramètre, les clés utilisées dans la requête changent (en se référant à l'objet 'tables'), mais à certains endroits de la requête on utlisait la clé shantytown_id au lieu d'aller chercher la disjonction de cas dans 'tables', ce qui entraînaît une mauvaise jointure entre les tables "ShantytownHistories" et "ShantytownOriginHistories" ;

## 📸 Captures d'écran


## 🚨 Notes pour la mise en production
