### PR TITLE
#patch (1417) Ajout d'une notification à la publication d'un message

### DIFF
--- a/packages/api/server/controllers/townController.js
+++ b/packages/api/server/controllers/townController.js
@@ -1504,15 +1504,23 @@ module.exports = (models) => {
             }
 
             // fetch refreshed comments
-            let comments;
+            let regularComments = {};
+            let covidComments = {};
             try {
-                const response = await models.shantytown.getComments(req.user, [req.params.id], true);
-                comments = response[req.params.id];
+                [regularComments, covidComments] = await Promise.all([
+                    models.shantytown.getComments(req.user, [req.params.id], false),
+                    models.shantytown.getComments(req.user, [req.params.id], true),
+                ]);
             } catch (error) {
-                comments = [];
+                // ignore
             }
 
-            return res.status(200).send(comments);
+            return res.status(200).send({
+                comments: {
+                    regular: regularComments[req.params.id] || [],
+                    covid: covidComments[req.params.id] || [],
+                },
+            });
         },
     };
 

--- a/packages/api/server/services/shantytownComment/createComment.js
+++ b/packages/api/server/services/shantytownComment/createComment.js
@@ -35,9 +35,13 @@ module.exports = async (comment, shantytown, author) => {
     }
 
     // on retourne la liste mise à jour des commentaires du site
-    let comments;
+    let regularComments;
+    let covidComments;
     try {
-        comments = await shantytownModel.getComments(author, [shantytown.id], false);
+        [regularComments, covidComments] = await Promise.all([
+            shantytownModel.getComments(author, [shantytown.id], false),
+            shantytownModel.getComments(author, [shantytown.id], true),
+        ]);
     } catch (error) {
         throw new ServiceError('fetch_failed', error);
     }
@@ -55,5 +59,8 @@ module.exports = async (comment, shantytown, author) => {
         // ignore
     }
 
-    return comments[shantytown.id];
+    return {
+        regular: regularComments[shantytown.id] || [],
+        covid: covidComments[shantytown.id] || [],
+    };
 };

