### PR TITLE
#patch (1315) alignement images et texte sur la landing page

### DIFF
--- a/packages/frontend/src/js/app/pages/LandingPage/LandingTutorialBanner.vue
+++ b/packages/frontend/src/js/app/pages/LandingPage/LandingTutorialBanner.vue
@@ -5,7 +5,7 @@
         <div class="lg:flex">
             <div class="lg:flex-shrink-0 justify-center">
                 <g-image
-                    width="240"
+                    width="260"
                     class="m-4 h-40"
                     src="./assets/prendre_en_main.jpg"
                     alt=""


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/2UKVzeNx/1315-images-d%C3%A9form%C3%A9es-sur-la-landing-page-et-aligner-les-images-et-textes-verticalement

## 🛠 Description de la PR
Modification de la largeur d'une des deux images pour l'aligner sur l'autre

## 📸 Captures d'écran
Anciennement : 
<img width="1097" alt="Capture d’écran 2021-12-16 à 14 51 37" src="https://user-images.githubusercontent.com/94321132/146384403-a88006f0-2d5d-44bc-9c79-adba71471d73.png">

Maintenant : 

<img width="1091" alt="Capture d’écran 2021-12-16 à 14 51 44" src="https://user-images.githubusercontent.com/94321132/146384424-6ba9f310-c03d-4a63-8ac2-1d00b7cfebdb.png">


## 🚨 Notes pour la mise en production
