### PR TITLE
#patch (1393) correction import isEqual

### DIFF
--- a/packages/frontend/src/js/app/components/TownForm/TownForm.vue
+++ b/packages/frontend/src/js/app/components/TownForm/TownForm.vue
@@ -114,7 +114,7 @@ import FormErrorLog from "#app/components/ui/Form/FormErrorLog";
 import { add, edit } from "#helpers/api/town";
 import { notify } from "#helpers/notificationHelper";
 import formatTown from "./utils/formatTown";
-const isEqual = require("lodash");
+const { isEqual } = require("lodash");
 
 export default {
     props: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/6zW869W7/1393-bug-impossible-de-cr%C3%A9er-mettre-%C3%A0-jour-des-sites

## 🛠 Description de la PR
l'import de la méthode isEqual de lodash n'était pas correct

