### PR TITLE
#patch (1440) Permettre aux admin nationaux de changer une résorption en fermeture et inversement

### DIFF
--- a/packages/api/db/migrations/30000009-create-fix_status-shantytown-permission.js
+++ b/packages/api/db/migrations/30000009-create-fix_status-shantytown-permission.js
@@ -1,0 +1,33 @@
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'INSERT INTO features(name, fk_entity, is_writing) VALUES(\'fix_status\', \'shantytown\', true)',
+            {
+                transaction,
+            },
+        )
+            .then(() => queryInterface.sequelize.query(
+                `INSERT INTO role_permissions(fk_role_admin, fk_feature, fk_entity, allowed, allow_all)
+                VALUES('national_admin', 'fix_status', 'shantytown', true, true)`,
+                {
+                    transaction,
+                },
+            )),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'DELETE FROM role_permissions WHERE fk_role_admin = \'national_admin\' AND fk_feature = \'fix_status\' AND fk_entity = \'shantytown\'',
+            {
+                transaction,
+            },
+        )
+            .then(() => queryInterface.sequelize.query(
+                'DELETE FROM features WHERE name = \'fix_status\' AND fk_entity = \'shantytown\'',
+                {
+                    transaction,
+                },
+            )),
+    ),
+
+};

--- a/packages/api/server/controllers/townController/fixClosedStatus.js
+++ b/packages/api/server/controllers/townController/fixClosedStatus.js
@@ -1,0 +1,21 @@
+const { fixClosedStatus } = require('#server/services/shantytown');
+
+const ERROR_RESPONSES = {
+    permission_denied: { code: 403, message: 'Permission refusée' },
+    [undefined]: { code: 500, message: 'Une erreur inconnue est survenue' },
+};
+
+module.exports = async (req, res, next) => {
+    try {
+        const updatedTown = await fixClosedStatus(req.user, req.body);
+        return res.status(200).send(updatedTown);
+    } catch (error) {
+        const { code, message } = ERROR_RESPONSES[error && error.code];
+        res.status(code).send({
+            error: {
+                user_message: message,
+            },
+        });
+        return next(error.nativeError || error);
+    }
+};

--- a/packages/api/server/controllers/townController/index.js
+++ b/packages/api/server/controllers/townController/index.js
@@ -6,6 +6,7 @@ const deleteTown = require('./deleteTown');
 const deleteComment = require('./deleteComment');
 const exportTown = require('./export');
 const createCovidComment = require('./createCovidComment');
+const fixClosedStatus = require('./fixClosedStatus');
 const edit = require('./edit');
 const createHighCovidComment = require('./createHighCovidComment')();
 const addActor = require('./addActor');
