### PR TITLE
#patch (1317) analyse impact solinum corrections

### DIFF
--- a/packages/frontend/src/js/app/pages/dashboard/POIView.vue
+++ b/packages/frontend/src/js/app/pages/dashboard/POIView.vue
@@ -35,8 +35,8 @@
                     <div v-if="poi.entity.phone" class="my-2">
                         Tel: {{ poi.entity.phone }}
                     </div>
-                    <div v-if="poi.entity.email" class="my-2">
-                        Email: {{ poi.entity.email }}
+                    <div v-if="poi.entity.mail" class="my-2">
+                        Email: {{ poi.entity.mail }}
                     </div>
                     <div v-if="poi.languages" class="my-2">
                         Langue: {{ poi.languages.join(", ") }}

--- a/packages/frontend/src/js/app/pages/dashboard/POIView.vue
+++ b/packages/frontend/src/js/app/pages/dashboard/POIView.vue
@@ -32,8 +32,14 @@
                         class="my-2"
                         v-html="poi.description"
                     />
-                    <div v-if="poi.entity.phone" class="my-2">
-                        Tel: {{ poi.entity.phone }}
+                    <div v-if="poi.entity.phones.length > 0" class="my-2">
+                        Tel:
+                        <div
+                            :key="phone.phoneNumber"
+                            v-for="phone in poi.entity.phones"
+                        >
+                            {{ phone.phoneNumber }}
+                        </div>
                     </div>
                     <div v-if="poi.entity.mail" class="my-2">
                         Email: {{ poi.entity.mail }}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/B0By3caF/1317-analyse-dimpacts-sur-la-nouvelle-api-de-solinum-soliguide

## 🛠 Description de la PR
-Dans l'objet que renvoie l'API de Solinum une clé a changé (email -> mail), ce qui fait que les adresses emails ne s'affichaient pas.
- De même, les clés 'phone' et 'phone2' ont été remplacés par une clé 'phones' dont la valeur est une liste des numéros de téléphone.



## 📸 Captures d'écran


## 🚨 Notes pour la mise en production
