### PR TITLE
#patch (1363-correctif) correction vue d'ensemble

### DIFF
--- a/packages/api/server/models/statsModel/getStats.js
+++ b/packages/api/server/models/statsModel/getStats.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const { sequelize } = require('#db/models');
 const decomposeForDiagramm = require('./_common/decomposeForDiagramm');
 const getArrayOfDates = require('./_common/getArrayOfDates');
@@ -16,11 +15,17 @@ module.exports = async () => {
             shantytowns.closed_at,
             resorbed,
             shantytowns.shantytown_id as id
-        FROM (
-            (SELECT updated_at, closed_at, CAST(closed_with_solutions AS text) as resorbed, shantytown_id, population_total, population_minors, minors_in_school FROM shantytowns)
-            UNION
-            (SELECT updated_at, closed_at, CAST(closed_with_solutions AS text) as resorbed, shantytown_id, population_total, population_minors, minors_in_school FROM "ShantytownHistories" sh
-            WHERE sh.updated_at > '${moment(otherDate).format('YYYY-MM-DD HH:mm:ss ZZ')}' )
+        FROM 
+            (
+                (
+                    SELECT shantytowns.updated_at, closed_at, CAST(closed_with_solutions AS text) as resorbed, shantytown_id, population_total, population_minors, minors_in_school 
+                    FROM shantytowns
+                )
+                UNION
+                (
+                    SELECT shantytowns.updated_at, closed_at, CAST(closed_with_solutions AS text) as resorbed, shantytown_id, population_total, population_minors, minors_in_school 
+                    FROM "ShantytownHistories" shantytowns
+                )
             ) shantytowns
         ORDER BY shantytowns.updated_at DESC`,
         {

--- a/packages/frontend/src/js/app/utils/formatStats.js
+++ b/packages/frontend/src/js/app/utils/formatStats.js
@@ -7,7 +7,7 @@ module.exports = stats => {
             label: "personnes ",
             label_secondary: "sur",
             label_tertiary: "sites",
-            figure_secondary: stats.openShantytowns.figures[0],
+            figure_secondary: stats.openShantytowns.figures.slice(-1)[0],
             color: stats.population.evolution >= 0 ? "red" : "green"
         },
         {
@@ -17,7 +17,7 @@ module.exports = stats => {
             label: `enfants`,
             label_secondary: "dont",
             label_tertiary: "scolarisés",
-            figure_secondary: stats.minorsInSchool.figures[0],
+            figure_secondary: stats.minorsInSchool.figures.slice(-1)[0],
             color: stats.minors.evolution >= 0 ? "red" : "green"
         },
         {


### PR DESCRIPTION



## 🛠 Description de la PR
correction API concernant les données de la vue d'ensemble : 
- dans formatStats, il faut récupérer la donnée du dernier élément du tableau et non le premier pour les sites ouverts et les mineurs scolarisés (lié au fait que j'ai changé l'ordre du tableau dans une correction récente)
- dans la requête de getStats, ne pas mettre de filtre sur la date de mise à jour des sites : récupérer tout l'historique, la méthode decomposeForDiagramm s'occupe ensuite de traiter les données