### PR TITLE
#patch (1407) Remove useless cookie

### DIFF
--- a/packages/frontend/webapp/src/js/app/pages/SignIn/index.vue
+++ b/packages/frontend/webapp/src/js/app/pages/SignIn/index.vue
@@ -79,9 +79,6 @@ export default {
                 });
                 this.$trackMatomoEvent("Login", "Connection");
 
-                const d = new Date();
-                d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000); // cookie is valid for 365 days
-                document.cookie = `logged_once=1;expires={d.toUTCString()};path=/`;
                 this.$router.push({ path: "/" });
                 this.loading = false;
             } catch (err) {

--- a/packages/frontend/webapp/src/js/app/pages/UserActivate/index.vue
+++ b/packages/frontend/webapp/src/js/app/pages/UserActivate/index.vue
@@ -79,10 +79,6 @@ export default {
                 });
                 this.$trackMatomoEvent("Demande d'accès", "Création compte");
 
-                const d = new Date();
-                d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000); // cookie is valid for 365 days
-                document.cookie = `logged_once=1;expires={d.toUTCString()};path=/`;
-
                 this.$router.push({ path: "/" });
                 notify({
                     group: "notifications",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/gHqRBVnA/1407

## 🛠 Description de la PR
En scindant www et webapp, la demande du ticket a été automatiquement traitée : la racine de webapp étant le formulaire de connexion, l'utilisateur se retrouve automatiquement redirigé vers ce dernier après activation de son compte, ce qui était la demande.

J'ai profité du ticket pour retirer le cookie devenue inutile `logged_once` (anciennement utilisé pour rediriger les utilisateurs qui s'étaient connectés au moins une fois vers le formulaire de connexion par défaut plutôt que la landing).

## 📸 Captures d'écran
Ø

## 🚨 Notes pour la mise en production
Ø