### PR TITLE
#patch (1276) Imprimer la carte telle qu'elle est vue sur écran

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -31,6 +31,7 @@
     "cypress": "^8.5.0",
     "cypress-localstorage-commands": "^1.5.0",
     "fuse.js": "^6.4.6",
+    "html2canvas": "^1.3.4",
     "leaflet.markercluster": "^1.4.1",
     "simplebar-vue": "^1.3.3",
     "vee-validate": "^3.4.0",

--- a/packages/frontend/src/js/app/components/map/map.js
+++ b/packages/frontend/src/js/app/components/map/map.js
@@ -397,11 +397,13 @@ export default {
                 height: this.map._size.y,
                 logging: false
             };
-
             // Stocke le paramètre "showAddress" avant le passage en mode impression
             this.showAddressesBeforePrint = this.showAddresses;
             // Affiche l'adresse des sites pour l'impression
-            this.showAddresses = true;
+            // timeout nécessaire pour Chrome
+            setTimeout(() => {
+                this.showAddresses = true;
+            }, 200);
             // Masque le contrôle de zoom
             this.map.removeControl(this.map.zoomControl);
             // Masque le contrôle affichant les couches
@@ -410,31 +412,37 @@ export default {
             // (masque barre de recherche, bouton d'impression et commutateur d'affichage des adresses de sites)
             document.body.classList.add("preprint");
 
-            if (manualPrint === true) {
-                const printWindow = window.open(
-                    "",
-                    "PrintWindow",
-                    "width=400,height=200"
-                );
-                html2canvas(
-                    document.getElementById("map"),
-                    html2canvasConfiguration
-                ).then(canvas => {
-                    const doc = printWindow.document;
-                    const img = doc.createElement("img");
-                    img.src = canvas.toDataURL("image/png");
-                    doc.body.appendChild(img);
+            // timeout nécessaire pour Chrome
+            setTimeout(() => {
+                if (manualPrint === true) {
+                    const printWindow = window.open(
+                        "",
+                        "PrintWindow",
+                        "width=800,height=600"
+                    );
+                    html2canvas(
+                        document.getElementById("map"),
+                        html2canvasConfiguration
+                    ).then(canvas => {
+                        const doc = printWindow.document;
+                        const img = doc.createElement("img");
+                        img.src = canvas.toDataURL("image/png");
+                        doc.body.appendChild(img);
+                        setTimeout(() => {
+                            printWindow.print();
+                            printWindow.close();
+                        }, 200);
+                    });
+                    // Restauration de l'environnement tel qu'il était avant la préparation de l'impression
+                    document.body.classList.remove("preprint");
+                    this.setupLayersControl();
+                    this.map.addControl(this.map.zoomControl);
+                    // timeout nécessaire pour Chrome
                     setTimeout(() => {
-                        printWindow.print();
-                        printWindow.close();
-                    }, 0);
-                });
-                // Restauration de l'environnement tel qu'il était avant la préparation de l'impression
-                document.body.classList.remove("preprint");
-                this.setupLayersControl();
-                this.map.addControl(this.map.zoomControl);
-                this.showAddresses = this.showAddressesBeforePrint;
-            }
+                        this.showAddresses = this.showAddressesBeforePrint;
+                    }, 200);
+                }
+            }, 200);
         },
         countNumberOfTowns() {
             this.numberOfShantytownsBy = this.towns.reduce(

--- a/packages/frontend/src/js/app/components/map/map.pug
+++ b/packages/frontend/src/js/app/components/map/map.pug
@@ -13,8 +13,8 @@
             </p>
         </div>
 
-        <div ref="printer" class="leaflet-printer" @click="preprint(true)">
-            <Icon icon="print" /> Imprimer
+        <div ref="printer" class="leaflet-printer" @click="printMapScreenshot(true)">
+            <Icon icon="print" /> Imprimer la carte
         </div>
     </div>
 </section>

--- a/packages/frontend/src/js/app/components/map/map.pug
+++ b/packages/frontend/src/js/app/components/map/map.pug
@@ -13,7 +13,7 @@
             </p>
         </div>
 
-        <div ref="printer" class="leaflet-printer" @click="printMapScreenshot(true)">
+        <div ref="printer" class="leaflet-printer" @click="printMapScreenshot">
             <Icon icon="print" /> Imprimer la carte
         </div>
     </div>

--- a/packages/frontend/src/js/app/components/map/map.scss
+++ b/packages/frontend/src/js/app/components/map/map.scss
@@ -21,9 +21,11 @@
         display: none;
     }
 
+
     #map {
-        width: 1024px;
-        height: 576px;
+        .leaflet-printer {
+            display: none;
+        }
 
         .leaflet-address-toggler {
             display: none;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/TgsqSpKL

## 🛠 Description de la PR
- Permettre l'impression de la carte telle qu'elle est vue sur l'écran
- L'idée est de prendre une capture de ce qui est affiché sur l'écran et d'imprimer cette capture
- La capture est réalisée grâce aux package [html2canvas](https://github.com/niklasvh/html2canvas)

## 📸 Captures d'écran
- Ecran:
![image](https://user-images.githubusercontent.com/50863659/147763551-286f8a39-00dd-4b9d-b9cd-44fa9d310621.png)

- Prévisualisation de l'impression:
![image](https://user-images.githubusercontent.com/50863659/147763659-8fe1d638-adf9-4b25-94d6-25c4bc3e789f.png)

## 🚨 Notes pour la mise en production
- Installer html2canvas sur le front:
```javascript
make prod exec rb_frontend "yarn add html2canvas"
``` 
- Relancer un:
```javascript
yarn lerna bootstrap
```