### PR TITLE
#minor (1358) export : date de mise à jour sans l'heure

### DIFF
--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -800,7 +800,7 @@ module.exports = (models) => {
                 },
                 updatedAt: {
                     title: 'Site mis à jour le',
-                    data: ({ updatedAt }) => (updatedAt ? tsToString(updatedAt, 'd/m/Y à h:i') : ''),
+                    data: ({ updatedAt }) => (updatedAt ? tsToString(updatedAt, 'd/m/Y') : ''),
                     width: COLUMN_WIDTHS.SMALL,
                 },
                 actors: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/VoJy7W7n

## 🛠 Description de la PR
- Le format de la date de mise à jour de l'expôrt des sites (dernière colonne) est désormais `d/m/Y`
