### PR TITLE
#patch (1433) Correction des permissions d'accès aux données judiciaires

### DIFF
--- a/packages/api/server/models/permissionModel/find.js
+++ b/packages/api/server/models/permissionModel/find.js
@@ -54,6 +54,21 @@ module.exports = async (owners) => {
             } : null,
         };
 
+        // ugly patch for shantytown_justice.access.allow_all qui doit avoir la même valeur que
+        // shantytown.list.allow_all
+        // la vue user_actual_permissions default shantytown_justice.access.allow_all à false
+        if (row.entity === 'shantytown'
+            && row.feature === 'list'
+            && acc[row.user_id].shantytown_justice
+            && acc[row.user_id].shantytown_justice.access) {
+            acc[row.user_id].shantytown_justice.access.allow_all = permission.allow_all;
+        } else if (row.entity === 'shantytown_justice'
+            && row.feature === 'access'
+            && acc[row.user_id].shantytown
+            && acc[row.user_id].shantytown.list) {
+            permission.allow_all = acc[row.user_id].shantytown.list.allow_all;
+        }
+
         acc[row.user_id][row.entity][row.feature] = permission;
         return acc;
     }, {});

--- a/packages/frontend/webapp/src/js/app/components/TownForm/TownForm.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/TownForm.vue
@@ -191,8 +191,9 @@ export default {
         },
 
         hasJusticePermission() {
-            return this.$store.getters["config/hasPermission"](
-                "shantytown_justice.access"
+            return this.$store.getters["config/hasLocalizedPermission"](
+                "shantytown_justice.access",
+                this.data
             );
         }
     },

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetails.vue
@@ -208,9 +208,10 @@ export default {
         },
         hasJusticePermission() {
             return (
-                this.$store.getters["config/getPermission"](
-                    "shantytown_justice.access"
-                ) !== null
+                this.$store.getters["config/hasLocalizedPermission"](
+                    "shantytown_justice.access",
+                    this.town
+                ) === true
             );
         },
         comments() {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ZXKtSgBr/1433

## 🛠 Description de la PR
Il y avait deux problèmes :
1. côté API, on ne retournait pas les données judiciaires parce que la permission était appliquée en prenant en compte le périmètre géographique, et côté frontend on essayait d'afficher les données judiciaires parce que la permission était appliquée SANS le périmètre géographique — le correctif consiste simplement à appliquer le périmètre géo côté front sur la fiche de site et sur le formulaire de saisie de site
2. l'option `allow_justice` crée systématiquement une permission `shantytown_justice.access` avec `allow_all` à false, ce qui pose problème pour les utilisateurs nationaux qui n'ont du coup accès aux données judiciaires... nulle part ! Il était trop compliqué de corriger ça côté vue, donc le correctif consiste à re-calculer la propriété `allow_all` dans la couche modèle, mais uniquement pour cette permission qui reste une exception)