### PR TITLE
#patch (1385) Nouveau style d'icônes sur la liste des sites

### DIFF
--- a/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
@@ -353,10 +353,10 @@ export default {
 
 <style scoped lang="scss">
 .cardGridTemplateColumns {
-    grid-template-columns: 160px 208px 164px 200px auto;
+    grid-template-columns: 160px 208px 170px 200px auto;
 
     @media print {
-        grid-template-columns: 160px 208px 164px 200px 236px;
+        grid-template-columns: 160px 208px 17px 200px 236px;
     }
 }
 

--- a/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
@@ -356,7 +356,7 @@ export default {
     grid-template-columns: 160px 208px 170px 200px auto;
 
     @media print {
-        grid-template-columns: 160px 208px 17px 200px 236px;
+        grid-template-columns: 160px 208px 170px 200px 236px;
     }
 }
 

--- a/packages/frontend/webapp/src/js/app/pages/TownsList/TownCardIcon.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownsList/TownCardIcon.vue
@@ -1,8 +1,13 @@
 <template>
-    <div :class="['flex items-center', colorClass]">
-        <div class="mr-2 w-4">
-            <Icon :icon="icon" />
-        </div>
+    <div class="flex items-center">
+        <span
+            :class="[
+                'flex rounded-full text-xs border-2 mr-2 mb-1 h-6 w-6 items-center justify-center',
+                colorClass
+            ]"
+            style="padding: 0.2em"
+            ><Icon :icon="icon"
+        /></span>
         <slot />
     </div>
 </template>
@@ -27,17 +32,17 @@ export default {
                 this.details &&
                 this.details.negative.length > 0
             ) {
-                return "text-secondary";
+                return "text-secondary border-secondary";
             }
 
             if (
                 (this.value === true && !this.inverted) ||
                 (this.value === false && this.inverted)
             ) {
-                return "text-green500";
+                return "text-green500 border-green500";
             }
 
-            return "text-red";
+            return "text-red border-red";
         },
         icon() {
             if (


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/h4wD4UkU/1385

## 🛠 Description de la PR
 ⚠️ **Cette branche part de celle du TB : à relire uniquement une fois que la 1363 est mergée dans develop**

Mise en cohérence des icônes de condition de vie de la liste des sites avec celles du tableau de bord. Je ne suis personnellement pas du tout convaincu par l'idée de mettre les icônes dans une pastille ronde : ça marche bien sur le "check", mais pas sur les autres icônes (qui ne sont pas sur le tableau de bord).

À voir avec le produit, personnellement je préconiserais de rester sur le style initial (icônes sans pastille) mais de conserver le passage en noir du texte.

## 📸 Captures d'écran
![Capture d’écran 2022-03-17 à 22 23 53](https://user-images.githubusercontent.com/1801091/158897717-33587a70-f4b3-476d-80df-497e56db11ab.png)

