### PR TITLE
#patch (1366) tout utilisateur pouvait cliquer sur Mettre a jour

### DIFF
--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -51,7 +51,7 @@
             <Button
                 data-cy="closeTown"
                 v-if="
-                    hasLocalizedPermission('shantytown.close') &&
+                    hasLocalizedPermission('shantytown.close', town) &&
                         town.status === 'open'
                 "
                 variant="primaryOutline"
@@ -67,7 +67,7 @@
                 icon="pen"
                 iconPosition="left"
                 v-if="
-                    hasLocalizedPermission('shantytown.update') &&
+                    hasLocalizedPermission('shantytown.update', town) &&
                         town.status === 'open'
                 "
                 @click="routeToUpdate"
@@ -77,8 +77,11 @@
                 to="#newComment"
                 @click.native="scrollFix('#newComment')"
                 v-if="
-                    hasLocalizedPermission('shantytown_comment.list') ||
-                        hasLocalizedPermission('shantytown_comment.create')
+                    hasLocalizedPermission('shantytown_comment.list', town) ||
+                        hasLocalizedPermission(
+                            'shantytown_comment.create',
+                            town
+                        )
                 "
             >
                 <Button variant="secondary" icon="comment" iconPosition="left"
@@ -87,7 +90,7 @@
             </router-link>
             <Button
                 data-cy="deleteTown"
-                v-if="hasLocalizedPermission('shantytown.delete')"
+                v-if="hasLocalizedPermission('shantytown.delete', town)"
                 class="ml-8"
                 variant="secondary"
                 icon="trash-alt"
@@ -101,7 +104,7 @@
 </template>
 
 <script>
-import { get as getConfig, getPermission } from "#helpers/api/config";
+import { get as getConfig, hasLocalizedPermission } from "#helpers/api/config";
 
 export default {
     props: {
@@ -116,27 +119,7 @@ export default {
         };
     },
     methods: {
-        hasLocalizedPermission(permissionName) {
-            const permission = getPermission(permissionName);
-            if (permission === null) {
-                return false;
-            }
-
-            if (permission.allow_all === true) {
-                return true;
-            }
-
-            return (
-                permission.allowed_on.regions.includes(this.town.region.code) ||
-                permission.allowed_on.departements.includes(
-                    this.town.departement.code
-                ) ||
-                permission.allowed_on.epci.includes(this.town.epci.code) ||
-                permission.allowed_on.cities.includes(this.town.city.code) ||
-                permission.allowed_on.cities.includes(this.town.city.main) ||
-                permission.allowed_on.shantytowns.includes(this.town.id)
-            );
-        },
+        hasLocalizedPermission,
         // Force scroll even if hash is already present in url
         scrollFix(to) {
             if (to === this.$route.hash) {

--- a/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownCard.vue
@@ -222,7 +222,10 @@
                 </div>
                 <div class="flex justify-end px-4 pt-4 print:hidden">
                     <div class="print:hidden">
-                        <transition name="fade" v-if="isOpen">
+                        <transition
+                            name="fade"
+                            v-if="isOpen && hasUpdateShantytownPermission"
+                        >
                             <router-link
                                 v-if="isHover"
                                 :to="`/site/${shantytown.id}/mise-a-jour`"
@@ -267,6 +270,9 @@ export default {
             type: Object
         },
         hasJusticePermission: {
+            type: Boolean
+        },
+        hasUpdateShantytownPermission: {
             type: Boolean
         }
     },

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -340,6 +340,12 @@
                         :key="shantytown.id"
                         :shantytown="shantytown"
                         :hasJusticePermission="hasJusticePermission"
+                        :hasUpdateShantytownPermission="
+                            hasLocalizedPermission(
+                                'shantytown.update',
+                                shantytown
+                            )
+                        "
                         class="mb-6"
                     />
                     <div
@@ -385,7 +391,8 @@ import TownsListFilters from "./TownsListFilters/TownsListFilters";
 import {
     get as getConfig,
     getPermission,
-    hasPermission
+    hasPermission,
+    hasLocalizedPermission
 } from "#helpers/api/config";
 import { filterShantytowns } from "./filterShantytowns";
 import Export from "#app/components/export2/Export.vue";
@@ -494,6 +501,7 @@ export default {
         }
     },
     methods: {
+        hasLocalizedPermission,
         refreshActivities() {
             this.getActivities(
                 this.filters.location !== null

--- a/packages/frontend/src/js/helpers/api/config.js
+++ b/packages/frontend/src/js/helpers/api/config.js
@@ -156,6 +156,34 @@ export function hasPermission(permissionName) {
 }
 
 /**
+ * Checks if the current user has a specific permission on a specific shantytown
+ *
+ * @param {String} permission
+ * @param {Object} shantytown
+ *
+ * @returns {boolean}
+ */
+export function hasLocalizedPermission(permissionName, town) {
+    const permission = getPermission(permissionName);
+    if (permission === null) {
+        return false;
+    }
+
+    if (permission.allow_all) {
+        return true;
+    }
+
+    return (
+        permission.allowed_on.regions.includes(town.region.code) ||
+        permission.allowed_on.departements.includes(town.departement.code) ||
+        permission.allowed_on.epci.includes(town.epci.code) ||
+        permission.allowed_on.cities.includes(town.city.code) ||
+        permission.allowed_on.cities.includes(town.city.main) ||
+        permission.allowed_on.shantytowns.includes(town.id)
+    );
+}
+
+/**
  * Marks a changelog as read
  *
  * @param {Number} version The latest version read by the user


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/oI7Owapo/1367-bug-un-acteur-national-peut-modifier-les-sites-via-la-liste-des-sites

## 🛠 Description de la PR
Dans la liste des sites, le bouton 'Mettre à jour' s'affichait sans vérifier que l'utilisateur avait bien la permission shantytown.update, tout utilisateur pouvait ainsi par ce biais accéder au formulaire de modification de site
Dorénavant le bouton s'affiche seulement si l'utilisateur a la permission shantytown.update (en vérifiant que la permission est bien sur le site grâce à la méthode hasLocalizedPermission)
