### PR TITLE
#patch (1384) Ajout de la parcelle cadastrale sur la fiche d'un site

### DIFF
--- a/packages/frontend/webapp/src/js/app/components/map/map.scss
+++ b/packages/frontend/webapp/src/js/app/components/map/map.scss
@@ -28,7 +28,8 @@
             display: none;
         }
 
-        .leaflet-address-toggler {
+        .leaflet-address-toggler,
+        .leaflet-cadastre-toggler {
             display: none;
         }
     }
@@ -250,7 +251,8 @@ img {
 }
 
 
-.leaflet-address-toggler {
+.leaflet-address-toggler,
+.leaflet-cadastre-toggler {
     font-family: Marianne;
     padding: 5px 10px;
     background: white;

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
@@ -189,6 +189,7 @@
                         ]"
                         :default-view="center"
                         :load-territory-layers="false"
+                        :cadastre="cadastre"
                         @town-click="goTo"
                         layer-name="Satellite"
                     ></Map>
@@ -199,6 +200,7 @@
 </template>
 
 <script>
+import { getCadastre } from "#helpers/ignHelper";
 import Map from "#app/components/map/map.vue";
 import DetailsPanel from "#app/components/ui/details/DetailsPanel.vue";
 import DetailsPanelSection from "#app/components/ui/details/DetailsPanelSection.vue";
@@ -214,11 +216,34 @@ export default {
     },
     data() {
         return {
-            nearbyTowns: []
+            nearbyTowns: [],
+            cadastre: null,
+            cadastrePromise: null
         };
     },
     components: { DetailsPanel, DetailsPanelSection, Map },
     methods: {
+        async loadCadastre() {
+            if (this.cadastre !== null || this.cadastrePromise !== null) {
+                return;
+            }
+            try {
+                this.cadastrePromise = getCadastre({
+                    type: "Point",
+                    coordinates: [this.town.longitude, this.town.latitude]
+                });
+                const response = await this.cadastrePromise;
+                if (
+                    Number.isInteger(response.totalFeatures) &&
+                    response.totalFeatures > 0
+                ) {
+                    this.cadastre = response;
+                }
+            } catch (error) {
+                // ignore
+            }
+            this.cadastrePromise = null;
+        },
         boolToStr(bool) {
             if (bool === null) {
                 return "non communiqué";
@@ -254,6 +279,8 @@ export default {
         }
     },
     async created() {
+        this.loadCadastre();
+
         try {
             const { towns } = await findNearby(
                 this.town.latitude,
@@ -263,6 +290,11 @@ export default {
             this.nearbyTowns = towns.filter(town => town.id !== this.town.id);
             // eslint-disable-next-line no-empty
         } catch (err) {}
+    },
+    beforeDestroy() {
+        if (this.cadastrePromise) {
+            this.cadastrePromise.abort();
+        }
     },
     computed: {
         buildAt() {

--- a/packages/frontend/webapp/src/js/helpers/ignHelper.js
+++ b/packages/frontend/webapp/src/js/helpers/ignHelper.js
@@ -1,0 +1,40 @@
+function onLoad(success, failure) {
+    if (this.status !== 200) {
+        failure();
+        return;
+    }
+
+    try {
+        success(JSON.parse(this.responseText));
+    } catch (error) {
+        failure();
+    }
+}
+
+/**
+ * @param {Object} geojson
+ *
+ * @returns {Promise}
+ */
+export function getCadastre(geojson) {
+    const xhr = new XMLHttpRequest();
+    const promise = new Promise((success, failure) => {
+        const queries = [`geom=${encodeURIComponent(JSON.stringify(geojson))}`];
+
+        xhr.open(
+            "GET",
+            `https://apicarto.ign.fr/api/cadastre/parcelle?${queries.join("&")}`
+        );
+        xhr.onload = onLoad.bind(xhr, success, failure);
+        xhr.onerror = failure;
+        xhr.ontimeout = failure;
+        xhr.send();
+    });
+    promise.abort = () => {
+        xhr.abort();
+    };
+
+    return promise;
+}
+
+export default getCadastre;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/fgwIZlor/1384

## 🛠 Description de la PR
- Ajout de l'API IGN à notre CSP (voir PR ici : https://github.com/MTES-MCT/resorption-bidonvilles-deploy/pull/19)
- Ajout d'une prop `cadastre` au composant `map.vue`, qui permet de définir une parcelle cadastrale
- Ajout d'un contrôle sur `map.vue`, identique au contrôle `Afficher les adresses des sites`. Ce contrôle n'est visible *que* si une parcelle cadastrale est renseignée
- Lorsque le contrôle `cadastreToggler` est coché, la parcelle est affichée, sinon elle est masquée
- Ajout d'un helper permettant d'interroger l'API IGN pour en tirer une parcelle cadastrale à partir d'un point GPS
- Modification de la fiche d'un site pour utiliser tout ça

## 📸 Captures d'écran
![Capture d’écran 2022-03-16 à 07 37 07](https://user-images.githubusercontent.com/1801091/158531019-16368a11-68f6-404f-8d40-2d0c6fa2ec9e.png)