### PR TITLE
#patch (1450) fix internal link

### DIFF
--- a/packages/frontend/ui/src/components/Link.vue
+++ b/packages/frontend/ui/src/components/Link.vue
@@ -48,7 +48,7 @@ export default {
 
     computed: {
         toRB() {
-            return /(\/\/|\.)resorption-bidonvilles\./.test(this.to) === true
+            return /(\/\/|\.)resorption-bidonvilles\./.test(this.to) === true;
         },
         internalLink() {
             return this.to && this.to[0] === "/" ;

--- a/packages/frontend/ui/src/components/Link.vue
+++ b/packages/frontend/ui/src/components/Link.vue
@@ -1,6 +1,6 @@
 <template>
     <span>
-        <Icon icon="external-link-alt" v-if="!internalLink" :class="`mr-1 ${linkClasses}`" />
+        <Icon icon="external-link-alt" v-if="!internalLink && !toRB" :class="`mr-1 ${linkClasses}`" />
         <router-link v-if="internalLink" :to="to" :class="linkClasses"
             ><slot></slot
         ></router-link>
@@ -47,8 +47,11 @@ export default {
     },
 
     computed: {
+        toRB() {
+            return /(\/\/|\.)resorption-bidonvilles\./.test(this.to) === true
+        },
         internalLink() {
-            return this.to && (this.to[0] === "/" || /(\/\/|\.)resorption-bidonvilles\./.test(this.to) === true);
+            return this.to && this.to[0] === "/" ;
         }
     }
 };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/4I4GlY7R/1450-landing-le-clic-sur-le-lien-connexion-affiche-cette-page-a-chang%C3%A9-dadresse

## 🛠 Description de la PR
le bouton de connexion sur la landing redirigeait vers '/connexion' et non pas 'https://app.resorption-bidonvilles.XXX/connexion'