@@ -28,6 +29,7 @@ module.exports = {
     deleteComment,
     exportTown,
     createCovidComment,
+    fixClosedStatus,
     edit,
     createHighCovidComment,
     addActor,

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -447,6 +447,16 @@ export default (app) => {
         middlewares.validation,
         controllers.town.close,
     );
+    app.post(
+        '/towns/:id/fix_status',
+        middlewares.auth.authenticate,
+        (...args) => middlewares.auth.checkPermissions(['shantytown.fix_status'], ...args),
+        middlewares.charte.check,
+        middlewares.appVersion.sync,
+        validators.fixClosedStatus,
+        middlewares.validation,
+        controllers.town.fixClosedStatus,
+    );
     app.delete(
         '/towns/:id',
         middlewares.auth.authenticate,

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -447,8 +447,8 @@ export default (app) => {
         middlewares.validation,
         controllers.town.close,
     );
-    app.post(
-        '/towns/:id/fix_status',
+    app.put(
+        '/towns/:id/closedWithSolutions',
         middlewares.auth.authenticate,
         (...args) => middlewares.auth.checkPermissions(['shantytown.fix_status'], ...args),
         middlewares.charte.check,

--- a/packages/api/server/middlewares/validators/fixClosedStatus.js
+++ b/packages/api/server/middlewares/validators/fixClosedStatus.js
@@ -1,0 +1,34 @@
+/* eslint-disable newline-per-chained-call */
+const { body, param } = require('express-validator');
+const shantytownModel = require('#server/models/shantytownModel');
+
+module.exports = [
+    param('id')
+        .toInt()
+        .isInt().bail().withMessage('L\'identifiant du site est invalide')
+        .custom(async (value, { req }) => {
+            let shantytown;
+            try {
+                shantytown = await shantytownModel.findOne(req.user, value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la recherche du site en base de données');
+            }
+
+            if (shantytown === null) {
+                throw new Error('Le site est introuvable en base de données');
+            }
+
+            if (shantytown.status === 'open') {
+                throw new Error('Ce site n\'est pas marqué comme fermé');
+            }
+
+            req.body.shantytown = shantytown;
+            return true;
+        }),
+
+    body('closed_with_solutions')
+        .isBoolean().bail().withMessage('Vous devez indiquer si le site a été résorbé définitivement')
+        .customSanitizer(value => (value === true ? 'yes' : 'no')),
+
+
+];

--- a/packages/api/server/middlewares/validators/index.js
+++ b/packages/api/server/middlewares/validators/index.js
@@ -1,4 +1,5 @@
 const closeTown = require('./closeTown');
+const fixClosedStatus = require('./fixClosedStatus');
 const createContact = require('./createContact');
 const createTown = require('./createTown');
 const createUser = require('./createUser');
@@ -22,6 +23,7 @@ const mePostNavigationLogs = require('./me/post.navigationLogs');
 
 module.exports = {
     closeTown,
+    fixClosedStatus,
     createContact,
     createTown,
     editTown,

--- a/packages/api/server/models/shantytownModel/fixClosedStatus.js
+++ b/packages/api/server/models/shantytownModel/fixClosedStatus.js
@@ -1,0 +1,17 @@
+const sequelize = require('#db/sequelize');
+
+module.exports = async (shantytownId, closedWithSolutions) => {
+    await sequelize.query(
+        `UPDATE shantytowns
+        SET 
+            closed_with_solutions = :closed_with_solutions
+        WHERE shantytown_id = :id`,
+        {
+            replacements: {
+                id: shantytownId,
+                closed_with_solutions: closedWithSolutions,
+            },
+
+        },
+    );
+};

--- a/packages/api/server/models/shantytownModel/fixClosedStatus.js
+++ b/packages/api/server/models/shantytownModel/fixClosedStatus.js
@@ -1,7 +1,7 @@
 const sequelize = require('#db/sequelize');
 
-module.exports = async (shantytownId, closedWithSolutions) => {
-    await sequelize.query(
+module.exports = (shantytownId, closedWithSolutions) => {
+    sequelize.query(
         `UPDATE shantytowns
         SET 
             closed_with_solutions = :closed_with_solutions

--- a/packages/api/server/models/shantytownModel/index.js
+++ b/packages/api/server/models/shantytownModel/index.js
@@ -10,6 +10,7 @@ const getUsenameOf = require('./_common/getUsenameOf');
 const update = require('./update');
 const serializeComment = require('./_common/serializeComment');
 const deleteShantytown = require('./delete');
+const fixClosedStatus = require('./fixClosedStatus');
 
 
 module.exports = {
@@ -25,4 +26,5 @@ module.exports = {
     serializeComment,
     update,
     deleteShantytown,
+    fixClosedStatus,
 };

--- a/packages/api/server/services/shantytown/fixClosedStatus.js
+++ b/packages/api/server/services/shantytown/fixClosedStatus.js
@@ -5,7 +5,7 @@ const permissionUtils = require('#server/utils/permission');
 
 module.exports = async (user, data) => {
     if (!permissionUtils.can(user).do('fix_status', 'shantytown').on(data.shantytown)) {
-        throw new ServiceError('permission_denied', new Error('Vous n\'avez pas la permission de modifier le statu d\'un site fermé'));
+        throw new ServiceError('permission_denied', new Error('Vous n\'avez pas la permission de modifier le statut d\'un site fermé'));
     }
     await shantytownModel.fixClosedStatus(
         data.shantytown.id,

--- a/packages/api/server/services/shantytown/fixClosedStatus.js
+++ b/packages/api/server/services/shantytown/fixClosedStatus.js
@@ -11,8 +11,7 @@ module.exports = async (user, data) => {
         data.shantytown.id,
         data.closed_with_solutions,
     );
-    const updatedTown = await shantytownModel.findOne(user, data.shantytown.id);
 
-
-    return updatedTown;
+    // eslint-disable-next-line no-return-await
+    return await shantytownModel.findOne(user, data.shantytown.id);
 };

--- a/packages/api/server/services/shantytown/fixClosedStatus.js
+++ b/packages/api/server/services/shantytown/fixClosedStatus.js
@@ -1,0 +1,21 @@
+const shantytownModel = require('#server/models/shantytownModel');
+const ServiceError = require('#server/errors/ServiceError');
+const getPermission = require('#server/utils/permission/getPermission');
+
+
+module.exports = async (user, data) => {
+    const permission = getPermission(user, 'fix_status', 'shantytown');
+
+    if (!permission) {
+        throw new ServiceError('permission_denied', new Error('Vous n\'avez pas la permission de modifier le statu d\'un site fermé'));
+    }
+
+    await shantytownModel.fixClosedStatus(
+        data.shantytown.id,
+        data.closed_with_solutions,
+    );
+    const updatedTown = await shantytownModel.findOne(user, data.shantytown.id);
+
+
+    return updatedTown;
+};

--- a/packages/api/server/services/shantytown/fixClosedStatus.js
+++ b/packages/api/server/services/shantytown/fixClosedStatus.js
@@ -12,6 +12,5 @@ module.exports = async (user, data) => {
         data.closed_with_solutions,
     );
 
-    // eslint-disable-next-line no-return-await
-    return await shantytownModel.findOne(user, data.shantytown.id);
+    return shantytownModel.findOne(user, data.shantytown.id);
 };

--- a/packages/api/server/services/shantytown/fixClosedStatus.js
+++ b/packages/api/server/services/shantytown/fixClosedStatus.js
@@ -1,15 +1,12 @@
 const shantytownModel = require('#server/models/shantytownModel');
 const ServiceError = require('#server/errors/ServiceError');
-const getPermission = require('#server/utils/permission/getPermission');
+const permissionUtils = require('#server/utils/permission');
 
 
 module.exports = async (user, data) => {
-    const permission = getPermission(user, 'fix_status', 'shantytown');
-
-    if (!permission) {
+    if (!permissionUtils.can(user).do('fix_status', 'shantytown').on(data.shantytown)) {
         throw new ServiceError('permission_denied', new Error('Vous n\'avez pas la permission de modifier le statu d\'un site fermé'));
     }
-
     await shantytownModel.fixClosedStatus(
         data.shantytown.id,
         data.closed_with_solutions,

--- a/packages/api/server/services/shantytown/fixClosedStatus.spec.js
+++ b/packages/api/server/services/shantytown/fixClosedStatus.spec.js
@@ -1,6 +1,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
+const { serialized: fakeUser } = require('#test/utils/user');
 
 const { expect } = chai;
 chai.use(sinonChai);
@@ -17,18 +18,13 @@ const fixClosedStatusService = require('./fixClosedStatus');
 
 describe.only('services/shantytown', () => {
     describe('fixClosedStatus()', () => {
-        const user = {
-            id: global.generate('string'),
-            permissions: {
-                shantytown: {
-                    fix_status: {
-                        allowed: true,
-                        allow_all: true,
-                        allowed_on: [],
-                    },
-                },
-            },
+        const user = fakeUser();
+        user.permissions.shantytown.fix_status = {
+            allowed: true,
+            allow_all: true,
+            allowed_on: [],
         };
+
         const data = {
             shantytown: fakeShantytown(paris.city(), { closed_with_solutions: false }),
             closed_with_solutions: 'yes',

--- a/packages/api/server/services/shantytown/fixClosedStatus.spec.js
+++ b/packages/api/server/services/shantytown/fixClosedStatus.spec.js
@@ -1,0 +1,69 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+const proxyquire = require('proxyquire');
+const shantytownModel = require('#server/models/shantytownModel');
+const ServiceError = require('#server/errors/ServiceError');
+
+let fixClosedStatusService;
+
+
+describe.only('services/shantytown', () => {
+    describe('fixClosedStatus()', () => {
+        const user = {};
+        const data = {
+            shantytown: {
+                id: 0,
+            },
+            closed_with_solutions: 'yes',
+        };
+
+        let stubs;
+        let getPermissionStub;
+
+        beforeEach(() => {
+            getPermissionStub = sinon.stub();
+            fixClosedStatusService = proxyquire('./fixClosedStatus', { '#server/utils/permission/getPermission': getPermissionStub });
+            stubs = {
+                fixClosedStatus: sinon.stub(shantytownModel, 'fixClosedStatus'),
+                findOne: sinon.stub(shantytownModel, 'findOne'),
+            };
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+        it('vérifie que l\'utilisateur a le droit de mofidier le statut d\'un site fermé', async () => {
+            try {
+                await fixClosedStatusService(user, data);
+            } catch (error) {
+                // ignore
+            }
+            expect(getPermissionStub).to.have.been.calledOnceWith(user, 'fix_status', 'shantytown');
+        });
+        it('Si l\'utilisateur n\'a pas la permission, renvoie une exception ServiceError \'permission_denied\'', async () => {
+            getPermissionStub.returns(false);
+            let responseError;
+            try {
+                await fixClosedStatusService(user, data);
+            } catch (error) {
+                responseError = error;
+            }
+            expect(responseError).to.be.instanceOf(ServiceError);
+            expect(responseError.code).to.be.eql('permission_denied');
+        });
+        it('met à jour le site en changeant le statut et renvoie le site ainsi modifié', async () => {
+            getPermissionStub.returns(true);
+            const updatedTown = {};
+            stubs.findOne.resolves(updatedTown);
+
+            const response = await fixClosedStatusService(user, data);
+            expect(stubs.fixClosedStatus).to.have.been.calledOnceWith(data.shantytown.id, data.closed_with_solutions);
+            expect(response).to.be.eql({});
+        });
+    });
+});

--- a/packages/api/server/services/shantytown/index.js
+++ b/packages/api/server/services/shantytown/index.js
@@ -6,6 +6,7 @@ const deleteTown = require('./deleteTown');
 const deleteComment = require('./deleteComment');
 const exportTown = require('./exportTown');
 const createCovidComment = require('./createCovidComment');
+const fixClosedStatus = require('./fixClosedStatus');
 
 module.exports = {
     create,
@@ -16,4 +17,5 @@ module.exports = {
     deleteComment,
     exportTown,
     createCovidComment,
+    fixClosedStatus,
 };

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -66,6 +66,14 @@
                 >Fermer le site</Button
             >
             <Button
+                v-if="canFixStatus && town.status !== 'open'"
+                variant="primaryOutline"
+                class="mr-8"
+                iconPosition="left"
+                @click="$emit('openCancel')"
+                >Corriger la fermeture du site</Button
+            >
+            <Button
                 data-cy="updateTown"
                 variant="primary"
                 class="mr-8"
@@ -113,6 +121,13 @@ import { mapGetters } from "vuex";
 import ResorptionTargetTag from "#app/components/ResorptionTargetTag/ResorptionTargetTag.vue";
 
 export default {
+    data() {
+        return {
+            canFixStatus: this.$store.getters["config/hasPermission"](
+                "shantytown.fix_status"
+            )
+        };
+    },
     props: {
         town: {
             type: Object

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -66,7 +66,10 @@
                 >Fermer le site</Button
             >
             <Button
-                v-if="canFixStatus && town.status !== 'open'"
+                v-if="
+                    hasLocalizedPermission('shantytown.fix_status', town) &&
+                        town.status !== 'open'
+                "
                 variant="primaryOutline"
                 class="mr-8"
                 iconPosition="left"
@@ -121,13 +124,6 @@ import { mapGetters } from "vuex";
 import ResorptionTargetTag from "#app/components/ResorptionTargetTag/ResorptionTargetTag.vue";
 
 export default {
-    data() {
-        return {
-            canFixStatus: this.$store.getters["config/hasPermission"](
-                "shantytown.fix_status"
-            )
-        };
-    },
     props: {
         town: {
             type: Object

--- a/packages/frontend/webapp/src/js/helpers/api/town.js
+++ b/packages/frontend/webapp/src/js/helpers/api/town.js
@@ -67,7 +67,7 @@ export function close(id, data) {
  * @returns {Promise}
  */
 export function fixClosedStatus(id, data) {
-    return postApi(`/towns/${id}/fix_status`, data);
+    return putApi(`/towns/${id}/closedWithSolutions`, data);
 }
 
 /**

--- a/packages/frontend/webapp/src/js/helpers/api/town.js
+++ b/packages/frontend/webapp/src/js/helpers/api/town.js
@@ -59,6 +59,18 @@ export function close(id, data) {
 }
 
 /**
+ * Fixes the status of a closed town
+ *
+ * @param {string}    id
+ * @param {Town_Data} data
+ *
+ * @returns {Promise}
+ */
+export function fixClosedStatus(id, data) {
+    return postApi(`/towns/${id}/fix_status`, data);
+}
+
+/**
  * Deletes a town
  *
  * @param {string} id


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Y21zxjgm/1440-fiche-site-permettre-aux-admin-nationaux-de-changer-une-r%C3%A9sorption-en-fermeture-et-inversement

## 🛠 Description de la PR
- côté db : ajout d'une nouvelle feature shantytown.fix_status, et d'une permission associée uniquement au rôle national_admin
- côté API, création d'un modèle, service (et test associé), controlleur et validator fixClosedStatus
- côté front :
 adaptation de la fiche site pour afficher un bouton 'Corriger la fermeture d'un site'  uniquement pour les sites fermés et uniquement pour les utilisateurs ayant la permission créée plus haut
adaptation de la modal de fermeture dans le cas d'une correction : on ne peut modifier que le champ 'S'agit-il d'une résorption', pour simplifier on n'affiche même que cette info et la date de fermeture

## 📸 Captures d'écran
<img width="684" alt="Capture d’écran 2022-05-11 à 15 15 41" src="https://user-images.githubusercontent.com/94321132/167858813-ffb2b280-1081-4d98-a892-5bb759921258.png">

<img width="750" alt="Capture d’écran 2022-05-11 à 15 16 49" src="https://user-images.githubusercontent.com/94321132/167859012-5834ff72-63c4-491e-8f23-0a9207ba9a61.png">


## 🚨 Notes pour la mise en production
migration à faire tourner