### PR TITLE
#minor (1351) Corrige la mise en forme des messages du journal du site

### DIFF
--- a/packages/frontend/src/js/app/components/InputAudience/InputAudience.vue
+++ b/packages/frontend/src/js/app/components/InputAudience/InputAudience.vue
@@ -5,9 +5,9 @@
 
             <RbTable :columns="columns" :data="rows">
                 <template v-slot:cell="{ column, row, content }">
-                    <span v-if="column === 'label'" class="pre-line">{{
-                        content
-                    }}</span>
+                    <span v-if="column === 'label'" class="whitespace-pre-line">
+                        {{ content }}
+                    </span>
                     <TextInput
                         v-else
                         type="number"

--- a/packages/frontend/src/js/app/pages/PlanDetails/PlanDetailsPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/pages/PlanDetails/PlanDetailsPanelCharacteristics.vue
@@ -51,7 +51,7 @@
                 </aside>
                 <section>
                     <span class="font-bold">Objectifs de l'intervention</span>
-                    <p class="pre-line">{{ plan.goals }}</p>
+                    <p class="whitespace-pre-line">{{ plan.goals }}</p>
                 </section>
             </DetailsPanelSection>
 
@@ -63,7 +63,7 @@
                     <span class="font-bold"
                         >Commentaires suite à la fermeture du dispositif</span
                     >
-                    <p class="pre-line">{{ plan.final_comment }}</p>
+                    <p class="whitespace-pre-line">{{ plan.final_comment }}</p>
                 </section>
             </DetailsPanelSection>
         </template>

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsComments.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsComments.vue
@@ -4,7 +4,6 @@
             {{ comments.length }} message{{ comments.length > 1 ? "s" : "" }}
         </div>
         <CommentBlock
-            class="pre-line"
             v-for="comment in sortedComments"
             :key="comment.id"
             :id="`message${comment.id}`"

--- a/packages/frontend/src/js/app/pages/TownDetails/ui/CommentBlock.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/ui/CommentBlock.vue
@@ -37,7 +37,7 @@
                     :tag="tag"
                 />
             </div>
-            <div>{{ comment.description }}</div>
+            <div class="whitespace-pre-line">{{ comment.description }}</div>
         </div>
     </div>
 </template>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kaDOAgpP

## 🛠 Description de la PR
- Supprime la classe `pre-line` de `packages/frontend/src/js/app/pages/TownDetails/TownDetailsComments.vue`
- Ajoute la classe `whitespace-pre-line` sur `comment.description` pour éviter la mise à la ligne des nom - prénom - affection de l'auteur
- Remplace `pre-line` par `whitespace-pre-line` dans les vues `InputAudience.vue` et `PlanDetailsPanelCharacteristics.vue`.

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/153851574-3ec76754-8f29-425f-ac8a-db16d546f907.png)

## 🚨 Notes pour la mise en production
- Ràs