### PR TITLE
#patch (1435) Correction de l'affichage de l'autocomplétion d'adresse qui persiste

### DIFF
--- a/packages/frontend/webapp/src/js/app/components/ui/Autocomplete.vue
+++ b/packages/frontend/webapp/src/js/app/components/ui/Autocomplete.vue
@@ -307,6 +307,8 @@ export default {
         },
 
         handleBlur() {
+            this.focused = false;
+
             if (this.blurTimeout !== null) {
                 clearTimeout(this.blurTimeout);
             }
@@ -324,7 +326,6 @@ export default {
                     this.searchInput = this.getResultValue(this.value);
                 }
 
-                this.focused = false;
                 this.$emit("blur", {
                     value: this.value,
                     search: this.searchInput


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/lwb1EK8P/1435

## 🛠 Description de la PR
Un dév récent a fait que la sortie du champ de saisie (`blur`) ne provoquait pas nécessairement une perte de focus.