### PR TITLE
#patch (1345) Correctifs divers autour des dispositifs

### DIFF
--- a/packages/api/db/migrations/20211215-06-populate-permission_attachments.js
+++ b/packages/api/db/migrations/20211215-06-populate-permission_attachments.js
@@ -1,7 +1,7 @@
 async function insertPermissionWithAttachment(queryInterface, transaction, feature, userId, organizationId, planIds) {
     const [[{ user_permission_id: fk_permission }]] = await queryInterface.sequelize.query(
         `INSERT INTO user_permissions (fk_user, fk_organization, fk_feature, fk_entity, allowed, allow_all, is_cumulative)
-        VALUES (:fk_user, :fk_organization, :feature, 'plan', true, false, true)
+        VALUES (:fk_user, :fk_organization, :feature, 'plan', true, false, false)
         RETURNING user_permission_id`,
         {
             transaction,

--- a/packages/api/db/migrations/30000001-insert-permission-plan_list-for-associations.js
+++ b/packages/api/db/migrations/30000001-insert-permission-plan_list-for-associations.js
@@ -1,0 +1,15 @@
+module.exports = {
+    up(queryInterface) {
+        return queryInterface.sequelize.query(
+            `INSERT INTO role_permissions(fk_role_regular, fk_feature, fk_entity, allowed, allow_all)
+            VALUES('association', 'list', 'plan', true, false)`,
+        );
+    },
+
+    down(queryInterface) {
+        return queryInterface.sequelize.query(
+            'DELETE FROM role_permissions WHERE fk_role_regular = \'association\' AND fk_feature = \'list\' AND fk_entity = \'plan\'',
+        );
+    },
+
+};

--- a/packages/api/server/models/planModel/_common/query.js
+++ b/packages/api/server/models/planModel/_common/query.js
@@ -474,9 +474,5 @@ module.exports = async (user, feature, filters = {}) => {
         });
     });
 
-    return rows
-        .map(serializePlan.bind(this, user, {
-            plan: user.permissions.plan[feature],
-            finances: (user.permissions.plan_finances && user.permissions.plan_finances.access) || null,
-        }));
+    return rows.map(serializePlan.bind(this, user));
 };

--- a/packages/api/server/models/planModel/_common/serializePlan.js
+++ b/packages/api/server/models/planModel/_common/serializePlan.js
@@ -7,7 +7,7 @@ const locationTypes = {
     other: 'dans plusieurs lieux (hébergement, permanence, rue...)',
 };
 
-module.exports = (user, permissions, plan) => {
+module.exports = (user, plan) => {
     const base = {
         type: 'plan',
         id: plan.id,
@@ -57,7 +57,8 @@ module.exports = (user, permissions, plan) => {
     base.canUpdateMarks = can(user).do('updateMarks', 'plan').on(base);
     base.canClose = can(user).do('close', 'plan').on(base);
 
-    if (!plan.finances || permissions.finances === null || permissions.finances.allowed !== true) {
+
+    if (!Array.isArray(plan.finances) || !can(user).do('access', 'plan_finances').on(base)) {
         base.finances = [];
     } else {
         const minYear = plan.finances.slice(-1)[0].year;

--- a/packages/frontend/src/js/app/pages/PlanDetails/PlanDetails.vue
+++ b/packages/frontend/src/js/app/pages/PlanDetails/PlanDetails.vue
@@ -37,6 +37,7 @@
                         :plan="plan"
                         class="mb-10"
                         id="financial"
+                        v-if="hasPermission('plan_finances.access')"
                     />
                     <PlanDetailsPanelTeam
                         :plan="plan"
@@ -135,6 +136,7 @@ import PlanDetailsPanelMarks from "./PlanDetailsPanelMarks.vue";
 import PlanDetailsInfo from "./PlanDetailsInfo.vue";
 import PlanDetailsCloseModal from "./PlanDetailsCloseModal.vue";
 import { get } from "#helpers/api/plan";
+import { hasPermission } from "#helpers/api/config";
 
 export default {
     components: {
@@ -262,6 +264,7 @@ export default {
     },
 
     methods: {
+        hasPermission,
         async fetchData() {
             if (this.loading === true) {
                 return;

--- a/packages/frontend/src/js/app/pages/PlanDetails/PlanDetails.vue
+++ b/packages/frontend/src/js/app/pages/PlanDetails/PlanDetails.vue
@@ -275,7 +275,14 @@ export default {
             this.plan = null;
 
             try {
-                this.plan = await get(this.$route.params.id);
+                const plan = await get(this.$route.params.id);
+                if (!plan) {
+                    throw {
+                        user_message:
+                            "Ce dispositif n'existe pas, ou son accès vous est interdit"
+                    };
+                }
+                this.plan = plan;
                 setTimeout(this.goToAnchor, 50);
             } catch (error) {
                 this.error =


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/iTy6yMcq/1345

## 🛠 Description de la PR
- autoriser les utilisateurs "opérateurs" à accéder en lecture à tous les dispositifs de leur territoire d'intervention
- mieux appliquer les permissions sur le droit d'accéder ou non aux données financières d'un dispositif (via la fonction `can()`)
- ne pas afficher le tableau "Financements" côté front si l'utilisateur n'a pas la permission d'accéder aux données de toute façon (quoi qu'il arrive le tableau serait vide)
- correction d'une vieille migration qui accordait trop de droits aux opérateurs et pilotes des dispositifs (is_cumulative était fixé à `true` au lieu de `false`, accordant des droits excessifs). les permissions ont été déjà corrigées immédiatement sur les bases de prod et préprod
- meilleure gestion du cas où on essaie d'accéder à la fiche d'un dispositif auquel on n'a pas accès (ou qui n'existe pas) : précédemment, la page restait en chargement, désormais on affiche un message d'erreur explicite

## 🚨 Notes pour la mise en production
La requête SQL corrective qui a déjà été jouée en production et pré-production : retire le is_cumulative pour les utilisateurs avec un attachment (au moment où cette requête est écrite, cela ne concerne que les opérateurs et pilotes de dispositifs) :
```
UPDATE
user_permissions
SET is_cumulative = FALSE
WHERE user_permission_id IN (
SELECT
up.user_permission_id
FROM (SELECT up.user_permission_id, COUNT(upa.*) AS total
FROM user_permissions up
LEFT JOIN user_permission_attachments upa ON upa.fk_user_permission = up.user_permission_id
GROUP BY up.user_permission_id) t
LEFT JOIN user_permissions up ON up.user_permission_id = t.user_permission_id
WHERE allowed IS TRUE AND total > 0 AND allow_all IS FALSE);
```