### PR TITLE
#patch (1319) Corrections diverses autour du formulaire de connexion

### DIFF
--- a/packages/frontend/routes.js
+++ b/packages/frontend/routes.js
@@ -477,7 +477,7 @@ const fileRoutes = [
         route: {
             meta: {
                 beforeEnter: {
-                    action: "redirect",
+                    action: "open",
                     to: "mailto:contact@resorption-bidonvilles.beta.gouv.fr"
                 }
             }

--- a/packages/frontend/src/js/app/pages/SignIn/index.vue
+++ b/packages/frontend/src/js/app/pages/SignIn/index.vue
@@ -1,13 +1,13 @@
 <template>
     <LoginLayout title="Connectez-vous à Résorption-bidonvilles">
-        <ValidationObserver ref="form" v-slot="{ handleSubmit }">
-            <div
-                class="bg-yellow-200 p-2 -m-4 mb-4 text-sm"
-                v-if="isRedirectedFromPrivatePage"
-            >
-                Veuillez vous connecter pour accéder à la page souhaitée.
-            </div>
+        <div
+            class="bg-yellow-200 p-2 -m-4 mb-4 text-sm"
+            v-bind:class="{ hidden: !isRedirectedFromPrivatePage }"
+        >
+            Veuillez vous connecter pour accéder à la page souhaitée.
+        </div>
 
+        <ValidationObserver ref="form" v-slot="{ handleSubmit }">
             <form @submit.prevent="handleSubmit(onLogin)">
                 <TextInput
                     placeholder="marcel.dupont@example.com"

--- a/packages/frontend/src/js/app/pages/SignIn/index.vue
+++ b/packages/frontend/src/js/app/pages/SignIn/index.vue
@@ -36,7 +36,7 @@
                     </div>
 
                     <div class="flex items-center">
-                        <router-link to="contact" class="w-1/2 text-primary"
+                        <router-link to="/contact" class="w-1/2 text-primary"
                             >Demander un accès</router-link
                         >
                         <div class="mx-2">|</div>

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -25,6 +25,7 @@ export default function(Vue) {
             directory
         },
         state: {
+            entrypoint: null,
             towns: {
                 data: [],
                 loading: true,
@@ -49,6 +50,9 @@ export default function(Vue) {
             detailedTown: null
         },
         mutations: {
+            setEntrypoint(state, value) {
+                state.entrypoint = value;
+            },
             setLoading(state, value) {
                 state.towns.loading = value;
             },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/z0xr3KBK/1319

## 🛠 Description de la PR
Pour une raison que je ne comprends pas bien, mais liée au SSR, le bloc "vous devez être identifié pour accéder à cette page" qui apparaît au-dessus du formulaire de connexion quand le paramètre GET "r=1" est défini bloquait le chargement de la page, mais uniquement en cas d'accès direct.

Il fallait donc accéder directement à l'adresse `/connexion/?r=1` pour avoir le soucis...
Je n'ai pas réussi à faire mieux que d'empêcher le problème de chargement et de navigation, mais il reste un comportement étrange (mais à mon sens minime) : le bloc en question n'apparaît pas en cas d'accès direct...

Au passage, j'ai corrigé deux autres problèmes :
- le système d'entrypoint n'était plus effectif depuis la mise en place de Gridsome (entrypoint = le fait de garder en mémoire la page "privée" à laquelle l'utilisateur essayait d'accéder, pour pouvoir le rediriger vers ladite page après connexion)
- le lien "Demander un accès", sous le formulaire de connexion, était mort (en cas d'accès direct au formulaire de connexion...)