### PR TITLE
#patch (1365) Régression sur la saisie des éléments d'audience

### DIFF
--- a/packages/frontend/src/js/app/components/InputAudience/InputAudience.vue
+++ b/packages/frontend/src/js/app/components/InputAudience/InputAudience.vue
@@ -83,11 +83,11 @@ export default {
                 },
                 {
                     label: "Exclusion du dispositif",
-                    type: "out_abandoned"
+                    type: "out_excluded"
                 },
                 {
                     label: "Abandon / départ volontaire",
-                    type: "out_excluded"
+                    type: "out_abandoned"
                 }
             ];
 


### PR DESCRIPTION
- "Exclusion du dispositif" (out_excluded) and "Abandon / départ volontaire" (out_abandoned) were interverted

## 🧾 Ticket Trello
https://trello.com/c/bWs31uE7

## 🛠 Description de la PR
- Corrige une régression concernant la saisie des audiences des dispositifs ou actions: lorsqu'on ajoute des informations dans la section **Abandon / départ volontaire** on alimente la section **Exclusion du dispositif**. 
