### PR TITLE
#patch (1309) champ "Nombre de ménages" non obligatoire

### DIFF
--- a/packages/api/db/migrations/20220103-01-alter-table-audiences-row-familles-nullable.js
+++ b/packages/api/db/migrations/20220103-01-alter-table-audiences-row-familles-nullable.js
@@ -1,0 +1,19 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.changeColumn(
+        'audiences',
+        'families',
+        {
+            type: Sequelize.INTEGER,
+            allowNull: true,
+        },
+    ),
+
+    down: (queryInterface, Sequelize) => queryInterface.changeColumn(
+        'audiences',
+        'families',
+        {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        },
+    ),
+};

--- a/packages/api/server/controllers/planController.js
+++ b/packages/api/server/controllers/planController.js
@@ -1189,8 +1189,18 @@ module.exports = models => ({
                 return false;
             }
 
-            return Object.values(stateData.audience[key]).some(value => Number.isNaN(value) || value < 0);
+            let returnValue = false;
+            returnValue = Object.keys(stateData.audience[key]).some((nestedKey) => {
+                if (nestedKey !== 'families') {
+                    if (Number.isNaN(stateData.audience[key][nestedKey]) || (stateData.audience[key][nestedKey]) < 0) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+            return returnValue;
         });
+
         if (hasBadValues) {
             addError('audience', 'Les chiffres indiqués ne peuvent pas être négatifs');
         }
@@ -1200,13 +1210,13 @@ module.exports = models => ({
                 addError('audience', 'Vous devez préciser le nombre de personnes intégrées au dispositif');
             }
 
-            if (Number.isNaN(stateData.audience.in.families) || stateData.audience.in.families <= 0) {
-                addError('audience', 'Vous devez préciser le nombre de ménages intégrés au dispositif');
-            }
+            if (Number.isNaN(stateData.audience.in.families)) stateData.audience.in.families = 0;
         }
 
-        if (stateData.audience.in.total < stateData.audience.in.families) {
-            addError('audience', 'Le nombre de ménages ne peut pas être supérieur au nombre de personnes');
+        if (stateData.audience.in.families > 0) {
+            if (stateData.audience.in.total < stateData.audience.in.families) {
+                addError('audience', 'Le nombre de ménages ne peut pas être supérieur au nombre de personnes');
+            }
         }
         if (stateData.audience.in.women + stateData.audience.in.minors > stateData.audience.in.total) {
             addError('audience', 'La somme du nombre de femmes et de mineurs ne peut pas être supérieure au nombre de personnes');

--- a/packages/api/server/controllers/planController.js
+++ b/packages/api/server/controllers/planController.js
@@ -1210,7 +1210,9 @@ module.exports = models => ({
                 addError('audience', 'Vous devez préciser le nombre de personnes intégrées au dispositif');
             }
 
-            if (Number.isNaN(stateData.audience.in.families)) stateData.audience.in.families = 0;
+            if (Number.isNaN(stateData.audience.in.families)) {
+                stateData.audience.in.families = 0;
+            }
         }
 
         if (stateData.audience.in.families > 0) {

--- a/packages/frontend/src/js/app/components/form/input/audience/audience.pug
+++ b/packages/frontend/src/js/app/components/form/input/audience/audience.pug
@@ -28,17 +28,17 @@
             </tr>
             <tr v-if="!inOnly">
                 <td><strong>Exclusion</strong> du dispositif</td>
-                <td><input type="number" v-model="data.out_abandoned.households" :disabled="disabled" /></td>
-                <td><input type="number" v-model="data.out_abandoned.people" :disabled="disabled" /></td>
-                <td><input type="number" v-model="data.out_abandoned.women" :disabled="disabled" /></td>
-                <td><input type="number" v-model="data.out_abandoned.minors" :disabled="disabled" /></td>
-            </tr>
-            <tr v-if="!inOnly">
-                <td><strong>Abandon / départ volontaire</strong></td>
                 <td><input type="number" v-model="data.out_excluded.households" :disabled="disabled" /></td>
                 <td><input type="number" v-model="data.out_excluded.people" :disabled="disabled" /></td>
                 <td><input type="number" v-model="data.out_excluded.women" :disabled="disabled" /></td>
                 <td><input type="number" v-model="data.out_excluded.minors" :disabled="disabled" /></td>
+            </tr>
+            <tr v-if="!inOnly">
+                <td><strong>Abandon / départ volontaire</strong></td>
+                <td><input type="number" v-model="data.out_abandoned.households" :disabled="disabled" /></td>
+                <td><input type="number" v-model="data.out_abandoned.people" :disabled="disabled" /></td>
+                <td><input type="number" v-model="data.out_abandoned.women" :disabled="disabled" /></td>
+                <td><input type="number" v-model="data.out_abandoned.minors" :disabled="disabled" /></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/5GQRDk7M
https://trello.com/c/fcsrNHo2

## 🛠 Description de la PR
- Migration permettant de rendre le champ `families` de la table `audiences` nullable
- Corrige le bug sur les dispositifs dans le compte du nombre de "abandons / départs volontaires" de la carte 1327

## 🚨 Notes pour la mise en production
- Jouer la migration `20220103-01-alter-table-audiences-row-familles-nullable.js`