### PR TITLE
#patch(1388) changement script precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 
 # on lint les fichiers staged
 # on le fait séquentiellement (--concurrency 1) car sinon il y a un conflit sur l'utilisation de git pour récupérer la liste des fichiers staged
-yarn lerna exec --concurrency 1 lint-staged
+yarn lerna exec --concurrency 1 yarn lint-staged


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/xb8DlBfM/1388-tech-changer-le-script-de-pre-commit-pour-utiliser-les-versions-locales-et-non-globales-de-lint-staged

## 🛠 Description de la PR
changement du script de precommit pour exécuter la commande "yarn lint-staged" et non "lint-staged" afin d'utiliser les versions de lint-staged installées dans les dépendances et non celle installée globalement (si elle existe)
