### PR TITLE
(1430) correction modèle dernières activités

### DIFF
--- a/packages/api/server/models/shantytownModel/getHistory.js
+++ b/packages/api/server/models/shantytownModel/getHistory.js
@@ -34,28 +34,48 @@ module.exports = async (user, location, shantytownFilter, numberOfActivities, la
                 author.fk_organization AS author_organization
             FROM
                 ((
+                    WITH
+                        shantytown_computed_origins AS (SELECT
+                            s.hid AS fk_shantytown,
+                            string_to_array(array_to_string(array_agg(soo.social_origin_id::VARCHAR || '|' || soo.label), ','), ',') AS origins
+                        FROM "ShantytownHistories" s
+                        LEFT JOIN "ShantytownOriginHistories" so ON so.fk_shantytown = s.hid
+                        LEFT JOIN social_origins soo ON so.fk_social_origin = soo.social_origin_id
+                        GROUP BY s.hid)
                     SELECT
                         shantytowns.hid,
                         shantytowns.closed_at,
                         shantytowns.created_at,
                         shantytowns.updated_at AS "date",
+                        sco.origins AS "socialOrigins",
                         COALESCE(shantytowns.updated_by, shantytowns.created_by) AS author_id,
                         ${Object.keys(SQL.selection).map(key => `${key} AS "${SQL.selection[key]}"`).join(',')}
                     FROM "ShantytownHistories" shantytowns
                     LEFT JOIN shantytowns AS s ON shantytowns.shantytown_id = s.shantytown_id
+                    LEFT JOIN shantytown_computed_origins sco ON sco.fk_shantytown = shantytowns.hid
                     ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
                     ${where.length > 0 ? `WHERE ((${where.join(') OR (')}))` : ''}
                 )
                 UNION
                 (
+                    WITH
+                        shantytown_computed_origins AS (SELECT
+                            s.shantytown_id AS fk_shantytown,
+                            string_to_array(array_to_string(array_agg(soo.social_origin_id::VARCHAR || '|' || soo.label), ','), ',') AS origins
+                        FROM shantytowns s
+                        LEFT JOIN shantytown_origins so ON so.fk_shantytown = s.shantytown_id
+                        LEFT JOIN social_origins soo ON so.fk_social_origin = soo.social_origin_id
+                        GROUP BY s.shantytown_id)
                     SELECT
                         0 as hid,
                         shantytowns.closed_at,
                         shantytowns.created_at,
                         shantytowns.updated_at AS "date",
+                        sco.origins AS "socialOrigins",
                         COALESCE(shantytowns.updated_by, shantytowns.created_by) AS author_id,
                         ${Object.keys(SQL.selection).map(key => `${key} AS "${SQL.selection[key]}"`).join(', ')}
                     FROM shantytowns
+                    LEFT JOIN shantytown_computed_origins sco ON sco.fk_shantytown = shantytowns.shantytown_id
                     ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
                     ${where.length > 0 ? `WHERE (${where.join(') OR (')})` : ''}
                 )) activities
@@ -64,7 +84,7 @@ module.exports = async (user, location, shantytownFilter, numberOfActivities, la
             ${maxDate ? ' AND activities.date >= :maxDate' : ''}
             ${shantytownFilter.includes('shantytownCreation') ? '' : 'AND activities.date - activities.created_at > \'00:00:01\''}
             ${shantytownFilter.includes('shantytownClosing') ? '' : 'AND activities.closed_at IS NULL'}
-            ${shantytownFilter.includes('shantytownUpdate') ? '' : 'AND (activities.closed_at IS NOT NULL OR activities.date - activities.created_at < \'00:00:01\')'}
+            ${shantytownFilter.includes('shantytownUpdate') ? '' : 'AND (activities.closed_at IS NOT NULL OR activities.date - activities.created_at <= \'00:00:01\')'}
             ORDER BY activities.date DESC
             ${limit}
             `,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JnVwKPnf/1430-bug-la-page-derni%C3%A8res-activit%C3%A9s-ne-prend-pas-en-compte-les-modifications-des-origines-sociales

## 🛠 Description de la PR
modification du modèle shantytown getHistory afin de récupérer l'historique des origines sociales en plus des autres données des sites


