### PR TITLE
#patch(1331) doublons dans shantytownHistories

### DIFF
--- a/packages/api/db/migrations/30000005-delete-duplicate-shantytown-history.js
+++ b/packages/api/db/migrations/30000005-delete-duplicate-shantytown-history.js
@@ -226,9 +226,8 @@ module.exports = {
         }, []));
         return transaction.commit();
     },
-    async down(queryInterface) {
+    async down() {
         // no need to do anything here
-        const transaction = await queryInterface.sequelize.transaction();
-        return transaction.commit();
+        return Promise.resolve();
     },
 };

--- a/packages/api/db/migrations/30000005-delete-duplicate-shantytown-history.js
+++ b/packages/api/db/migrations/30000005-delete-duplicate-shantytown-history.js
@@ -1,0 +1,232 @@
+const selectModificationValues = [
+    'shantytown_id',
+    'name',
+    'built_at',
+    'declared_at',
+    'address',
+    'address_details',
+    'owner',
+    'is_reinstallation',
+    'reinstallation_comments',
+    'census_status',
+    'census_conducted_at',
+    'census_conducted_by',
+    'population_total',
+    'population_couples',
+    'population_minors',
+    'population_minors_0_3',
+    'population_minors_3_6',
+    'population_minors_6_12',
+    'population_minors_12_16',
+    'population_minors_16_18',
+    'field_type',
+    'owner_type',
+    'social_origins',
+    'electricity_type',
+    'electricity_comments',
+    'access_to_sanitary',
+    'sanitary_comments',
+    'access_to_water',
+    'water_comments',
+    'water_potable',
+    'water_continuous_access',
+    'water_public_point',
+    'water_distance',
+    'water_roads_to_cross',
+    'water_everyone_has_access',
+    'water_stagnant_water',
+    'water_hand_wash_access',
+    'water_hand_wash_access_number',
+    'sanitary_number',
+    'sanitary_insalubrious',
+    'sanitary_on_site',
+    'trash_evacuation',
+    'trash_cans_on_site',
+    'trash_accumulation',
+    'trash_evacuation_regular',
+    'vermin',
+    'vermin_comments',
+    'fire_prevention_measures',
+    'fire_prevention_diagnostic',
+    'fire_prevention_site_accessible',
+    'fire_prevention_devices',
+    'fire_prevention_comments',
+    'owner_complaint',
+    'justice_procedure',
+    'justice_rendered',
+    'justice_rendered_at',
+    'justice_rendered_by',
+    'justice_challenged',
+    'police_status',
+    'police_requested_at',
+    'police_granted_at',
+    'bailiff',
+];
+
+const selectShantytownsValues = [
+    'shantytowns.updated_by',
+    'shantytowns.shantytown_id',
+    'shantytowns.updated_at as date',
+    'shantytowns.name',
+    'shantytowns.built_at',
+    'shantytowns.declared_at',
+    'shantytowns.address',
+    'shantytowns.address_details',
+    'shantytowns.owner',
+    'shantytowns.is_reinstallation',
+    'shantytowns.reinstallation_comments',
+    'shantytowns.census_status::text',
+    'shantytowns.census_conducted_at',
+    'shantytowns.census_conducted_by',
+    'shantytowns.population_total',
+    'shantytowns.population_couples',
+    'shantytowns.population_minors',
+    'shantytowns.population_minors_0_3',
+    'shantytowns.population_minors_3_6',
+    'shantytowns.population_minors_6_12',
+    'shantytowns.population_minors_12_16',
+    'shantytowns.population_minors_16_18',
+    'field_types.label as field_type',
+    'owner_types.label as owner_type',
+    'sco.origins AS social_origins',
+    'electricity_types.label as electricity_type',
+    'shantytowns.electricity_comments',
+    'shantytowns.access_to_sanitary',
+    'shantytowns.sanitary_comments',
+    'shantytowns.access_to_water',
+    'shantytowns.water_comments',
+    'shantytowns.water_potable',
+    'shantytowns.water_continuous_access',
+    'shantytowns.water_public_point',
+    'shantytowns.water_distance::text',
+    'shantytowns.water_roads_to_cross',
+    'shantytowns.water_everyone_has_access',
+    'shantytowns.water_stagnant_water',
+    'shantytowns.water_hand_wash_access',
+    'shantytowns.water_hand_wash_access_number',
+    'shantytowns.sanitary_number',
+    'shantytowns.sanitary_insalubrious',
+    'shantytowns.sanitary_on_site',
+    'shantytowns.trash_evacuation',
+    'shantytowns.trash_cans_on_site',
+    'shantytowns.trash_accumulation',
+    'shantytowns.trash_evacuation_regular',
+    'shantytowns.vermin',
+    'shantytowns.vermin_comments',
+    'shantytowns.fire_prevention_measures',
+    'shantytowns.fire_prevention_diagnostic',
+    'shantytowns.fire_prevention_site_accessible',
+    'shantytowns.fire_prevention_devices',
+    'shantytowns.fire_prevention_comments',
+    'shantytowns.owner_complaint',
+    'shantytowns.justice_procedure',
+    'shantytowns.justice_rendered',
+    'shantytowns.justice_rendered_at',
+    'shantytowns.justice_rendered_by',
+    'shantytowns.justice_challenged',
+    'shantytowns.police_status::text',
+    'shantytowns.police_requested_at',
+    'shantytowns.police_granted_at',
+    'shantytowns.bailiff',
+];
+
+const intermediary = selectModificationValues.map(value => `modifications.${value}, lag(modifications.${value}) over (ORDER BY modifications.shantytown_id asc, modifications.date asc) AS lag_${value}`);
+const where = selectModificationValues.map(value => `((${value} IS NULL AND lag_${value} is NULL) OR ${value} = lag_${value})`);
+
+const finalRequest = `
+    WITH table_duplicates AS (SELECT 
+        modifications.date,
+        modifications.hid, lag(modifications.hid) over (ORDER BY modifications.shantytown_id asc, modifications.date asc) AS lag_hid,
+        modifications.updated_by, lag(modifications.updated_by) over (ORDER BY modifications.shantytown_id asc, modifications.date asc) AS lag_updated_by,
+        ${intermediary.join(', ')}
+    FROM 
+    (
+        (WITH 
+        shantytown_histories_computed_origins AS (SELECT 
+            sh.hid AS fk_shantytown, 
+            string_to_array(array_to_string(array_agg(soo.social_origin_id::VARCHAR || '|' || soo.label), ','), ',') AS origins 
+        FROM "ShantytownHistories" sh
+        LEFT JOIN "ShantytownOriginHistories" so ON so.fk_shantytown = sh.hid
+        LEFT JOIN social_origins soo ON so.fk_social_origin = soo.social_origin_id
+        GROUP BY sh.hid
+        )
+    SELECT
+    shantytowns.hid,
+    ${selectShantytownsValues.join(', ')}
+    FROM "ShantytownHistories" shantytowns
+    LEFT JOIN field_types ON shantytowns.fk_field_type = field_types.field_type_id
+    LEFT JOIN owner_types ON shantytowns.fk_owner_type = owner_types.owner_type_id
+    LEFT JOIN electricity_types ON shantytowns.fk_electricity_type = electricity_types.electricity_type_id
+    LEFT JOIN shantytown_histories_computed_origins sco ON sco.fk_shantytown = shantytowns.hid
+    WHERE shantytowns.closed_at IS NULL
+    )
+
+    UNION ALL
+
+    (with shantytown_computed_origins as (SELECT
+            sh.shantytown_id AS fk_shantytown, 
+            string_to_array(array_to_string(array_agg(soo.social_origin_id::VARCHAR || '|' || soo.label), ','), ',') AS origins 
+        FROM shantytowns sh
+        LEFT JOIN shantytown_origins so ON so.fk_shantytown = sh.shantytown_id 
+        LEFT JOIN social_origins soo ON so.fk_social_origin = soo.social_origin_id
+        GROUP BY sh.shantytown_id 
+        )
+    SELECT
+    0 AS hid,
+    ${selectShantytownsValues.join(', ')}
+    FROM shantytowns shantytowns
+    LEFT JOIN field_types ON shantytowns.fk_field_type = field_types.field_type_id
+    LEFT JOIN owner_types ON shantytowns.fk_owner_type = owner_types.owner_type_id
+    LEFT JOIN electricity_types ON shantytowns.fk_electricity_type = electricity_types.electricity_type_id
+    LEFT JOIN shantytown_computed_origins sco ON sco.fk_shantytown = shantytowns.shantytown_id
+    WHERE shantytowns.closed_at IS NULL
+    )) modifications
+    ORDER BY modifications.date DESC)
+    SELECT hid, lag_hid, shantytown_id, updated_by, lag_updated_by FROM table_duplicates
+    WHERE ${where.join(' AND ')}`;
+
+
+module.exports = {
+    async up(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+        const historyDuplicates = await queryInterface.sequelize.query(
+            finalRequest,
+            {
+                type: queryInterface.sequelize.QueryTypes.SELECT,
+                transaction,
+            },
+        );
+
+        await Promise.all(historyDuplicates.reduce((acc, town) => {
+            if (town.hid !== 0) {
+                acc.push(queryInterface.sequelize.query('DELETE FROM "ShantytownHistories" WHERE hid = :hid', {
+                    transaction,
+                    replacements: {
+                        hid: town.hid,
+                    },
+                }));
+            } else {
+                acc.push(queryInterface.sequelize.query('DELETE FROM "ShantytownHistories" WHERE hid = :hid', {
+                    transaction,
+                    replacements: {
+                        hid: town.lag_hid,
+                    },
+                }));
+                acc.push(queryInterface.sequelize.query('UPDATE shantytowns SET updated_by = :updated_by WHERE shantytown_id = :id', {
+                    transaction,
+                    replacements: {
+                        updated_by: town.lag_updated_by,
+                        id: town.shantytown_id,
+                    },
+                }));
+            }
+            return acc;
+        }, []));
+        return transaction.commit();
+    },
+    async down(queryInterface) {
+        // no need to do anything here
+        const transaction = await queryInterface.sequelize.transaction();
+        return transaction.commit();
+    },
+};