--- a/packages/api/test/suites/server/controllers/shantytownCommentController/create.spec.js
+++ b/packages/api/test/suites/server/controllers/shantytownCommentController/create.spec.js
@@ -48,7 +48,10 @@ describe.only('controllers/shantytownComment', () => {
 
         it('répond une 200 et la liste des commentaires retournée par le service shantytownComment/createComment()', async () => {
             // le service createComment() retourne une liste de commentaires
-            const comments = []; // @todo: utiliser une liste de fakeComments() dès que l'utilitaire est mergé dans develop
+            const comments = {
+                regular: [],
+                covid: [],
+            }; // @todo: utiliser une liste de fakeComments() dès que l'utilitaire est mergé dans develop
             createCommentService.resolves(comments);
 
             const res = mockRes();

--- a/packages/api/test/suites/server/services/shantytownComment/createComment.spec.js
+++ b/packages/api/test/suites/server/services/shantytownComment/createComment.spec.js
@@ -73,6 +73,7 @@ describe.only('services/shantytownComment', () => {
                     watchers: [fakeUser(), fakeUser({ id: 3 }), fakeUser({ id: 4 })],
                     comment: fakeComment(),
                     commentList: [],
+                    covidCommentList: [],
                 };
 
                 // createComment() retourne un id de commentaire
@@ -84,6 +85,11 @@ describe.only('services/shantytownComment', () => {
                     .withArgs(input.user, [input.shantytown.id], false)
                     .resolves({
                         [input.shantytown.id]: output.commentList,
+                    });
+                dependencies.getComments
+                    .withArgs(input.user, [input.shantytown.id], true)
+                    .resolves({
+                        [input.shantytown.id]: output.covidCommentList,
                     });
 
                 // findOneComment() retourne un commentaire
@@ -140,7 +146,10 @@ describe.only('services/shantytownComment', () => {
             });
 
             it('collecte et retourne la liste des commentaires actualisés', async () => {
-                expect(response).to.be.eql(output.commentList);
+                expect(response).to.be.eql({
+                    regular: output.commentList,
+                    covid: output.covidCommentList,
+                });
             });
         });
 

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetails.vue
@@ -89,7 +89,6 @@
                 </div>
                 <TownDetailsNewComment
                     :class="['flex-1', comments.length === 0 && 'pb-32']"
-                    v-on:submit="handleNewComment($event)"
                     id="newComment"
                     :user="user"
                     :nbComments="comments.length"
@@ -261,14 +260,6 @@ export default {
         },
         openCovid() {
             this.covidOpen = true;
-        },
-        handleNewComment(comments) {
-            this.$trackMatomoEvent(
-                "Site",
-                "Création commentaire",
-                `S${this.town.id}`
-            );
-            this.town.comments.regular = comments;
         },
         deleteTown() {
             if (

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
@@ -100,6 +100,7 @@
                             validationName="Ecrire un message"
                             placeholder="Partagez votre passage sur le site, le contexte sanitaire, la situation des habitants, difficultés rencontrées lors de votre intervention…"
                             :showMandatoryStar="true"
+                            :disabled="loading"
                         />
                         <div class="flex items-center justify-between">
                             <Button
@@ -188,7 +189,7 @@ export default {
             });
         },
         async addCovidComment() {
-            if (this.loading) {
+            if (this.loading === true) {
                 return;
             }
 

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
@@ -140,7 +140,6 @@
 <script>
 import { fr } from "vuejs-datepicker/dist/locale";
 import CheckableGroup from "#app/components/ui/Form/CheckableGroup";
-import { addCovidComment } from "#helpers/api/town";
 import CommentBlock from "#app/components/CommentBlock/CommentBlock.vue";
 
 export default {
@@ -188,7 +187,7 @@ export default {
                 this.$refs.form.reset();
             });
         },
-        addCovidComment() {
+        async addCovidComment() {
             if (this.loading) {
                 return;
             }
@@ -197,68 +196,56 @@ export default {
             this.covidErrors = [];
             this.loading = true;
 
-            addCovidComment(this.$route.params.id, {
-                date: this.form.date,
-                description: this.form.newComment,
-                action_mediation_sante: this.form.interventionType.includes(
-                    "action_mediation_sante"
-                ),
-                equipe_mobile_depistage: this.form.interventionType.includes(
-                    "equipe_mobile_depistage"
-                ),
-                equipe_mobile_vaccination: this.form.interventionType.includes(
-                    "equipe_mobile_vaccination"
-                ),
-                sensibilisation_vaccination: this.form.interventionType.includes(
-                    "sensibilisation_vaccination"
-                ),
-                personnes_orientees: this.form.interventionType.includes(
-                    "personnes_orientees"
-                ),
-                personnes_avec_symptomes: this.form.interventionType.includes(
-                    "personnes_avec_symptomes"
-                ),
-                besoin_action: this.form.interventionType.includes(
-                    "besoin_action"
-                )
-            })
-                .then(async response => {
-                    this.$trackMatomoEvent(
-                        "Site",
-                        "Création commentaire Covid",
-                        `S${this.town.id}`
-                    );
-
-                    try {
-                        await this.$store.dispatch("setDetailedTown", {
-                            ...this.town,
-                            comments: {
-                                ...this.town.comments,
-                                covid: response
-                            }
-                        });
-                    } catch (ignore) {
-                        //
+            try {
+                await this.$store.dispatch(
+                    "shantytownComments/publishCovidComment",
+                    {
+                        townId: parseInt(this.$route.params.id, 10),
+                        comment: {
+                            date: this.form.date,
+                            description: this.form.newComment,
+                            action_mediation_sante: this.form.interventionType.includes(
+                                "action_mediation_sante"
+                            ),
+                            equipe_mobile_depistage: this.form.interventionType.includes(
+                                "equipe_mobile_depistage"
+                            ),
+                            equipe_mobile_vaccination: this.form.interventionType.includes(
+                                "equipe_mobile_vaccination"
+                            ),
+                            sensibilisation_vaccination: this.form.interventionType.includes(
+                                "sensibilisation_vaccination"
+                            ),
+                            personnes_orientees: this.form.interventionType.includes(
+                                "personnes_orientees"
+                            ),
+                            personnes_avec_symptomes: this.form.interventionType.includes(
+                                "personnes_avec_symptomes"
+                            ),
+                            besoin_action: this.form.interventionType.includes(
+                                "besoin_action"
+                            )
+                        }
                     }
+                );
 
-                    this.form = {
-                        newComment: "",
-                        date: new Date(),
-                        interventionType: []
-                    };
-                    this.$nextTick(() => {
-                        this.$refs.form.reset();
-                    });
-                    this.loading = false;
-                })
-                .catch(response => {
-                    const fields = response.fields || {};
-                    this.loading = false;
-                    this.covidErrors = Object.keys(fields).reduce(
-                        (acc, key) => [...acc, ...fields[key]],
-                        []
-                    );
+                this.form = {
+                    newComment: "",
+                    date: new Date(),
+                    interventionType: []
+                };
+                this.$nextTick(() => {
+                    this.$refs.form.reset();
                 });
+            } catch (error) {
+                const fields = error.fields || {};
+                this.covidErrors = Object.keys(fields).reduce(
+                    (acc, key) => [...acc, ...fields[key]],
+                    []
+                );
+            }
+
+            this.loading = false;
         }
     }
 };

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
@@ -16,6 +16,7 @@
             <TextArea
                 rows="5"
                 name="newComment"
+                :disabled="loading"
                 v-model="newComment"
                 placeholder="Partagez votre passage sur le site, le contexte sanitaire, la situation des habitants, difficultés rencontrées lors de votre intervention…"
             />
@@ -86,6 +87,10 @@ export default {
             this.newComment = "";
         },
         async addComment() {
+            if (this.loading === true) {
+                return;
+            }
+
             // clean previous errors
             this.commentError = null;
             this.commentErrors = {};
@@ -108,6 +113,7 @@ export default {
                 this.commentError = response.user_message;
                 this.commentErrors = response.fields || {};
             }
+
             this.loading = false;
         }
     }

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
@@ -63,8 +63,6 @@
 </template>
 
 <script>
-import { addComment as apiAddComment } from "#helpers/api/town";
-
 export default {
     data() {
         return {
@@ -94,11 +92,17 @@ export default {
             this.loading = true;
 
             try {
-                const response = await apiAddComment(this.$route.params.id, {
-                    description: this.newComment,
-                    private: this.isPrivate
-                });
-                this.$emit("submit", response.comments);
+                await this.$store.dispatch(
+                    "shantytownComments/publishComment",
+                    {
+                        townId: parseInt(this.$route.params.id, 10),
+                        comment: {
+                            description: this.newComment,
+                            private: this.isPrivate
+                        }
+                    }
+                );
+
                 this.newComment = "";
             } catch (response) {
                 this.commentError = response.user_message;

--- a/packages/frontend/webapp/src/js/app/store/index.js
+++ b/packages/frontend/webapp/src/js/app/store/index.js
@@ -18,6 +18,7 @@ import directory from "./modules/directory";
 import highCovidComments from "./modules/highCovidComments";
 import navigation from "./modules/navigation/navigation";
 import plans from "./modules/plans";
+import shantytownComments from "./modules/shantytownComments";
 import userModule from "./modules/user";
 import config from "./modules/config";
 
@@ -32,6 +33,7 @@ export default new Vuex.Store({
         highCovidComments,
         navigation,
         plans,
+        shantytownComments,
         user: userModule,
         config
     },

--- a/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
+++ b/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
+++ b/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
@@ -7,47 +7,37 @@ export default {
 
     actions: {
         async publishComment({ commit }, { townId, comment }) {
-            const { comments } = await addComment(townId, comment);
-            notify({
-                group: "notifications",
-                type: "success",
-                title: "Message publié",
-                text:
-                    "Votre message est bien enregistré et a été envoyé aux acteurs de votre département par mail."
-            });
-
-            commit(
-                "updateShantytownComments",
-                { townId, comments },
-                { root: true }
-            );
-            Vue.prototype.$trackMatomoEvent(
-                "Site",
+            publish(
+                addComment,
+                townId,
+                comment,
                 "Création commentaire",
-                `S${townId}`
+                commit
             );
         },
 
         async publishCovidComment({ commit }, { townId, comment }) {
-            const { comments } = await addCovidComment(townId, comment);
-            notify({
-                group: "notifications",
-                type: "success",
-                title: "Message publié",
-                text:
-                    "Votre message est bien enregistré et a été envoyé aux acteurs de votre département par mail."
-            });
-
-            commit(
-                "updateShantytownComments",
-                { townId, comments },
-                { root: true }
-            );
-            Vue.prototype.$trackMatomoEvent(
-                "Site",
+            publish(
+                addCovidComment,
+                townId,
+                comment,
                 "Création commentaire Covid",
-                `S${townId}`
+                commit
             );
         }
     }
 };
+
+async function publish(apiMethod, townId, comment, matomoAction, commit) {
+    const { comments } = await apiMethod(townId, comment);
+    notify({
+        group: "notifications",
+        type: "success",
+        title: "Message publié",
+        text:
+            "Votre message est bien enregistré et a été envoyé aux acteurs de votre département par mail."
+    });
+
+    commit("updateShantytownComments", { townId, comments }, { root: true });
+    Vue.prototype.$trackMatomoEvent("Site", matomoAction, `S${townId}`);
+}

--- a/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
+++ b/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
@@ -1,4 +1,4 @@
-import { addComment } from "#helpers/api/town";
+import { addComment, addCovidComment } from "#helpers/api/town";
 import Vue from "vue";
 
 export default {
@@ -13,10 +13,24 @@ export default {
                 { townId, comments },
                 { root: true }
             );
-
             Vue.prototype.$trackMatomoEvent(
                 "Site",
                 "Création commentaire",
+                `S${townId}`
+            );
+        },
+
+        async publishCovidComment({ commit }, { townId, comment }) {
+            const { comments } = await addCovidComment(townId, comment);
+
+            commit(
+                "updateShantytownComments",
+                { townId, comments },
+                { root: true }
+            );
+            Vue.prototype.$trackMatomoEvent(
+                "Site",
+                "Création commentaire Covid",
                 `S${townId}`
             );
         }

--- a/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
+++ b/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
@@ -1,1 +1,24 @@
-export default {};
+import { addComment } from "#helpers/api/town";
+import Vue from "vue";
+
+export default {
+    namespaced: true,
+
+    actions: {
+        async publishComment({ commit }, { townId, comment }) {
+            const { comments } = await addComment(townId, comment);
+
+            commit(
+                "updateShantytownComments",
+                { townId, comments },
+                { root: true }
+            );
+
+            Vue.prototype.$trackMatomoEvent(
+                "Site",
+                "Création commentaire",
+                `S${townId}`
+            );
+        }
+    }
+};

--- a/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
+++ b/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
@@ -1,4 +1,5 @@
 import { addComment, addCovidComment } from "#helpers/api/town";
+import { notify } from "#helpers/notificationHelper";
 import Vue from "vue";
 
 export default {
@@ -7,6 +8,13 @@ export default {
     actions: {
         async publishComment({ commit }, { townId, comment }) {
             const { comments } = await addComment(townId, comment);
+            notify({
+                group: "notifications",
+                type: "success",
+                title: "Message publié",
+                text:
+                    "Votre message est bien enregistré et a été envoyé aux acteurs de votre département par mail."
+            });
 
             commit(
                 "updateShantytownComments",
@@ -22,6 +30,13 @@ export default {
 
         async publishCovidComment({ commit }, { townId, comment }) {
             const { comments } = await addCovidComment(townId, comment);
+            notify({
+                group: "notifications",
+                type: "success",
+                title: "Message publié",
+                text:
+                    "Votre message est bien enregistré et a été envoyé aux acteurs de votre département par mail."
+            });
 
             commit(
                 "updateShantytownComments",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/jsWj9HZz/1417

## 🛠 Description de la PR
J'ai profité de ce ticket pour factoriser la logique de publication des messages et répercuter l'évolution des messages directement dans le store.

- création d'un store shantytownComments qui expose deux actions `publishComment` et `publishCovidComment` qui publient le commentaire, affichent une notification, assurent le tracking matomo, et rafraîchissent le store en conséquence
- côté API, modification des routes qui servent à la création de commentaires de façon à ce qu'elles retournent systématiquement l'arbre complet des commentaires du site (pas uniquement que les commentaires regular ou que les commentaires covid) : l'intérêt est de simplifier la mise à jour du store côté front. L'idéal aurait été de ne retourner que le commentaire fraîchement ajouté, mais j'ai préféré limité l'impact de cette PR en conservant la logique déjà existante.
- mise à jour des tests unitaires en conséquence

## 📸 Captures d'écran
![Capture d’écran 2022-04-28 à 18 38 15](https://user-images.githubusercontent.com/1801091/165801949-e3b9bdab-6998-4526-a619-71af38d9d474.png)
