### PR TITLE
#patch (1409) Bug affichage carto - conditions d'accès à l'eau

### DIFF
--- a/packages/api/server/models/shantytownModel/_common/getWaterAccessConditions.js
+++ b/packages/api/server/models/shantytownModel/_common/getWaterAccessConditions.js
@@ -13,7 +13,6 @@ module.exports = (shantytown) => {
         if (
             !shantytown.waterPotable
             || !shantytown.waterContinuousAccess
-            || !shantytown.waterPublicPoint
             || !shantytown.waterDistance
             || shantytown.waterDistance !== '0-20'
             || shantytown.waterRoadsToCross === null


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/OUa9IW0i

## 🛠 Description de la PR
Correction du bug d'affichage sur carto affectant les conditions d'accès à l'eau. Si les habitants ont accès à un point d'eau mais que celui-ci n'est pas public, on classe les conditions d'accès à l'eau dans la catégorie "à améliorer". Ce qui n'est pas correct. Ce critère n'est pas à retenir pour passer le statut des conditions d'accès à l'eau de "oui" à "à améliorer". Le calcul côté API est désormais équivalent à ce qui est fait côté front dans `packages/frontend/src/js/app/pages/TownDetails/formatLivingConditions.js`

## 🚨 Notes pour la mise en production
RAS