### PR TITLE
#patch (1344) Fix d'un bug dans la saisie des indicateurs

### DIFF
--- a/packages/api/server/controllers/planController.js
+++ b/packages/api/server/controllers/planController.js
@@ -168,6 +168,15 @@ function sanitizeState(plan, data) {
     };
 
     function extractAudience(key) {
+        if (!audience[key]) {
+            return {
+                total: 0,
+                families: 0,
+                women: 0,
+                minors: 0,
+            };
+        }
+
         return {
             total: parseInt(audience[key].total, 10),
             families: parseInt(audience[key].families, 10),


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/OPwcKTP3/1344

## 🛠 Description de la PR
Dans les dispositifs qui n'ont pas de système d'entrée/sortie, le champ "audience.in" est vide, et ça posait problème côté API.