### PR TITLE
#patch (1391) suppression des sites dans ShantytownHistories

### DIFF
--- a/packages/api/db/migrations/30000006-delete-useless-rows-from-shantytownHistories.js
+++ b/packages/api/db/migrations/30000006-delete-useless-rows-from-shantytownHistories.js
@@ -1,0 +1,22 @@
+// deletes rows in table Shantytownhistories corresponding to shantytowns that have been deleted in table shantytowns
+
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'SELECT DISTINCT shantytown_id  FROM "ShantytownHistories" sh WHERE sh.shantytown_id NOT IN (SELECT shantytown_id FROM shantytowns)',
+            { type: queryInterface.sequelize.QueryTypes.SELECT, transaction },
+        )
+            .then(shantytowns => Promise.all(shantytowns.map(({ shantytown_id }) => queryInterface.bulkDelete(
+                '"ShantytownHistories"',
+                {
+                    shantytown_id,
+                },
+                {
+                    transaction,
+                },
+            )))),
+    ),
+
+
+    down: () => Promise.resolve(),
+};

--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -11,6 +11,7 @@ const { sendUserCommentDeletion } = require('#server/mails/mails');
 const { can } = require('#server/utils/permission');
 const mattermostUtils = require('#server/utils/mattermost');
 const userModel = require('#server/models/userModel')(sequelize);
+const { deleteShantytown } = require('#server/models/shantytownModel')();
 const mails = require('#server/mails/mails');
 const shantytownService = require('#server/services/shantytown');
 const shantytownActorThemes = require('#server/config/shantytown_actor_themes');
@@ -181,7 +182,7 @@ module.exports = (models) => {
 
             // delete the town
             try {
-                await town.destroy();
+                deleteShantytown(town.id);
                 return res.status(200).send({});
             } catch (e) {
                 res.status(500).send({

--- a/packages/api/server/models/shantytownModel/delete.js
+++ b/packages/api/server/models/shantytownModel/delete.js
@@ -1,0 +1,23 @@
+const { sequelize } = require('#db/models');
+
+module.exports = async (id) => {
+    const promises = [
+        sequelize.query(
+            'DELETE FROM shantytowns WHERE shantytown_id = :id',
+            {
+                replacements: {
+                    id,
+                },
+            },
+        ),
+        sequelize.query(
+            'DELETE FROM "ShantytownHistories" WHERE shantytown_id = :id',
+            {
+                replacements: {
+                    id,
+                },
+            },
+        ),
+    ];
+    await Promise.all(promises);
+};

--- a/packages/api/server/models/shantytownModel/delete.js
+++ b/packages/api/server/models/shantytownModel/delete.js
@@ -1,23 +1,24 @@
 const { sequelize } = require('#db/models');
 
 module.exports = async (id) => {
-    const promises = [
-        sequelize.query(
-            'DELETE FROM shantytowns WHERE shantytown_id = :id',
-            {
-                replacements: {
-                    id,
-                },
+    const transaction = await sequelize.transaction();
+    await sequelize.query(
+        'DELETE FROM shantytowns WHERE shantytown_id = :id',
+        {
+            transaction,
+            replacements: {
+                id,
             },
-        ),
-        sequelize.query(
+        },
+    )
+        .then(sequelize.query(
             'DELETE FROM "ShantytownHistories" WHERE shantytown_id = :id',
             {
+                transaction,
                 replacements: {
                     id,
                 },
             },
-        ),
-    ];
-    await Promise.all(promises);
+        ));
+    await transaction.commit();
 };

--- a/packages/api/server/models/shantytownModel/getHistory.js
+++ b/packages/api/server/models/shantytownModel/getHistory.js
@@ -44,7 +44,6 @@ module.exports = async (user, location, shantytownFilter, numberOfActivities, la
                     FROM "ShantytownHistories" shantytowns
                     LEFT JOIN shantytowns AS s ON shantytowns.shantytown_id = s.shantytown_id
                     ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
-                    WHERE s.shantytown_id IS NOT NULL /* filter out history of deleted shantytowns */
                     ${where.length > 0 ? `AND ((${where.join(') OR (')}))` : ''}
                 )
                 UNION

--- a/packages/api/server/models/shantytownModel/index.js
+++ b/packages/api/server/models/shantytownModel/index.js
@@ -7,6 +7,8 @@ const getHistory = require('./getHistory');
 const getUsenameOf = require('./_common/getUsenameOf');
 const update = require('./update');
 const serializeComment = require('./_common/serializeComment');
+const deleteShantytown = require('./delete');
+
 
 module.exports = () => ({
     createCovidComment,
@@ -18,4 +20,5 @@ module.exports = () => ({
     getUsenameOf,
     serializeComment,
     update,
+    deleteShantytown,
 });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/hzQBQ3xH/1391-retirer-de-la-bdd-lhistorique-des-sites-supprim%C3%A9s

## 🛠 Description de la PR
Lorsque l'on supprime un site, jusqu'à présent, le site était supprimé dans la table shantytowns, mais les lignes de l'historique demeuraient dans ShantytownHistories.
Désormais ce n'est plus le cas: cette PR inclue : 
- une modification dans l'API avec la création d'une méthode delete dans shantytownModel 
- une migration supprimant les lignes dans ShantytownHistories correspondant à des sites déjà supprimés


## 🚨 Notes pour la mise en production
Migration à faire tourner