### PR TITLE
#patch (1394) correction recherche dernières activités

### DIFF
--- a/packages/api/server/models/shantytownModel/getHistory.js
+++ b/packages/api/server/models/shantytownModel/getHistory.js
@@ -44,7 +44,7 @@ module.exports = async (user, location, shantytownFilter, numberOfActivities, la
                     FROM "ShantytownHistories" shantytowns
                     LEFT JOIN shantytowns AS s ON shantytowns.shantytown_id = s.shantytown_id
                     ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
-                    ${where.length > 0 ? `AND ((${where.join(') OR (')}))` : ''}
+                    ${where.length > 0 ? `WHERE ((${where.join(') OR (')}))` : ''}
                 )
                 UNION
                 (


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/bXSBsRiA/1394-bug-la-recherche-par-filtre-g%C3%A9ographique-des-derni%C3%A8res-activit%C3%A9s-ne-fonctionne-plus

## 🛠 Description de la PR
il y  avait un soucis dans l'écriture de la requête SQL

