### PR TITLE
#patch (1382) delete justice_status from ShantytownHistories

### DIFF
--- a/packages/api/db/migrations/30000005-delete-justice-status.js
+++ b/packages/api/db/migrations/30000005-delete-justice-status.js
@@ -1,0 +1,26 @@
+
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => Promise.all([
+            queryInterface.removeColumn('ShantytownHistories', 'justice_status', {
+                transaction,
+            }),
+            queryInterface.sequelize.query('DROP TYPE "enum_ShantytownHistories_justice_status" CASCADE', {
+                transaction,
+            }),
+        ]),
+    ),
+
+
+    down: (queryInterface, Sequelize) => Promise.all([
+
+        queryInterface.addColumn(
+            'ShantytownHistories',
+            'justice_status',
+            {
+                type: Sequelize.ENUM('none', 'seized', 'rendered'),
+                allowNull: true,
+            },
+        ),
+    ]),
+};


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/3pPQjegl/1382-tech-suppression-de-la-colonne-justicestatus-dans-la-table-shantytownhistories

## 🛠 Description de la PR
migration pour supprimer la colonne justice_status de la table ShantytownHistories

## 🚨 Notes pour la mise en production
migration à faire tourner