--- a/packages/api/server/controllers/townController/edit.js
+++ b/packages/api/server/controllers/townController/edit.js
@@ -2,6 +2,7 @@
 const { sequelize } = require('#db/models');
 const shantytownModel = require('#server/models/shantytownModel')(sequelize);
 
+
 module.exports = () => async (req, res, next) => {
     let town;
     try {
@@ -18,7 +19,6 @@ module.exports = () => async (req, res, next) => {
             user_message: `Le site d'identifiant ${req.params.id} n'existe pas : mise à jour impossible`,
         });
     }
-
     try {
         await shantytownModel.update(
             req.user,
@@ -96,9 +96,8 @@ module.exports = () => async (req, res, next) => {
                 bailiff: req.body.bailiff,
             },
         );
-        town = await shantytownModel.findOne(req.user, req.params.id);
-
-        return res.status(200).send(town);
+        const updatedTown = await shantytownModel.findOne(req.user, req.params.id);
+        return res.status(200).send(updatedTown);
     } catch (e) {
         res.status(500).send({
             user_message: 'Une erreur est survenue dans l\'enregistrement du site en base de données',

--- a/packages/frontend/src/js/app/components/TownForm/TownForm.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownForm.vue
@@ -113,18 +113,20 @@ import FormLeftColumn from "#app/components/ui/Form/FormLeftColumn";
 import FormErrorLog from "#app/components/ui/Form/FormErrorLog";
 import { add, edit } from "#helpers/api/town";
 import { notify } from "#helpers/notificationHelper";
+import formatTown from "./utils/formatTown";
+const isEqual = require("lodash");
 
 export default {
     props: {
         mode: {
-            type: String
+            type: String,
         },
         data: {
             type: Object,
             default() {
                 return {};
-            }
-        }
+            },
+        },
     },
 
     components: {
@@ -136,7 +138,7 @@ export default {
         TownFormPanelCharacteristics,
         TownFormPanelPeople,
         TownFormPanelLivingConditions,
-        TownFormPanelJudicial
+        TownFormPanelJudicial,
     },
 
     data() {
@@ -150,172 +152,12 @@ export default {
                 { id: "people", label: "Habitants" },
                 {
                     id: "living_conditions",
-                    label: "Conditions de vie et environnement"
+                    label: "Conditions de vie et environnement",
                 },
-                { id: "judicial", label: "Procédure judiciaire" }
+                { id: "judicial", label: "Procédure judiciaire" },
             ],
-            town: {
-                location: {
-                    address: {
-                        label: this.data.address
-                            ? this.data.address
-                            : undefined,
-                        citycode: this.data.city
-                            ? this.data.city.code
-                            : undefined
-                    },
-                    name: this.data.name || undefined,
-                    coordinates: this.data.latitude
-                        ? [this.data.latitude, this.data.longitude]
-                        : undefined
-                },
-                characteristics: {
-                    built_at: this.data.builtAt
-                        ? new Date(this.data.builtAt * 1000)
-                        : undefined,
-                    declared_at: this.data.declaredAt
-                        ? new Date(this.data.declaredAt * 1000)
-                        : undefined,
-                    field_type: this.data.fieldType
-                        ? this.data.fieldType.id
-                        : undefined,
-                    detailed_address: this.data.addressDetails,
-                    owner_type: this.data.ownerType
-                        ? this.data.ownerType.id
-                        : undefined,
-                    owner: this.data.owner,
-                    is_reinstallation: this.boolToInt(
-                        this.data.isReinstallation
-                    ),
-                    reinstallation_comments:
-                        this.data.reinstallationComments || undefined
-                },
-                people: {
-                    population: {
-                        populationTotal: this.intToStr(
-                            this.data.populationTotal
-                        ),
-                        populationCouples: this.intToStr(
-                            this.data.populationCouples
-                        ),
-                        populationMinors: this.intToStr(
-                            this.data.populationMinors
-                        )
-                    },
-                    populationMinors: {
-                        populationMinors0To3: this.intToStr(
-                            this.data.populationMinors0To3
-                        ),
-                        populationMinors3To6: this.intToStr(
-                            this.data.populationMinors3To6
-                        ),
-                        populationMinors6To12: this.intToStr(
-                            this.data.populationMinors6To12
-                        ),
-                        populationMinors12To16: this.intToStr(
-                            this.data.populationMinors12To16
-                        ),
-                        populationMinors16To18: this.intToStr(
-                            this.data.populationMinors16To18
-                        ),
-                        minorsInSchool: this.intToStr(this.data.minorsInSchool)
-                    },
-                    social_origins: this.data.socialOrigins
-                        ? this.data.socialOrigins.map(({ id }) => id)
-                        : [],
-                    census_status: this.toNullableStr(this.data.censusStatus),
-                    census_conducted_at: this.data.censusConductedAt
-                        ? new Date(this.data.censusConductedAt * 1000)
-                        : undefined,
-                    census_conducted_by: this.data.censusConductedBy
-                },
-                living_conditions: {
-                    access_to_water: this.boolToInt(this.data.accessToWater),
-                    water_comments: this.data.waterComments || undefined,
-                    electricity_type: this.data.electricityType
-                        ? this.data.electricityType.id
-                        : undefined,
-                    electricity_comments:
-                        this.data.electricityComments || undefined,
-                    access_to_sanitary: this.boolToInt(
-                        this.data.accessToSanitary
-                    ),
-                    sanitary_comments: this.data.sanitaryComments || undefined,
-                    trash_evacuation: this.boolToInt(this.data.trashEvacuation),
-                    water_potable: this.boolToInt(this.data.waterPotable),
-                    water_public_point: this.boolToInt(
-                        this.data.waterPublicPoint
-                    ),
-                    water_continuous_access: this.boolToInt(
-                        this.data.waterContinuousAccess
-                    ),
-                    water_distance: this.data.waterDistance,
-                    water_roads_to_cross: this.boolToInt(
-                        this.data.waterRoadsToCross
-                    ),
-                    water_everyone_has_access: this.boolToInt(
-                        this.data.waterEveryoneHasAccess
-                    ),
-                    water_stagnant_water: this.boolToInt(
-                        this.data.waterStagnantWater
-                    ),
-                    water_hand_wash_access: this.boolToInt(
-                        this.data.waterHandWashAccess
-                    ),
-                    water_hand_wash_access_number: this.data
-                        .waterHandWashAccessNumber,
-                    sanitary_number: this.data.sanitaryNumber,
-                    sanitary_insalubrious: this.boolToInt(
-                        this.data.sanitaryInsalubrious
-                    ),
-                    sanitary_on_site: this.boolToInt(this.data.sanitaryOnSite),
-                    trash_cans_on_site: this.data.trashCansOnSite,
-                    trash_accumulation: this.boolToInt(
-                        this.data.trashAccumulation
-                    ),
-                    trash_evacuation_regular: this.boolToInt(
-                        this.data.trashEvacuationRegular
-                    ),
-                    vermin: this.boolToInt(this.data.vermin),
-                    vermin_comments: this.data.verminComments,
-                    fire_prevention_measures: this.boolToInt(
-                        this.data.firePreventionMeasures
-                    ),
-                    fire_prevention_diagnostic: this.boolToInt(
-                        this.data.firePreventionDiagnostic
-                    ),
-                    fire_prevention_devices: this.boolToInt(
-                        this.data.firePreventionDevices
-                    ),
-                    fire_prevention_site_accessible: this.boolToInt(
-                        this.data.firePreventionSiteAccessible
-                    ),
-                    fire_prevention_comments: this.data.firePreventionComments
-                },
-                judicial: {
-                    owner_complaint: this.boolToInt(this.data.ownerComplaint),
-                    justice_procedure: this.boolToInt(
-                        this.data.justiceProcedure
-                    ),
-                    justice_rendered: this.boolToInt(this.data.justiceRendered),
-                    justice_rendered_at: this.data.justiceRenderedAt
-                        ? new Date(this.data.justiceRenderedAt * 1000)
-                        : undefined,
-                    justice_rendered_by:
-                        this.data.justiceRenderedBy || undefined,
-                    justice_challenged: this.boolToInt(
-                        this.data.justiceChallenged
-                    ),
-                    police_status: this.toNullableStr(this.data.policeStatus),
-                    police_requested_at: this.data.policeRequestedAt
-                        ? new Date(this.data.policeRequestedAt * 1000)
-                        : undefined,
-                    police_granted_at: this.data.policeGrantedAt
-                        ? new Date(this.data.policeGrantedAt * 1000)
-                        : undefined,
-                    bailiff: this.data.bailiff || undefined
-                }
-            }
+            initialTown: this.formatTown(this.data),
+            town: this.formatTown(this.data),
         };
     },
 
@@ -350,40 +192,17 @@ export default {
             return this.$store.getters["config/hasPermission"](
                 "shantytown_justice.access"
             );
-        }
+        },
     },
 
     methods: {
+        formatTown,
         back() {
             this.$router.replace(this.backPage);
         },
 
         closeInfo() {
             this.showInfo = false;
-        },
-
-        boolToInt(bool) {
-            if (bool === undefined) {
-                return undefined;
-            }
-
-            if (bool === true) {
-                return 1;
-            }
-
-            if (bool === false) {
-                return 0;
-            }
-
-            return -1;
-        },
-
-        intToStr(int) {
-            if (typeof int === "number") {
-                return `${int}`;
-            }
-
-            return undefined;
         },
 
         strToInt(str) {
@@ -400,14 +219,6 @@ export default {
             }
 
             return str;
-        },
-
-        toNullableStr(value) {
-            if (value === undefined || value === null) {
-                return "null";
-            }
-
-            return value;
         },
 
         formatDate(d) {
@@ -430,7 +241,14 @@ export default {
                 );
                 return;
             }
-
+            if (isEqual(this.town, this.initialTown)) {
+                this.mainError =
+                    "Modification impossible : aucun champ n'a été modifié";
+                this.$router.replace("#top", () =>
+                    this.$router.replace("#erreurs")
+                );
+                return;
+            }
             this.loading = true;
             this.mainError = null;
             this.$router.replace("#top");
@@ -466,14 +284,14 @@ export default {
                         this.town.characteristics.declared_at
                     ),
                     field_type: this.town.characteristics.field_type,
-                    detailed_address: this.town.characteristics
-                        .detailed_address,
+                    detailed_address:
+                        this.town.characteristics.detailed_address,
                     owner_type: this.town.characteristics.owner_type,
                     owner: this.town.characteristics.owner,
-                    is_reinstallation: this.town.characteristics
-                        .is_reinstallation,
-                    reinstallation_comments: this.town.characteristics
-                        .reinstallation_comments,
+                    is_reinstallation:
+                        this.town.characteristics.is_reinstallation,
+                    reinstallation_comments:
+                        this.town.characteristics.reinstallation_comments,
                     population_total: this.strToInt(
                         this.town.people.population.populationTotal
                     ),
@@ -526,7 +344,7 @@ export default {
                     police_granted_at: this.formatDate(
                         this.town.judicial.police_granted_at
                     ),
-                    bailiff: this.town.judicial.bailiff
+                    bailiff: this.town.judicial.bailiff,
                 });
 
                 this.loading = false;
