### PR TITLE
#patch (1347) Correction du bug d'afichage du nom du propriétaire (site)

### DIFF
--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelCharacteristics.vue
@@ -95,13 +95,8 @@ export default {
         const { owner_types } = getConfig();
         return {
             values: owner_types,
-            isMounted: false,
             input: this.value
         };
-    },
-
-    mounted() {
-        this.isMounted = true;
     },
 
     computed: {

--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelCharacteristics.vue
@@ -57,6 +57,7 @@
 </template>
 
 <script>
+import { get as getConfig, hasPermission } from "#helpers/api/config";
 import InputBuiltAt from "./inputs/InputBuiltAt.vue";
 import InputDeclaredAt from "./inputs/InputDeclaredAt.vue";
 import InputFieldType from "./inputs/InputFieldType.vue";
@@ -66,7 +67,6 @@ import InputOwner from "./inputs/InputOwner.vue";
 import InputIsReinstallation from "./inputs/InputIsReinstallation.vue";
 import InputReinstallationComments from "./inputs/InputReinstallationComments.vue";
 import TownFormClosedShantytowns from "./TownFormClosedShantytowns.vue";
-import { hasPermission } from "#helpers/api/config";
 
 export default {
     components: {
@@ -92,7 +92,9 @@ export default {
     },
 
     data() {
+        const { owner_types } = getConfig();
         return {
+            values: owner_types,
             isMounted: false,
             input: this.value
         };
@@ -104,20 +106,34 @@ export default {
 
     computed: {
         ownerTypeIsUnknown() {
-            if (!this.isMounted) {
+            if (
+                this.input.owner_type === undefined ||
+                this.input.owner_type < 1
+            ) {
                 return true;
             }
 
-            const value = this.input.owner_type;
-            if (this.$refs.ownerType === undefined) {
-                return true;
-            }
+            return this.isUnknown(this.input.owner_type);
+        }
+    },
 
-            return this.$refs.ownerType.isUnknown(value);
+    methods: {
+        isUnknown(value) {
+            const label = this.getLabelFor(value);
+            return label === undefined || label === "Inconnu";
         },
 
         hasOwnerPermission() {
             return hasPermission("shantytown_owner.access");
+        },
+
+        getLabelFor(ownerTypeId) {
+            const value = this.values.find(({ id }) => id === ownerTypeId);
+            if (value === undefined) {
+                return undefined;
+            }
+
+            return value.label;
         }
     }
 };

--- a/packages/frontend/src/js/app/components/TownForm/TownFormPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownFormPanelCharacteristics.vue
@@ -101,13 +101,6 @@ export default {
 
     computed: {
         ownerTypeIsUnknown() {
-            if (
-                this.input.owner_type === undefined ||
-                this.input.owner_type < 1
-            ) {
-                return true;
-            }
-
             return this.isUnknown(this.input.owner_type);
         }
     },

--- a/packages/frontend/src/js/app/components/TownForm/inputs/InputOwnerType.vue
+++ b/packages/frontend/src/js/app/components/TownForm/inputs/InputOwnerType.vue
@@ -46,22 +46,6 @@ export default {
         checked() {
             this.$emit("input", this.checked);
         }
-    },
-
-    methods: {
-        isUnknown(value) {
-            const label = this.getLabelFor(value);
-            return label === undefined || label === "Inconnu";
-        },
-
-        getLabelFor(ownerTypeId) {
-            const value = this.values.find(({ id }) => id === ownerTypeId);
-            if (value === undefined) {
-                return undefined;
-            }
-
-            return value.label;
-        }
     }
 };
 </script>

--- a/packages/frontend/src/js/app/components/TownForm/inputs/InputWaterDistance.vue
+++ b/packages/frontend/src/js/app/components/TownForm/inputs/InputWaterDistance.vue
@@ -39,7 +39,7 @@ export default {
     components: { SubQuestionWrapper },
     props: {
         value: {
-            type: Number,
+            type: String,
             required: false,
             default: undefined
         }

--- a/packages/frontend/src/js/app/components/TownForm/inputs/InputWaterHandWashNumber.vue
+++ b/packages/frontend/src/js/app/components/TownForm/inputs/InputWaterHandWashNumber.vue
@@ -22,9 +22,9 @@ export default {
     components: { InlineTextInput },
     props: {
         value: {
-            type: String,
+            type: Number,
             required: false,
-            default: ""
+            default: undefined
         },
         population: {
             type: Object


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/CJ1VQzUi

## 🛠 Description de la PR
- Résout le problème de non affichage du nom du propriétaire sur la fiche site en mode édition
- Corrige deux bugs (warning) relatifs à une erreur de type des propriétés `value` des composants ` InputWaterHandWashNumber.vue` et ` InputWaterDistance.vue`
- Pour déterminer si le type de propriétaire est undefined, on teste la propriété de l'objet `town` plutôt que la valeur du champ affichant cette information.
- Du coup, on peut supprimer l'initialisation de la données `isMounted` passée à `true` lorsque le hook de cycle de vie `mounted` est exécuté.
- Les méthodes `isUnknown()` et `getLabelFor()` sont déplacées du composant enfant `InputOwnerType.vue` vers le composant père `TownFormPanelCharacteristics.vue`.

## 🚨 Notes pour la mise en production
- Ràs