### PR TITLE
#minor (1311) Adapter le front pour permettre d'associer plusieurs territoires d'intervention

### DIFF
--- a/packages/api/server/models/shantytownModel/getHistory.js
+++ b/packages/api/server/models/shantytownModel/getHistory.js
@@ -82,6 +82,7 @@ module.exports = async (user, location) => {
                     city: {
                         code: activity.cityCode,
                         name: activity.cityName,
+                        main: activity.cityMain,
                     },
                     epci: {
                         code: activity.epciCode,

--- a/packages/frontend/src/js/app/components/ActivityCard/ActivityCard.vue
+++ b/packages/frontend/src/js/app/components/ActivityCard/ActivityCard.vue
@@ -289,7 +289,7 @@ export default {
             }
 
             if (
-                this.permission.geographic_level === "nation" ||
+                this.permission.allow_all ||
                 this.user.organization.location.type === "nation"
             ) {
                 return true;

--- a/packages/frontend/src/js/app/components/ActivityCard/ActivityCard.vue
+++ b/packages/frontend/src/js/app/components/ActivityCard/ActivityCard.vue
@@ -288,22 +288,29 @@ export default {
                 return false;
             }
 
-            if (
-                this.permission.allow_all ||
-                this.user.organization.location.type === "nation"
-            ) {
+            if (this.permission.allow_all) {
                 return true;
             }
 
-            // on vérifie qu'il a le droit de modérer spécifiquement ce commentaire
-            const locationType =
-                this.user.organization.location.type === "region"
-                    ? "region"
-                    : "departement";
-
             return (
-                this.activity.shantytown[locationType].code ===
-                this.user.organization.location[locationType].code
+                this.permission.allowed_on.regions.includes(
+                    this.activity.shantytown.region.code
+                ) ||
+                this.permission.allowed_on.departements.includes(
+                    this.activity.shantytown.departement.code
+                ) ||
+                this.permission.allowed_on.epci.includes(
+                    this.activity.shantytown.epci.code
+                ) ||
+                this.permission.allowed_on.cities.includes(
+                    this.activity.shantytown.city.code
+                ) ||
+                this.permission.allowed_on.cities.includes(
+                    this.activity.shantytown.city.main
+                ) ||
+                this.permission.allowed_on.shantytowns.includes(
+                    this.activity.shantytown.id
+                )
             );
         }
     },

--- a/packages/frontend/src/js/app/components/form/input/townList/townList.js
+++ b/packages/frontend/src/js/app/components/form/input/townList/townList.js
@@ -72,7 +72,7 @@ export default {
                 type: user.organization.location.type
             }
         };
-        const hasNationalPermission = permission.geographic_level === "nation";
+        const hasNationalPermission = permission.allow_all;
 
         let location;
         let defaultLocation;

--- a/packages/frontend/src/js/app/pages/History/History.vue
+++ b/packages/frontend/src/js/app/pages/History/History.vue
@@ -133,8 +133,8 @@ export default {
         },
         defaultPath() {
             const { user } = getConfig();
-            const { geographic_level } = getPermission("shantytown.list");
-            if (geographic_level === "nation") {
+            const { allow_all } = getPermission("shantytown.list");
+            if (allow_all) {
                 return "/activites/nation";
             }
 

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -122,11 +122,9 @@ export default {
                 return false;
             }
 
-            let level =
-                permission.geographic_level !== "local"
-                    ? permission.geographic_level
-                    : this.user.organization.location.type;
-
+            let level = permission.allow_all
+                ? "nation"
+                : this.user.organization.location.type;
             const userLocation = this.user.organization.location[level];
             if (level === "nation") {
                 return true;

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -122,20 +122,26 @@ export default {
                 return false;
             }
 
-            let level = permission.allow_all
-                ? "nation"
-                : this.user.organization.location.type;
-            const userLocation = this.user.organization.location[level];
-            if (level === "nation") {
+            if (permission.allow_all === true) {
                 return true;
-            } else if (userLocation === null) {
-                return false;
             }
 
-            const townCode = this.town[level].main || this.town[level].code;
-            const userCode = userLocation.main || userLocation.code;
-
-            return townCode === userCode;
+            return (
+                this.permission.allowed_on.regions.includes(
+                    this.town.region.code
+                ) ||
+                this.permission.allowed_on.departements.includes(
+                    this.town.departement.code
+                ) ||
+                this.permission.allowed_on.epci.includes(this.town.epci.code) ||
+                this.permission.allowed_on.cities.includes(
+                    this.town.city.code
+                ) ||
+                this.permission.allowed_on.cities.includes(
+                    this.town.city.main
+                ) ||
+                this.permission.allowed_on.shantytowns.includes(this.town.id)
+            );
         },
         // Force scroll even if hash is already present in url
         scrollFix(to) {

--- a/packages/frontend/src/js/app/pages/covid/covid.js
+++ b/packages/frontend/src/js/app/pages/covid/covid.js
@@ -133,8 +133,7 @@ export default {
         canSubmitHighComment() {
             return (
                 this.user.organization.location.type !== "nation" &&
-                getPermission("covid_comment.list").geographic_level !==
-                    "nation"
+                !getPermission("covid_comment.list").allow_all
             );
         }
     },

--- a/packages/frontend/src/js/app/pages/plans.create/plans.create.js
+++ b/packages/frontend/src/js/app/pages/plans.create/plans.create.js
@@ -412,7 +412,9 @@ export default {
                     permission.allowed_on.regions.map(code =>
                         getDepartementsForRegion(code)
                     )
-                ).flat())
+                )
+                    .map(({ departements }) => departements)
+                    .flat())
             ];
 
             return this.departements.filter(({ code }) => {

--- a/packages/frontend/src/js/app/pages/plans.list/plans.list.js
+++ b/packages/frontend/src/js/app/pages/plans.list/plans.list.js
@@ -22,7 +22,7 @@ export default {
     data() {
         const { user } = getConfig();
         const permission = getPermission("plan.list");
-        const hasNationalPermission = permission.geographic_level === "nation";
+        const hasNationalPermission = permission.allow_all;
         const data = {
             locationTitle: null,
             defaultLocation: null,
@@ -157,7 +157,6 @@ export default {
 
             this.state = "loading";
             this.error = null;
-
             list()
                 .then(plans => {
                     this.plans = plans;

--- a/packages/frontend/src/js/helpers/api/geo.js
+++ b/packages/frontend/src/js/helpers/api/geo.js
@@ -21,10 +21,6 @@ export function getDepartementsForRegion(regionCode) {
     return getApi(`/regions/${regionCode}/departements`);
 }
 
-export function getDepartements() {
-    return getApi("/departements");
-}
-
 /**
  * Lists all departements related to a specific epci
  *

--- a/packages/frontend/src/js/helpers/api/geo.js
+++ b/packages/frontend/src/js/helpers/api/geo.js
@@ -21,6 +21,10 @@ export function getDepartementsForRegion(regionCode) {
     return getApi(`/regions/${regionCode}/departements`);
 }
 
+export function getDepartements() {
+    return getApi("/departements");
+}
+
 /**
  * Lists all departements related to a specific epci
  *


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/bp42X3k7/1311-adapter-le-front-pour-permettre-dassocier-plusieurs-territoires-dintervention

## 🛠 Description de la PR
essentiellement remplacer permission.geographic_level === 'nation' par permission.allow_all ou équivalent,
à l'exception d'un petit changement de logique dans create.plan.js pour récupérer la liste des départements où l'utilisateur a le droit de déclarer le dispositif.


## 📸 Captures d'écran


## 🚨 Notes pour la mise en production
