### PR TITLE
correction PR 1310

### DIFF
--- a/packages/api/db/migrations/20211215-02-create-table-role_permissions.js
+++ b/packages/api/db/migrations/20211215-02-create-table-role_permissions.js
@@ -175,6 +175,7 @@ module.exports = {
                     fk_entity,
                     allowed,
                     CASE
+                        WHEN allowed IS FALSE THEN NULL
                         WHEN fk_geographic_level = 'nation' THEN TRUE
                         ELSE FALSE
                     END AS allow_all

--- a/packages/api/server/models/planModel/_common/query.js
+++ b/packages/api/server/models/planModel/_common/query.js
@@ -2,7 +2,7 @@ const { sequelize } = require('#db/models');
 const userModel = require('#server/models/userModel')();
 const shantytownModel = require('#server/models/shantytownModel')();
 const serializePlan = require('./serializePlan');
-const { where } = require('#server/utils/permission/where');
+const { where } = require('#server/utils/permission');
 const stringifyWhereClause = require('#server/models/_common/stringifyWhereClause');
 
 module.exports = async (user, feature, filters = {}) => {

--- a/packages/api/server/models/planModel/_common/serializePlan.js
+++ b/packages/api/server/models/planModel/_common/serializePlan.js
@@ -51,10 +51,10 @@ module.exports = (user, permissions, plan) => {
         topics: plan.topics,
         createdBy: plan.createdBy,
         updatedBy: plan.updatedBy,
-        canUpdate: can(user).do('update', 'plan').on(plan),
-        canUpdateMarks: can(user).do('updateMarks', 'plan').on(plan),
-        canClose: can(user).do('close', 'plan').on(plan),
     };
+    base.canUpdate = can(user).do('update', 'plan').on(base);
+    base.canUpdateMarks = can(user).do('updateMarks', 'plan').on(base);
+    base.canClose = can(user).do('close', 'plan').on(base);
 
     if (!plan.finances || permissions.finances === null || permissions.finances.allowed !== true) {
         base.finances = [];


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/nUDTNHB3/1310-modifier-le-sch%C3%A9ma-de-bdd-pour-permettre-dassocier-plusieurs-territoires-dintervention-%C3%A0-une-structure-donn%C3%A9e

## 🛠 Description de la PR
feedback sur la PR 1310
A part les modifications commités dans cette PR je crois que tout fonctionne correctement côté API, sauf :
dans le cas où une permission est à allow-false mais en territoire d'intervention : nation (de mémoire c'est la fonction can qui posait soucis dans ce cas de figure)
Solution : écrire une migration pour set allow-all à true dans cette situation ? 

## 📸 Captures d'écran


## 🚨 Notes pour la mise en production