@@ -544,7 +362,7 @@ export default {
                     group: "notifications",
                     type: "success",
                     title: "Succès",
-                    text: this.successNotificationWording
+                    text: this.successNotificationWording,
                 });
             } catch (err) {
                 this.loading = false;
@@ -584,8 +402,8 @@ export default {
         },
         showClosedTowns(closedTowns) {
             this.nearbyClosedShantytowns = closedTowns;
-        }
-    }
+        },
+    },
 };
 </script>
 

--- a/packages/frontend/src/js/app/components/TownForm/utils/formatTown.js
+++ b/packages/frontend/src/js/app/components/TownForm/utils/formatTown.js
@@ -1,0 +1,136 @@
+function boolToInt(bool) {
+    if (bool === undefined) {
+        return undefined;
+    }
+
+    if (bool === true) {
+        return 1;
+    }
+
+    if (bool === false) {
+        return 0;
+    }
+
+    return -1;
+}
+
+function intToStr(int) {
+    if (typeof int === "number") {
+        return `${int}`;
+    }
+
+    return undefined;
+}
+
+function toNullableStr(value) {
+    if (value === undefined || value === null) {
+        return "null";
+    }
+
+    return value;
+}
+
+export default function formatTown(data) {
+    return {
+        location: {
+            address: {
+                label: data.address ? data.address : undefined,
+                citycode: data.city ? data.city.code : undefined
+            },
+            name: data.name || undefined,
+            coordinates: data.latitude
+                ? [data.latitude, data.longitude]
+                : undefined
+        },
+        characteristics: {
+            built_at: data.builtAt ? new Date(data.builtAt * 1000) : undefined,
+            declared_at: data.declaredAt
+                ? new Date(data.declaredAt * 1000)
+                : undefined,
+            field_type: data.fieldType ? data.fieldType.id : undefined,
+            detailed_address: data.addressDetails,
+            owner_type: data.ownerType ? data.ownerType.id : undefined,
+            owner: data.owner,
+            is_reinstallation: boolToInt(data.isReinstallation),
+            reinstallation_comments: data.reinstallationComments || undefined
+        },
+        people: {
+            population: {
+                populationTotal: intToStr(data.populationTotal),
+                populationCouples: intToStr(data.populationCouples),
+                populationMinors: intToStr(data.populationMinors)
+            },
+            populationMinors: {
+                populationMinors0To3: intToStr(data.populationMinors0To3),
+                populationMinors3To6: intToStr(data.populationMinors3To6),
+                populationMinors6To12: intToStr(data.populationMinors6To12),
+                populationMinors12To16: intToStr(data.populationMinors12To16),
+                populationMinors16To18: intToStr(data.populationMinors16To18),
+                minorsInSchool: intToStr(data.minorsInSchool)
+            },
+            social_origins: data.socialOrigins
+                ? data.socialOrigins.map(({ id }) => id)
+                : [],
+            census_status: toNullableStr(data.censusStatus),
+            census_conducted_at: data.censusConductedAt
+                ? new Date(data.censusConductedAt * 1000)
+                : undefined,
+            census_conducted_by: data.censusConductedBy
+        },
+        living_conditions: {
+            access_to_water: boolToInt(data.accessToWater),
+            water_comments: data.waterComments || undefined,
+            electricity_type: data.electricityType
+                ? data.electricityType.id
+                : undefined,
+            electricity_comments: data.electricityComments || undefined,
+            access_to_sanitary: boolToInt(data.accessToSanitary),
+            sanitary_comments: data.sanitaryComments || undefined,
+            trash_evacuation: boolToInt(data.trashEvacuation),
+            water_potable: boolToInt(data.waterPotable),
+            water_public_point: boolToInt(data.waterPublicPoint),
+            water_continuous_access: boolToInt(data.waterContinuousAccess),
+            water_distance: data.waterDistance,
+            water_roads_to_cross: boolToInt(data.waterRoadsToCross),
+            water_everyone_has_access: boolToInt(data.waterEveryoneHasAccess),
+            water_stagnant_water: boolToInt(data.waterStagnantWater),
+            water_hand_wash_access: boolToInt(data.waterHandWashAccess),
+            water_hand_wash_access_number: data.waterHandWashAccessNumber,
+            sanitary_number: data.sanitaryNumber,
+            sanitary_insalubrious: boolToInt(data.sanitaryInsalubrious),
+            sanitary_on_site: boolToInt(data.sanitaryOnSite),
+            trash_cans_on_site: data.trashCansOnSite,
+            trash_accumulation: boolToInt(data.trashAccumulation),
+            trash_evacuation_regular: boolToInt(data.trashEvacuationRegular),
+            vermin: boolToInt(data.vermin),
+            vermin_comments: data.verminComments,
+            fire_prevention_measures: boolToInt(data.firePreventionMeasures),
+            fire_prevention_diagnostic: boolToInt(
+                data.firePreventionDiagnostic
+            ),
+            fire_prevention_devices: boolToInt(data.firePreventionDevices),
+            fire_prevention_site_accessible: boolToInt(
+                data.firePreventionSiteAccessible
+            ),
+            fire_prevention_comments: data.firePreventionComments
+        },
+        judicial: {
+            owner_complaint: boolToInt(data.ownerComplaint),
+            justice_procedure: boolToInt(data.justiceProcedure),
+            justice_rendered: boolToInt(data.justiceRendered),
+            justice_rendered_at: data.justiceRenderedAt
+                ? new Date(data.justiceRenderedAt * 1000)
+                : undefined,
+            justice_rendered_by: data.justiceRenderedBy || undefined,
+            justice_challenged: boolToInt(data.justiceChallenged),
+            police_status: toNullableStr(data.policeStatus),
+            police_requested_at: data.policeRequestedAt
+                ? new Date(data.policeRequestedAt * 1000)
+                : undefined,
+            police_granted_at: data.policeGrantedAt
+                ? new Date(data.policeGrantedAt * 1000)
+                : undefined,
+            bailiff: data.bailiff || undefined
+        }
+    };
+}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/MtXk5xrq/1331-modification-dun-site-emp%C3%AAcher-la-validation-dune-modification-si-aucun-champ-na-%C3%A9t%C3%A9-modifi%C3%A9-et-supprimer-les-%C3%A9ventuels-doublons

## 🛠 Description de la PR
 La présence de doublons dans les lignes de shantytowns et ShantytownHistories pouvaient être la source de bug avec l'infinite scrolling de la page 'Dernières activités'
Cette PR résout le problème : 
- réorganisation du fichier TownForm.vue pour le rendre plus lisible (avec export de certaines fonctions dans un fichier séparé), et ajout d'une vérification avant de soumettre le formulaire : si aucun champ n'est modifié, pas d'appel API, et on affiche une erreur.
- migration pour supprimer les doublons existants actuellement


## 🚨 Notes pour la mise en production
migration à faire tourner