### PR TITLE
#patch (1448) Impossible de saisir une date de diagnostic si la date d'installation est vide

### DIFF
--- a/packages/frontend/webapp/src/js/app/components/TownForm/inputs/InputCensusConductedAt.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/inputs/InputCensusConductedAt.vue
@@ -17,7 +17,7 @@ import { extend } from "vee-validate";
 extend("censusConductedAfterCreation", {
     params: ["target"],
     validate(conductedAt, { target: builtAt }) {
-        return conductedAt >= builtAt;
+        return builtAt ? conductedAt >= builtAt : true;
     },
     message:
         "La date du diagnostic doit être ultérieure à la date d'installation"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Uz5CPkr8/1448-saisie-de-site-impossible-de-saisir-une-date-de-diagnostic-si-la-date-dinstallation-est-vide

## 🛠 Description de la PR
RAS

