### PR TITLE
#patch (1436) Montrer le bouton "Mettre à jour" aux opérateurs d'une action, mais grisé

### DIFF
--- a/packages/frontend/webapp/src/js/app/components/ui/Tooltip.vue
+++ b/packages/frontend/webapp/src/js/app/components/ui/Tooltip.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="has-tooltip inline-block">
+    <div class="inline-block" v-bind:class="disabled ? [] : 'has-tooltip'">
         <div
             class="tooltip mt-10 ml-5 bg-yellow-200 shadow-md text-black py-4 px-6"
         >
@@ -14,6 +14,10 @@ export default {
     props: {
         text: {
             type: String
+        },
+        disabled: {
+            type: Boolean,
+            default: false
         }
     }
 };

--- a/packages/frontend/webapp/src/js/app/pages/PlanDetails/PlanDetailsHeader.vue
+++ b/packages/frontend/webapp/src/js/app/pages/PlanDetails/PlanDetailsHeader.vue
@@ -34,15 +34,25 @@
                 @click="$emit('closePlan')"
                 >Fermer l'action</Button
             >
-            <Button
-                variant="primary"
-                class="ml-8"
-                icon="pen"
-                iconPosition="left"
-                v-if="plan.canUpdate === true && plan.closed_at === null"
-                @click="routeToUpdate"
-                >Mettre à jour</Button
+            <Tooltip
+                text="Accessible uniquement aux pilotes de cette action"
+                :disabled="plan.canUpdate === true"
             >
+                <Button
+                    variant="primary"
+                    class="ml-8"
+                    icon="pen"
+                    iconPosition="left"
+                    v-if="
+                        (plan.canUpdate === true ||
+                            plan.canUpdateMarks === true) &&
+                            plan.closed_at === null
+                    "
+                    :disabled="plan.canUpdate !== true"
+                    @click="routeToUpdate"
+                    >Mettre à jour</Button
+                >
+            </Tooltip>
             <Button
                 variant="primary"
                 class="ml-8"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Gsb1lIDk/1436

## 🛠 Description de la PR
RàS de particulier, j'ai dû rajouter une prop `disabled` au composant `Tooltip` pour qu'il ne soit pas visible quand le bouton est actif.

## 📸 Captures d'écran
![Capture d’écran 2022-05-18 à 11 12 01](https://user-images.githubusercontent.com/1801091/169018378-7792d3be-8c59-4408-8cb2-06dc789d8ee0.png)