### PR TITLE
#patch (1318) Correction d'un bug d'initialisation de Matomo

### DIFF
--- a/packages/frontend/src/init/matomo.js
+++ b/packages/frontend/src/init/matomo.js
@@ -3,6 +3,12 @@ import VueMatomo from "#matomo/matomo";
 
 export default function(Vue) {
     if (VUE_APP_MATOMO_ON === "true") {
+        if (typeof String.prototype.replaceAll === "undefined") {
+            String.prototype.replaceAll = function(match, replace) {
+                return this.replace(new RegExp(match, "g"), () => replace);
+            };
+        }
+
         Vue.use(VueMatomo, {
             // Configure your matomo server and site by providing
             host: "https://stats.data.gouv.fr",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QyYIz4eA/1318

## 🛠 Description de la PR
Correction d'un bug de Matomo qui n'arrivait pas à s'initialiser sur les vieilles version de Firefox et Chrome à cause de l'absence de la fonction String.replaceAll.
Cela fait probablement suite à une mise à jour à distance de Matomo.

Ce bug provoque en cascade d'autres soucis : impossible de mettre à jour des sites, décompte du nombre d'utilisateurs erronés, problèmes de navigation entre la landing et la page de connexion, etc.