### PR TITLE
#patch (960) Permettre la mise à jour des sites rattachés à un dispositif

### DIFF
--- a/packages/api/db/migrations/30000006-create-table-plan_shantytowns_history.js
+++ b/packages/api/db/migrations/30000006-create-table-plan_shantytowns_history.js
@@ -1,0 +1,185 @@
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+        await queryInterface.createTable(
+            'plan_shantytowns_history',
+            {
+                fk_plan: {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                    primaryKey: true,
+                },
+                fk_shantytown: {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                    primaryKey: true,
+                },
+                created_by: {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                },
+                created_at: {
+                    type: Sequelize.DATE,
+                    allowNull: false,
+                    defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+                },
+                updated_by: {
+                    type: Sequelize.INTEGER,
+                    allowNull: true,
+                    defaultValue: null,
+                },
+                updated_at: {
+                    type: Sequelize.DATE,
+                    allowNull: true,
+                    defaultValue: null,
+                    onUpdate: Sequelize.literal('CURRENT_TIMESTAMP'),
+                },
+            },
+            {
+                transaction,
+            },
+        );
+
+        await Promise.all([
+            queryInterface.addConstraint(
+                'plan_shantytowns_history',
+                ['fk_plan'],
+                {
+                    type: 'foreign key',
+                    name: 'fk_plan_shantytowns_history_plan',
+                    references: {
+                        table: 'plans_history',
+                        field: 'hid',
+                    },
+                    onUpdate: 'cascade',
+                    onDelete: 'cascade',
+                    transaction,
+                },
+            ),
+            queryInterface.addConstraint(
+                'plan_shantytowns_history',
+                ['fk_shantytown'],
+                {
+                    type: 'foreign key',
+                    name: 'fk_plan_shantytowns_history_shantytown',
+                    references: {
+                        table: 'shantytowns',
+                        field: 'shantytown_id',
+                    },
+                    onUpdate: 'cascade',
+                    onDelete: 'cascade',
+                    transaction,
+                },
+            ),
+            queryInterface.addConstraint(
+                'plan_shantytowns_history',
+                ['created_by'],
+                {
+                    type: 'foreign key',
+                    name: 'fk_plan_shantytowns_history_creator',
+                    references: {
+                        table: 'users',
+                        field: 'user_id',
+                    },
+                    onUpdate: 'cascade',
+                    onDelete: 'restrict',
+                    transaction,
+                },
+            ),
+            queryInterface.addConstraint(
+                'plan_shantytowns_history',
+                ['updated_by'],
+                {
+                    type: 'foreign key',
+                    name: 'fk_plan_shantytowns_history_editor',
+                    references: {
+                        table: 'users',
+                        field: 'user_id',
+                    },
+                    onUpdate: 'cascade',
+                    onDelete: 'restrict',
+                    transaction,
+                },
+            ),
+        ]);
+
+        // on peuple la table
+        const data = await queryInterface.sequelize.query(
+            `WITH plan_hids AS (
+                SELECT plan_id, array_agg(hid) AS hids FROM plans_history GROUP BY plan_id
+            )
+            SELECT
+                plan_hids.hids,
+                plan_shantytowns.fk_shantytown,
+                plan_shantytowns.created_by,
+                plan_shantytowns.created_at,
+                plan_shantytowns.updated_by,
+                plan_shantytowns.updated_at
+            FROM plan_shantytowns
+            LEFT JOIN plan_hids ON plan_shantytowns.fk_plan = plan_hids.plan_id
+            WHERE hids IS NOT NULL`,
+            {
+                type: queryInterface.sequelize.QueryTypes.SELECT,
+                transaction,
+            },
+        );
+        await queryInterface.bulkInsert(
+            'plan_shantytowns_history',
+            data
+                .map(
+                    ({
+                        hids, fk_shantytown, created_by, created_at, updated_by, updated_at,
+                    }) => hids.map(hid => ({
+                        fk_plan: hid,
+                        fk_shantytown,
+                        created_by,
+                        created_at,
+                        updated_by,
+                        updated_at,
+                    })),
+                )
+                .flat(),
+            { transaction },
+        );
+
+        return transaction.commit();
+    },
+
+    async down(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        await Promise.all([
+            queryInterface.removeConstraint(
+                'plan_shantytowns_history',
+                'fk_plan_shantytowns_history_editor',
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.removeConstraint(
+                'plan_shantytowns_history',
+                'fk_plan_shantytowns_history_creator',
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.removeConstraint(
+                'plan_shantytowns_history',
+                'fk_plan_shantytowns_history_shantytown',
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.removeConstraint(
+                'plan_shantytowns_history',
+                'fk_plan_shantytowns_history_plan',
+                {
+                    transaction,
+                },
+            ),
+        ]);
+        await queryInterface.dropTable('plan_shantytowns_history', { transaction });
+
+        return transaction.commit();
+    },
+};

--- a/packages/api/server/controllers/planController.js
+++ b/packages/api/server/controllers/planController.js
@@ -390,6 +390,32 @@ async function historize(planId, transaction) {
     );
 
     await sequelize.query(
+        `INSERT INTO plan_shantytowns_history(
+            fk_plan,
+            fk_shantytown,
+            created_by,
+            created_at,
+            updated_by,
+            updated_at
+        ) (SELECT
+            :hid,
+            fk_shantytown,
+            created_by,
+            created_at,
+            updated_by,
+            updated_at
+        FROM plan_shantytowns
+        WHERE fk_plan = :planId)`,
+        {
+            replacements: {
+                hid,
+                planId,
+            },
+            transaction,
+        },
+    );
+
+    await sequelize.query(
         `INSERT INTO finances_history(
             fk_plan,
             year,

--- a/packages/frontend/src/js/app/components/InputShantytowns/InputShantytowns.vue
+++ b/packages/frontend/src/js/app/components/InputShantytowns/InputShantytowns.vue
@@ -108,10 +108,6 @@ export default {
                 { id: "fieldType", label: "Type de site" },
                 { id: "population", label: "Nombre de personnes" }
             ],
-            tabs: [
-                { id: "open", label: "Sites ouverts" },
-                { id: "closed", label: "Sites fermés" }
-            ],
             currentTab: "open",
             search: ""
         };
@@ -122,6 +118,16 @@ export default {
             shantytowns: "towns",
             townsLoading: "townsLoading"
         }),
+        tabs() {
+            return [
+                {
+                    id: "selected",
+                    label: `Sites sélectionnés (${this.input.length})`
+                },
+                { id: "open", label: "Sites ouverts" },
+                { id: "closed", label: "Sites fermés" }
+            ];
+        },
         data() {
             if (!this.shantytowns) {
                 return [];
@@ -129,14 +135,21 @@ export default {
 
             const reg = new RegExp(this.search, "i");
             return this.shantytowns
-                .filter(({ status, city, usename }) => {
+                .filter(({ id, status, city, usename }) => {
                     // filter by status
                     if (this.currentTab === "open") {
                         if (status !== "open") {
                             return false;
                         }
-                    } else if (status === "open") {
-                        return false;
+                    } else if (this.currentTab === "closed") {
+                        if (status === "open") {
+                            return false;
+                        }
+                    } else {
+                        // currentTab === "selected" here
+                        if (!this.input.includes(id)) {
+                            return false;
+                        }
                     }
 
                     // filter by search

--- a/packages/frontend/src/js/app/components/InputShantytowns/InputShantytowns.vue
+++ b/packages/frontend/src/js/app/components/InputShantytowns/InputShantytowns.vue
@@ -74,6 +74,11 @@ export default {
                 return [];
             }
         },
+        defaultTab: {
+            type: String,
+            required: false,
+            default: "open"
+        },
         validationName: {
             type: String
         },
@@ -108,7 +113,7 @@ export default {
                 { id: "fieldType", label: "Type de site" },
                 { id: "population", label: "Nombre de personnes" }
             ],
-            currentTab: "open",
+            currentTab: this.defaultTab,
             search: ""
         };
     },

--- a/packages/frontend/src/js/app/components/PlanForm/PlanFormPanelLocation.vue
+++ b/packages/frontend/src/js/app/components/PlanForm/PlanFormPanelLocation.vue
@@ -12,6 +12,7 @@
             <InputLocationShantytowns
                 v-if="input.location_type === 'shantytowns'"
                 v-model="input.location_shantytowns"
+                :defaultTab="mode === 'create' ? 'open' : 'selected'"
             />
 
             <InputLocationAddress

--- a/packages/frontend/src/js/app/components/PlanForm/PlanFormPanelLocation.vue
+++ b/packages/frontend/src/js/app/components/PlanForm/PlanFormPanelLocation.vue
@@ -12,7 +12,6 @@
             <InputLocationShantytowns
                 v-if="input.location_type === 'shantytowns'"
                 v-model="input.location_shantytowns"
-                :disabled="mode !== 'create'"
             />
 
             <InputLocationAddress

--- a/packages/frontend/src/js/app/components/PlanForm/inputs/InputLocationShantytowns.vue
+++ b/packages/frontend/src/js/app/components/PlanForm/inputs/InputLocationShantytowns.vue
@@ -7,6 +7,7 @@
         rules="required"
         :disabled="disabled"
         v-model="input"
+        :defaultTab="defaultTab"
     >
         <template v-slot:info
             >Merci de sélectionner les sites concernés par l'action. Si vous ne
@@ -34,6 +35,11 @@ export default {
             type: Boolean,
             required: false,
             default: false
+        },
+        defaultTab: {
+            type: String,
+            required: false,
+            default: "open"
         }
     },
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/s8arhLL4/960

## 🛠 Description de la PR
- création de la table `plan_shantytowns_history` (peuplée pour avoir un historique cohérent vis-à-vis de `plans_history`)
- modification de l'API pour systématiquement enregistrer l'historique de `plan_shantytowns` à chaque modification
- modification de l'API et du front pour permettre la mise à jour de la liste des sites
- amélioration de l'UX du formulaire de mise à jour en rajoutant un onglet "Sites sélectionnés" pour pouvoir facilement "décocher" un site, si besoin

## 📸 Captures d'écran
![Capture d’écran 2022-03-17 à 15 55 40](https://user-images.githubusercontent.com/1801091/158831582-1d807373-c7aa-42f0-9063-92f1c7575abf.png)