### PR TITLE
#patch (952) Filtrer les actions par champ d'intervention

### DIFF
--- a/packages/frontend/src/js/app/pages/PlanList/PlanFilters.vue
+++ b/packages/frontend/src/js/app/pages/PlanList/PlanFilters.vue
@@ -1,0 +1,39 @@
+<template>
+    <nav>
+        <p>Filtrer par</p>
+        <CustomFilter
+            title="Champs d'intervention"
+            :options="topicOptions"
+            v-model="topicFilter"
+        />
+    </nav>
+</template>
+
+<script>
+import { get as getConfig } from "#helpers/api/config";
+
+export default {
+    data() {
+        const { topics } = getConfig();
+
+        return {
+            topicOptions: topics.map(({ uid, name }) => ({
+                id: uid,
+                value: uid,
+                label: name
+            }))
+        };
+    },
+
+    computed: {
+        topicFilter: {
+            get() {
+                return this.$store.state.plans.topicFilter;
+            },
+            set(value) {
+                this.$store.commit("setTopicFilter", value);
+            }
+        }
+    }
+};
+</script>

--- a/packages/frontend/src/js/app/pages/PlanList/PlanList.vue
+++ b/packages/frontend/src/js/app/pages/PlanList/PlanList.vue
@@ -10,12 +10,15 @@
             <PlanListHeader class="pt-10" />
 
             <div v-if="pageContent.length >= 1">
-                <Pagination
-                    class="md:mt-0 mb-6 justify-end"
-                    :currentPage="currentPage"
-                    :nbPages="nbPages"
-                    :onChangePage="onChangePage"
-                />
+                <div class="flex justify-between items-end mb-4">
+                    <PlanFilters class="mb-1" />
+                    <Pagination
+                        class="md:mt-0 justify-end"
+                        :currentPage="currentPage"
+                        :nbPages="nbPages"
+                        :onChangePage="onChangePage"
+                    />
+                </div>
                 <PlanCard
                     v-for="plan in pageContent"
                     :key="plan.id"
@@ -47,6 +50,7 @@ import PlanListLoader from "./PlanListLoader.vue";
 import PlanListHeader from "./PlanListHeader/PlanListHeader.vue";
 import PlanListEmpty from "./PlanListEmpty.vue";
 import PlanCard from "./PlanListCard/PlanCard.vue";
+import PlanFilters from "./PlanFilters.vue";
 import LoadingError from "#app/components/PrivateLayout/LoadingError.vue";
 import { mapGetters } from "vuex";
 
@@ -61,7 +65,8 @@ export default {
         PlanListLoader,
         PlanListHeader,
         PlanCard,
-        PlanListEmpty
+        PlanListEmpty,
+        PlanFilters
     },
 
     methods: {

--- a/packages/frontend/src/js/app/pages/PlanList/PlanList.vue
+++ b/packages/frontend/src/js/app/pages/PlanList/PlanList.vue
@@ -1,14 +1,15 @@
 <template>
     <PrivateLayout>
         <PlanListSearchBar />
+        <PrivateContainer>
+            <PlanListHeader class="pt-10" />
+        </PrivateContainer>
 
-        <PrivateContainer v-if="state == 'loading'">
+        <PrivateContainer v-if="state === 'loading'">
             <PlanListLoader></PlanListLoader>
         </PrivateContainer>
 
         <PrivateContainer v-else-if="state == 'loaded'">
-            <PlanListHeader class="pt-10" />
-
             <div v-if="pageContent.length >= 1">
                 <div class="flex justify-between items-end mb-4">
                     <PlanFilters class="mb-1" />

--- a/packages/frontend/src/js/app/pages/PlanList/PlanListEmpty.vue
+++ b/packages/frontend/src/js/app/pages/PlanList/PlanListEmpty.vue
@@ -1,5 +1,18 @@
 <template>
-    <div class="text-center text-G600 italic pb-10">
-        Aucune action sur ce territoire
+    <div>
+        <PlanFilters class="mb-10" />
+        <p class="text-center text-G600 italic pb-10">
+            Aucune action ne correspond aux filtres et territoire sélectionnés
+        </p>
     </div>
 </template>
+
+<script>
+import PlanFilters from "./PlanFilters.vue";
+
+export default {
+    components: {
+        PlanFilters
+    }
+};
+</script>

--- a/packages/frontend/src/js/app/pages/PlanList/PlanListHeader/PlanListHeader.vue
+++ b/packages/frontend/src/js/app/pages/PlanList/PlanListHeader/PlanListHeader.vue
@@ -1,12 +1,14 @@
 <template>
-    <div>
-        <h1 class="text-display-lg mb-4 whitespace-nowrap">Actions</h1>
-        <h2 class="mb-4">
-            L'ensemble des actions sur votre territoire :
-            <span class="font-bold">{{ location.label }}</span>
-        </h2>
+    <div class="flex justify-between items-start mb-8">
+        <div>
+            <h1 class="text-display-lg mb-2 whitespace-nowrap">Actions</h1>
+            <h2 v-if="state !== 'loading'">
+                L'ensemble des actions sur votre territoire :
+                <span class="font-bold">{{ location.label }}</span>
+            </h2>
+        </div>
 
-        <div class="md:flex md:flex-row-reverse mb-6">
+        <div class="flex items-end space-x-6">
             <div v-if="hasPermission('plan.create')">
                 <router-link to="/nouvelle-action">
                     <Button
@@ -24,7 +26,6 @@
                 icon="file-excel"
                 iconPosition="left"
                 variant="primary"
-                class="mr-6"
                 @click="exportPlans"
                 :loading="exportIsPending"
                 >Exporter</Button
@@ -60,25 +61,26 @@ export default {
                     group: "notifications",
                     type: "error",
                     title: "Une erreur est survenue",
-                    text: "Une erreur est survenue durant l'export des actions"
+                    text: "Une erreur est survenue durant l'export des actions",
                 });
             }
 
             this.exportIsPending = false;
-        }
+        },
     },
 
     data() {
         return {
-            exportIsPending: false
+            exportIsPending: false,
         };
     },
 
     computed: {
         ...mapGetters({
             location: "plansLocationFilter",
-            hasPermission: "config/hasPermission"
-        })
-    }
+            hasPermission: "config/hasPermission",
+            state: "plansState",
+        }),
+    },
 };
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/TMQeaI0O/952

## 🛠 Description de la PR
- mise en place du filtre
- légère amélioration UX du header de la liste des actions (faire en sorte que les boutons "déclarer" et "exporter" soient visibles même pendant le loading des données, la raison de ce changement étant qu'avec le nouveau menu on ne peut plus accéder au formulaire de déclaration de dispositif autrement, et je trouve ça dommage de bloquer la navigation en attendant le chargement des données)