### PR TITLE
#patch (1384) Ajout de la parcelle cadastrale sur la fiche d'un site

### DIFF
--- a/packages/frontend/src/js/app/components/map/map.scss
+++ b/packages/frontend/src/js/app/components/map/map.scss
@@ -28,7 +28,8 @@
             display: none;
         }
 
-        .leaflet-address-toggler {
+        .leaflet-address-toggler,
+        .leaflet-cadastre-toggler {
             display: none;
         }
     }
@@ -250,7 +251,8 @@ img {
 }
 
 
-.leaflet-address-toggler {
+.leaflet-address-toggler,
+.leaflet-cadastre-toggler {
     font-family: Marianne;
     padding: 5px 10px;
     background: white;

--- a/packages/frontend/src/js/app/components/map/map.vue
+++ b/packages/frontend/src/js/app/components/map/map.vue
@@ -9,6 +9,11 @@
         </Address>
 
         <div id="map">
+            <div ref="cadastreToggler" class="leaflet-cadastre-toggler">
+                <input type="checkbox" v-model="showCadastre" />
+                Voir le cadastre
+            </div>
+
             <div ref="adressToggler" class="leaflet-address-toggler">
                 <input type="checkbox" v-model="showAddresses" />
                 Voir les adresses des sites
@@ -289,6 +294,20 @@ export default {
             showAddresses: false,
 
             /**
+             * Indique s'il faut afficher la parcelle cadastrale ou non
+             *
+             * Cette valeur est contrôlée par une checkbox directement sur la carte
+             *
+             * @type {Boolean}
+             */
+            showCadastre: false,
+
+            /**
+             *
+             */
+            cadastreTogglerControl: null,
+
+            /**
              * Value of showAddresses before the print
              *
              * Used to restore the original value after the print
@@ -416,6 +435,8 @@ export default {
         },
 
         cadastre() {
+            this.setupCadastreTogglerControl();
+
             if (this.cadastreLayer) {
                 this.map.removeLayer(this.cadastreLayer);
                 delete this.cadastreLayer;
@@ -427,7 +448,18 @@ export default {
             }
 
             this.cadastreLayer = L.geoJSON(this.cadastre);
-            this.map.addLayer(this.cadastreLayer);
+
+            if (this.showCadastre === true) {
+                this.map.addLayer(this.cadastreLayer);
+            }
+        },
+
+        showCadastre() {
+            if (this.showCadastre === true) {
+                this.map.addLayer(this.cadastreLayer);
+            } else {
+                this.map.removeLayer(this.cadastreLayer);
+            }
         }
     },
 
@@ -665,6 +697,45 @@ export default {
         },
 
         /**
+         * Initialise le contrôle "Voir les adresses des sites"
+         *
+         * @returns {undefined}
+         */
+        setupCadastreTogglerControl() {
+            if (!this.cadastre) {
+                if (!this.cadastreTogglerControl) {
+                    return;
+                }
+
+                this.cadastreTogglerControl.remove();
+                return;
+            }
+
+            if (!this.cadastreTogglerControl) {
+                const { cadastreToggler } = this.$refs;
+                const CadastreToggler = L.Control.extend({
+                    options: {
+                        position: "topright"
+                    },
+
+                    onAdd(map) {
+                        map.cadastreToggler = this;
+                        return cadastreToggler;
+                    },
+
+                    onRemove(map) {
+                        delete map.cadastreToggler;
+                    }
+                });
+                this.cadastreTogglerControl = new CadastreToggler();
+            }
+
+            if (!this.map.cadastreToggler) {
+                this.map.addControl(this.cadastreTogglerControl);
+            }
+        },
+
+        /**
          * Initialise le contrôle "Légende"
          *
          * @returns {undefined}
@@ -720,7 +791,6 @@ export default {
 
             if (this.cadastre) {
                 this.cadastreLayer = L.geoJSON(this.cadastre);
-                this.map.addLayer(this.cadastreLayer);
             }
 
             this.map.on("zoomend", this.onZoomEnd);

--- a/packages/frontend/src/js/app/components/map/map.vue
+++ b/packages/frontend/src/js/app/components/map/map.vue
@@ -741,18 +741,23 @@ export default {
         onZoomEnd() {
             const zoomLevel = this.map.getZoom();
 
-            if (zoomLevel <= REGION_MAX_ZOOM_LEVEL) {
-                this.displayShantytownsLevel = false;
-                this.loadRegionalData();
-                this.showRegionalLayer();
-            } else if (zoomLevel <= DEPT_MAX_ZOOM_LEVEL) {
-                this.displayShantytownsLevel = false;
-                this.loadDepartementalData();
-                this.showDepartementalLayer();
-            } else if (zoomLevel <= CITY_MAX_ZOOM_LEVEL) {
-                this.displayShantytownsLevel = false;
-                this.loadCityData();
-                this.showCityLayer();
+            if (this.loadTerritoryLayers) {
+                if (zoomLevel <= REGION_MAX_ZOOM_LEVEL) {
+                    this.displayShantytownsLevel = false;
+                    this.loadRegionalData();
+                    this.showRegionalLayer();
+                } else if (zoomLevel <= DEPT_MAX_ZOOM_LEVEL) {
+                    this.displayShantytownsLevel = false;
+                    this.loadDepartementalData();
+                    this.showDepartementalLayer();
+                } else if (zoomLevel <= CITY_MAX_ZOOM_LEVEL) {
+                    this.displayShantytownsLevel = false;
+                    this.loadCityData();
+                    this.showCityLayer();
+                } else {
+                    this.displayShantytownsLevel = true;
+                    this.showTownsLayer();
+                }
             } else {
                 this.displayShantytownsLevel = true;
                 this.showTownsLayer();

--- a/packages/frontend/src/js/app/components/map/map.vue
+++ b/packages/frontend/src/js/app/components/map/map.vue
@@ -457,6 +457,9 @@ export default {
         showCadastre() {
             if (this.showCadastre === true) {
                 this.map.addLayer(this.cadastreLayer);
+
+                const { center } = this.defaultView;
+                this.centerMap(center, 18);
             } else {
                 this.map.removeLayer(this.cadastreLayer);
             }

--- a/packages/frontend/src/js/app/components/map/map.vue
+++ b/packages/frontend/src/js/app/components/map/map.vue
@@ -37,7 +37,6 @@
 
 <script>
 /* eslint-disable no-underscore-dangle */
-
 import L from "leaflet";
 import Address from "#app/components/address/address.vue";
 import { get as getConfig } from "#helpers/api/config";
@@ -167,6 +166,15 @@ export default {
             type: String,
             required: false,
             default: "Dessin"
+        },
+
+        /* *****************************
+         * Options pour le cadastre
+         * ************************** */
+        cadastre: {
+            type: Object,
+            required: false,
+            default: null
         }
     },
 
@@ -196,6 +204,11 @@ export default {
              * @type {L.layerGroup}
              */
             cityLayer: this.loadTerritoryLayers ? L.layerGroup() : false,
+
+            /**
+             * La couche cadastrale
+             */
+            cadastreLayer: null,
 
             /**
              * La carte
@@ -400,6 +413,21 @@ export default {
             this.$nextTick(() => {
                 this.setSearchMarker(type, label, [lat, lon]);
             });
+        },
+
+        cadastre() {
+            if (this.cadastreLayer) {
+                this.map.removeLayer(this.cadastreLayer);
+                delete this.cadastreLayer;
+                this.cadastreLayer = null;
+            }
+
+            if (!this.cadastre) {
+                return;
+            }
+
+            this.cadastreLayer = L.geoJSON(this.cadastre);
+            this.map.addLayer(this.cadastreLayer);
         }
     },
 
@@ -689,6 +717,11 @@ export default {
                 layers: this.mapLayers[this.layerName], // fond de carte à afficher
                 scrollWheelZoom: false // interdire le zoom via la molette de la souris
             });
+
+            if (this.cadastre) {
+                this.cadastreLayer = L.geoJSON(this.cadastre);
+                this.map.addLayer(this.cadastreLayer);
+            }
 
             this.map.on("zoomend", this.onZoomEnd);
             if (this.loadTerritoryLayers) {

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
@@ -230,7 +230,14 @@ export default {
                     type: "Point",
                     coordinates: [this.town.longitude, this.town.latitude]
                 });
-                this.cadastre = await this.cadastrePromise;
+                const response = await this.cadastrePromise;
+
+                if (
+                    Number.isInteger(response.totalFeatures) &&
+                    response.totalFeatures > 0
+                ) {
+                    this.cadastre = response;
+                }
             } catch (error) {
                 // ignore
             }

--- a/packages/frontend/src/js/helpers/ignHelper.js
+++ b/packages/frontend/src/js/helpers/ignHelper.js
@@ -1,0 +1,40 @@
+function onLoad(success, failure) {
+    if (this.status !== 200) {
+        failure();
+        return;
+    }
+
+    try {
+        success(JSON.parse(this.responseText));
+    } catch (error) {
+        failure();
+    }
+}
+
+/**
+ * @param {Object} geojson
+ *
+ * @returns {Promise}
+ */
+export function getCadastre(geojson) {
+    const xhr = new XMLHttpRequest();
+    const promise = new Promise((success, failure) => {
+        const queries = [`geom=${encodeURIComponent(JSON.stringify(geojson))}`];
+
+        xhr.open(
+            "GET",
+            `https://apicarto.ign.fr/api/cadastre/parcelle?${queries.join("&")}`
+        );
+        xhr.onload = onLoad.bind(xhr, success, failure);
+        xhr.onerror = failure;
+        xhr.ontimeout = failure;
+        xhr.send();
+    });
+    promise.abort = () => {
+        xhr.abort();
+    };
+
+    return promise;
+}
+
+export default getCadastre;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/fgwIZlor/1384

## 🛠 Description de la PR
- Ajout de l'API IGN à notre CSP (voir PR ici : https://github.com/MTES-MCT/resorption-bidonvilles-deploy/pull/19)
- Ajout d'une prop `cadastre` au composant `map.vue`, qui permet de définir une parcelle cadastrale
- Ajout d'un contrôle sur `map.vue`, identique au contrôle `Afficher les adresses des sites`. Ce contrôle n'est visible *que* si une parcelle cadastrale est renseignée
- Lorsque le contrôle `cadastreToggler` est coché, la parcelle est affichée, sinon elle est masquée
- Ajout d'un helper permettant d'interroger l'API IGN pour en tirer une parcelle cadastrale à partir d'un point GPS
- Modification de la fiche d'un site pour utiliser tout ça

## 📸 Captures d'écran
![Capture d’écran 2022-03-16 à 07 37 07](https://user-images.githubusercontent.com/1801091/158531019-16368a11-68f6-404f-8d40-2d0c6fa2ec9e.png)