### PR TITLE
#patch (1369) Correction de la recherche textuelle sur la liste des sites

### DIFF
--- a/packages/frontend/src/js/app/components/GeoSearchbar/GeoSearchbar.vue
+++ b/packages/frontend/src/js/app/components/GeoSearchbar/GeoSearchbar.vue
@@ -2,7 +2,7 @@
     <div class="-mb-6 flex flex-1 justify-center">
         <div class="searchbox">
             <AutocompleteV2
-                :defaultValue="this.$props.value"
+                :defaultValue="originalValue"
                 :search="search"
                 v-model="result"
                 @blur="data => $emit('blur', data)"
@@ -13,6 +13,7 @@
                 :inputClasses="['rounded-full shadow-sm']"
                 :placeholder="placeholder"
                 :disabled="disabled"
+                :allowFreeInput="allowFreeInput"
                 ref="autocomplete"
             >
                 <template v-slot:cta>
@@ -100,6 +101,10 @@ export default {
             default: "Adresse, nom d’un site, ville, code postal…",
             required: false
         },
+        allowFreeInput: {
+            type: Boolean,
+            default: false
+        },
         disabled: {
             type: Boolean,
             required: false,
@@ -108,6 +113,7 @@ export default {
     },
     data() {
         return {
+            originalValue: this.value,
             input: "",
             result: "",
             results: [],

--- a/packages/frontend/src/js/app/components/ui/Autocomplete.vue
+++ b/packages/frontend/src/js/app/components/ui/Autocomplete.vue
@@ -310,7 +310,7 @@ export default {
                 if (!this.value) {
                     this.onItemSelect(null);
                 } else if (
-                    this.allowFreeInput === true &&
+                    this.allowFreeInput &&
                     this.searchInput !== this.originalSearchInput
                 ) {
                     this.value = null;

--- a/packages/frontend/src/js/app/components/ui/Autocomplete.vue
+++ b/packages/frontend/src/js/app/components/ui/Autocomplete.vue
@@ -206,6 +206,10 @@ export default {
         showMandatoryStar: {
             type: Boolean,
             default: false
+        },
+        allowFreeInput: {
+            type: Boolean,
+            default: false
         }
     },
     computed: {
@@ -223,14 +227,18 @@ export default {
         }
     },
     data() {
+        const searchInput = this.defaultValue
+            ? this.getResultValue(this.defaultValue)
+            : "";
+
         return {
             show: true,
             focused: false,
             value: this.defaultValue || null,
-            searchInput: this.defaultValue
-                ? this.getResultValue(this.defaultValue)
-                : "",
-            results: []
+            searchInput,
+            originalSearchInput: searchInput,
+            results: [],
+            blurTimeout: null
         };
     },
     watch: {
@@ -240,6 +248,10 @@ export default {
     },
     mounted() {
         this.$refs.provider.syncValue(this.value);
+    },
+    unmounted() {
+        clearTimeout(this.blurTimeout);
+        this.blurTimeout = null;
     },
     methods: {
         setValue(value) {
@@ -269,24 +281,51 @@ export default {
 
             this.$emit("submit", newValue);
             this.$emit("input", newValue);
+            this.$emit("blur", {
+                value: this.value,
+                search: this.searchInput
+            });
             this.$refs.provider.syncValue(newValue);
             this.$refs.provider.validate();
             this.$refs.searchInput.blur();
+
+            clearTimeout(this.blurTimeout);
+            this.blurTimeout = null;
         },
         handleFocus() {
+            clearTimeout(this.blurTimeout);
+            this.blurTimeout = null;
+
             this.focused = true;
+            this.originalSearchInput = this.searchInput;
         },
 
         handleBlur() {
-            // If user has deleted his input, delete the selected value
-            if (!this.value) {
-                this.onItemSelect(null);
-            } else {
-                // If user has changed his last input, restore to last value
-                this.searchInput = this.getResultValue(this.value);
+            if (this.blurTimeout !== null) {
+                clearTimeout(this.blurTimeout);
             }
-            this.focused = false;
-            this.$emit("blur", { value: this.value, search: this.searchInput });
+
+            this.blurTimeout = setTimeout(() => {
+                // If user has deleted his input, delete the selected value
+                if (!this.value) {
+                    this.onItemSelect(null);
+                } else if (
+                    this.allowFreeInput === true &&
+                    this.searchInput !== this.originalSearchInput
+                ) {
+                    this.value = null;
+                } else {
+                    // restore to last selected value
+                    this.searchInput = this.getResultValue(this.value);
+                }
+
+                this.focused = false;
+                this.$emit("blur", {
+                    value: this.value,
+                    search: this.searchInput
+                });
+                this.blurTimeout = null;
+            }, 100);
         }
     }
 };

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -16,6 +16,7 @@
                 <GeoSearchbar
                     data-cy-input="geoFilter"
                     :value="filters.location"
+                    :allowFreeInput="true"
                     @blur="handleSearchBlur"
                 />
             </PrivateContainer>

--- a/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
+++ b/packages/frontend/src/js/app/pages/TownsList/TownsList.vue
@@ -504,14 +504,16 @@ export default {
     methods: {
         hasLocalizedPermission,
         refreshActivities() {
-            this.getActivities(
-                this.filters.location !== null
-                    ? this.filters.location.locationType
-                    : "nation",
-                this.filters.location !== null
-                    ? this.filters.location.code
-                    : null
-            );
+            if (this.filters.location !== undefined) {
+                this.getActivities(
+                    this.filters.location !== null
+                        ? this.filters.location.locationType
+                        : "nation",
+                    this.filters.location !== null
+                        ? this.filters.location.code
+                        : null
+                );
+            }
         },
         async getActivities(locationType, locationCode) {
             this.lastActivities = [];
@@ -534,13 +536,13 @@ export default {
             this.activitiesLoading = false;
         },
         handleSearchBlur(data) {
-            this.refreshActivities();
             this.$trackMatomoEvent("Liste des sites", "Recherche");
             this.$store.commit("setFilters", {
                 ...this.filters,
                 location: data.value,
                 search: data.search
             });
+            this.refreshActivities();
         },
         updateSort(val) {
             this.$store.commit("setSort", val);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JxvVya5d/1369

## 🛠 Description de la PR
Une solution un peu complexe pour un problème qui semblait à priori simple.
Le problème était le suivant : lorsque l'on quittait le champ de recherche (événement blur), le composant d'autocomplete réinitialisait la valeur du champ avec le dernier item qui avait été cliqué.
Si par défaut le champ était vide, alors il n'y avait pas de problème, il n'y avait rien à réinitialiser et donc la recherche textuelle marchait. En revanche, si le champ n'était pas vide par défaut, la recherche textuelle ne pouvait pas s'appliquer.

Pour corriger ça j'ai dû faire trois changements principaux (détails dans le diff, j'ai laissé des commentaires) :
- rajouter une prop pour autoriser ou non la recherche textuelle (interdite par défaut)
- ajouter un timeout sur la gestion du blur
- interdire le changement de valeur par défaut du champ de recherche en cours de route

## 📸 Captures d'écran
![Capture d’écran 2022-03-09 à 17 56 37](https://user-images.githubusercontent.com/1801091/157491352-28a985f6-b726-4887-a9e9-89eb61286738.png)
