### PR TITLE
#patch (1438) Demande d'accès — Permettre les demandes d'accès de personnes en rectorat

### DIFF
--- a/packages/api/.eslintrc
+++ b/packages/api/.eslintrc
@@ -45,7 +45,10 @@
     },
     "overrides": [
         {
-            "files": "test/**/*.spec.js",
+            "files": [
+                "test/**/*.spec.js",
+                "server/**/*.spec.js"
+            ],
             "rules": {
                 "no-unused-expressions": "off"
             }

--- a/packages/api/db/migrations/30000013-01-create-table-academies.js
+++ b/packages/api/db/migrations/30000013-01-create-table-academies.js
@@ -1,0 +1,149 @@
+/* eslint-disable object-curly-newline */
+const academies = [
+    { uid: 'clermont', particle: 'de ', name: 'Clermont-Ferrand', departements: ['03', '15', '43', '63'] },
+    { uid: 'grenoble', particle: 'de ', name: 'Grenoble', departements: ['07', '26', '38', '73', '74'] },
+    { uid: 'lyon', particle: 'de ', name: 'Lyon', departements: ['01', '42', '69'] },
+    { uid: 'besancon', particle: 'de ', name: 'Besançon', departements: ['25', '39', '70', '90'] },
+    { uid: 'dijon', particle: 'de ', name: 'Dijon', departements: ['21', '58', '71', '89'] },
+    { uid: 'rennes', particle: 'de ', name: 'Rennes', departements: ['22', '29', '35', '56'] },
+    { uid: 'orleans', particle: 'd\'', name: 'Orléans-Tours', departements: ['18', '28', '36', '37', '41', '45'] },
+    { uid: 'corse', particle: 'de ', name: 'Corse', departements: ['2A', '2B'] },
+    { uid: 'nancy', particle: 'de ', name: 'Nancy-Metz', departements: ['54', '55', '57', '88'] },
+    { uid: 'reims', particle: 'de ', name: 'Reims', departements: ['08', '10', '51', '52'] },
+    { uid: 'strasbourg', particle: 'de ', name: 'Strasbourg', departements: ['67', '68'] },
+    { uid: 'guadeloupe', particle: 'de ', name: 'la Guadeloupe', departements: ['971'] },
+    { uid: 'guyane', particle: 'de ', name: 'la Guyane', departements: ['973'] },
+    { uid: 'amiens', particle: 'd\'', name: 'Amiens', departements: ['02', '60', '80'] },
+    { uid: 'lille', particle: 'de ', name: 'Lille', departements: ['59', '62'] },
+    { uid: 'creteil', particle: 'de ', name: 'Créteil', departements: ['77', '93', '94'] },
+    { uid: 'paris', particle: 'de ', name: 'Paris', departements: ['75'] },
+    { uid: 'versailles', particle: 'de ', name: 'Versailles', departements: ['78', '91', '92', '95'] },
+    { uid: 'martinique', particle: 'de ', name: 'Martinique', departements: ['972'] },
+    { uid: 'normandie', particle: 'de ', name: 'Normandie', departements: ['14', '50', '61', '27', '76'] },
+    { uid: 'bordeaux', particle: 'de ', name: 'Bordeaux', departements: ['24', '33', '40', '47', '64'] },
+    { uid: 'limoges', particle: 'de ', name: 'Limoges', departements: ['19', '23', '87'] },
+    { uid: 'poitiers', particle: 'de ', name: 'Poitiers', departements: ['16', '17', '79', '86'] },
+    { uid: 'montpellier', particle: 'de ', name: 'Montpellier', departements: ['11', '30', '34', '48', '66'] },
+    { uid: 'toulouse', particle: 'de ', name: 'Toulouse', departements: ['09', '12', '31', '32', '46', '65', '81', '82'] },
+    { uid: 'nantes', particle: 'de ', name: 'Nantes', departements: ['44', '49', '53', '72', '85'] },
+    { uid: 'aix', particle: 'd\'', name: 'Aix-Marseille', departements: ['04', '05', '13', '84'] },
+    { uid: 'nice', particle: 'de ', name: 'Nice', departements: ['06', '83'] },
+    { uid: 'reunion', particle: 'de ', name: 'La Réunion', departements: ['974'] },
+    { uid: 'mayotte', particle: 'de ', name: 'Mayotte', departements: ['976'] },
+];
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        await Promise.all([
+            queryInterface.createTable(
+                'academies',
+                {
+                    uid: {
+                        type: Sequelize.STRING,
+                        primaryKey: true,
+                    },
+                    particle: {
+                        type: Sequelize.STRING,
+                        allowNull: false,
+                    },
+                    name: {
+                        type: Sequelize.STRING,
+                        allowNull: false,
+                    },
+                },
+                { transaction },
+            ),
+            queryInterface.addColumn(
+                'departements',
+                'fk_academie',
+                {
+                    type: Sequelize.STRING,
+                    allowNull: true,
+                },
+                { transaction },
+            ),
+        ]);
+
+        // add constraints
+        await Promise.all([
+            queryInterface.addConstraint(
+                'academies',
+                ['name'],
+                {
+                    type: 'unique',
+                    name: 'uk_academies_name',
+                    transaction,
+                },
+            ),
+            queryInterface.addConstraint(
+                'departements',
+                ['fk_academie'],
+                {
+                    type: 'foreign key',
+                    name: 'fk_departements_academie',
+                    references: {
+                        table: 'academies',
+                        field: 'uid',
+                    },
+                    onUpdate: 'cascade',
+                    onDelete: 'restrict',
+                    transaction,
+                },
+            ),
+        ]);
+
+        // populate
+        await queryInterface.bulkInsert(
+            'academies',
+            academies.map(({ uid, particle, name }) => ({
+                uid,
+                particle,
+                name,
+            })),
+            { transaction },
+        );
+        await Promise.all(
+            academies.map(({ uid, departements }) => departements.map(departement => queryInterface.sequelize.query(
+                'UPDATE departements SET fk_academie = :academie WHERE code = :departement',
+                {
+                    replacements: {
+                        academie: uid,
+                        departement,
+                    },
+                    transaction,
+                },
+            ))).flat(),
+        );
+
+        // change constraint (fk_academie NOT NULLABLE)
+        await queryInterface.changeColumn(
+            'departements',
+            'fk_academie',
+            {
+                type: Sequelize.STRING,
+                allowNull: false,
+            },
+            { transaction },
+        );
+
+        return transaction.commit();
+    },
+
+    async down(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        await Promise.all([
+            queryInterface.removeConstraint('academies', 'uk_academies_name', { transaction }),
+            queryInterface.removeConstraint('departements', 'fk_departements_academie', { transaction }),
+        ]);
+
+        await Promise.all([
+            queryInterface.removeColumn('departements', 'fk_academie', { transaction }),
+            queryInterface.dropTable('academies', { transaction }),
+        ]);
+
+        return transaction.commit();
+    },
+};

--- a/packages/api/db/migrations/30000013-02-create-organization-rectorat.js
+++ b/packages/api/db/migrations/30000013-02-create-organization-rectorat.js
@@ -1,0 +1,89 @@
+module.exports = {
+    async up(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        const [
+            [[{ organization_type_id }]],
+            academies,
+        ] = await Promise.all([
+            queryInterface.sequelize.query(
+                `INSERT INTO organization_types(uid, name_singular, name_plural, fk_category, fk_role)
+                VALUES ('rectorat', 'Rectorat', 'Rectorats', 'public_establishment', 'collaborator')
+                RETURNING organization_type_id`,
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.sequelize.query(
+                `SELECT name, particle, departement FROM (
+                    SELECT
+                        academies.name,
+                        academies.particle,
+                        departements.code AS departement,
+                        ROW_NUMBER() OVER(PARTITION BY departements.fk_academie) AS position
+                    FROM academies
+                    LEFT JOIN departements ON departements.fk_academie = academies.uid
+                ) t
+                WHERE t.position = 1`,
+                {
+                    type: queryInterface.sequelize.QueryTypes.SELECT,
+                    transaction,
+                },
+            ),
+        ]);
+
+        await queryInterface.bulkInsert(
+            'organizations',
+            academies.map(({ name, particle, departement }) => ({
+                name: `Rectorat - Académie ${particle}${name}`,
+                active: true,
+                fk_type: organization_type_id,
+                fk_departement: departement,
+                being_funded: false,
+            })),
+            { transaction },
+        );
+
+        await queryInterface.sequelize.query(
+            'REFRESH MATERIALIZED VIEW localized_organizations',
+            { transaction },
+        );
+        return transaction.commit();
+    },
+
+    async down(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        const [{ organization_type_id }] = await queryInterface.sequelize.query(
+            'SELECT organization_type_id FROM organization_types WHERE uid = \'rectorat\'',
+            {
+                type: queryInterface.sequelize.QueryTypes.SELECT,
+                transaction,
+            },
+        );
+        await queryInterface.sequelize.query(
+            'DELETE FROM organizations WHERE fk_type = :organization_type_id',
+            {
+                transaction,
+                replacements: {
+                    organization_type_id,
+                },
+            },
+        );
+        await queryInterface.sequelize.query(
+            'REFRESH MATERIALIZED VIEW localized_organizations',
+            { transaction },
+        );
+        await queryInterface.sequelize.query(
+            'DELETE FROM organization_types WHERE organization_type_id = :organization_type_id',
+            {
+                transaction,
+                replacements: {
+                    organization_type_id,
+                },
+            },
+        );
+
+        return transaction.commit();
+    },
+};

--- a/packages/api/server/models/organizationModel/findByType.js
+++ b/packages/api/server/models/organizationModel/findByType.js
@@ -13,21 +13,26 @@ module.exports = typeId => sequelize.query(
         organizations."epci_code",
         organizations."epci_name",
         organizations."city_code",
-        organizations."city_name"
+        organizations."city_name",
+        organization_types."uid" AS organization_type_uid
     FROM localized_organizations AS organizations
     LEFT JOIN organization_types ON organizations.fk_type = organization_types.organization_type_id
     WHERE
-        organizations.fk_type = :typeId
+        organizations.fk_type = ?
     ORDER BY
         CASE organization_types.fk_category
             WHEN 'association' THEN organizations.name
             ELSE '' END
         ASC,
+        CASE organization_types.uid
+            WHEN 'rectorat' THEN SUBSTRING(organizations.name, '(?<=(?:d''|de la |de ))[A-Z].+')
+            ELSE '' END
+        ASC,
         departement_code ASC, REPLACE(region_name, 'Î', 'I') ASC, epci_name ASC, city_name ASC`,
     {
         type: sequelize.QueryTypes.SELECT,
-        replacements: {
+        replacements: [
             typeId,
-        },
+        ],
     },
 );

--- a/packages/api/server/services/createUser.spec.js
+++ b/packages/api/server/services/createUser.spec.js
@@ -1,0 +1,77 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const chaiAsPromised = require('chai-as-promised');
+const rewiremock = require('rewiremock/node');
+const { serialized: fakeUser } = require('#test/utils/user');
+
+const { expect } = chai;
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+// stubs
+const sequelize = {
+    transaction: sinon.stub(),
+};
+const mattermostUtils = {
+    triggerNotifyNewUserFromRectorat: sinon.stub(),
+};
+const userModel = {
+    findOne: sinon.stub(),
+};
+const createUser = rewiremock.proxy('./createUser.js', {
+    '#db/sequelize': sequelize,
+    '#server/utils/mattermost': mattermostUtils,
+    '#server/models/userModel': userModel,
+});
+
+describe('userService.createUser()', () => {
+    afterEach(() => {
+        sinon.reset();
+    });
+
+    it('envoie une notification mattermost lorsqu\'un utilisateur de rectorat est créé', async () => {
+        // prepare
+        const user = fakeUser();
+        user.organization.type.uid = 'rectorat';
+        sequelize.transaction.resolves(user.id);
+        userModel.findOne.withArgs(user.id).resolves(user);
+        // execute
+        await createUser();
+        // assert
+        expect(mattermostUtils.triggerNotifyNewUserFromRectorat).to.have.been.calledWith(user);
+    });
+
+    it('n\'envoie pas de notification mattermost lorsqu\'un utilisateur hors rectorat est créé', async () => {
+        // prepare
+        const user = fakeUser();
+        sequelize.transaction.resolves(user.id);
+        userModel.findOne.withArgs(user.id).resolves(user);
+        // execute
+        await createUser();
+        // assert
+        expect(mattermostUtils.triggerNotifyNewUserFromRectorat).to.not.have.been.called;
+    });
+
+    it('retourne l\'utilisateur nouvellement créé', async () => {
+        // prepare
+        const user = fakeUser();
+        sequelize.transaction.resolves(user.id);
+        userModel.findOne.withArgs(user.id).resolves(user);
+        // execute
+        const response = await createUser();
+        // assert
+        expect(response).to.be.eql(user);
+    });
+
+    it('ne lance pas d\'exception si l\'envoi de la notification mattermost échoue', async () => {
+        // prepare
+        const user = fakeUser();
+        user.organization.type.uid = 'rectorat';
+        sequelize.transaction.resolves(user.id);
+        userModel.findOne.withArgs(user.id).resolves(user);
+        mattermostUtils.triggerNotifyNewUserFromRectorat.rejects(new Error('une erreur'));
+        // assert
+        await expect(createUser()).not.to.be.rejected;
+    });
+});

--- a/packages/api/server/services/createUser.spec.js
+++ b/packages/api/server/services/createUser.spec.js
@@ -25,7 +25,7 @@ const createUser = rewiremock.proxy('./createUser.js', {
     '#server/models/userModel': userModel,
 });
 
-describe('userService.createUser()', () => {
+describe.only('userService.createUser()', () => {
     afterEach(() => {
         sinon.reset();
     });

--- a/packages/api/server/utils/mattermost.js
+++ b/packages/api/server/utils/mattermost.js
@@ -3,7 +3,7 @@ const { mattermost } = require('#server/config');
 const { webappUrl } = require('#server/config');
 
 const formatAddress = town => `${town.address} ${town.name ? `« ${town.name} » ` : ''}`;
-const formatUsername = user => `${user.first_name} ${user.last_name} `;
+const formatUsername = user => `[${user.first_name} ${user.last_name}](${webappUrl}/nouvel-utilisateur/${user.id}) `;
 const formatTownLink = (townID, text) => `[${text}](${webappUrl}/site/${townID})`;
 
 const formatDate = ((dateToFormat) => {
@@ -315,6 +315,24 @@ async function triggerRemoveDeclaredActor(town, user) {
     await removeDeclaredActor.send(mattermostMessage);
 }
 
+async function triggerNotifyNewUserFromRectorat(user) {
+    if (!mattermost) {
+        return;
+    }
+
+    const webhook = new IncomingWebhook(mattermost);
+    const username = formatUsername(user);
+
+    const mattermostMessage = {
+        channel: '#tech',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: L'utilisateur(ice) ${username}, membre de Rectorat, a été créé(e). Merci de lui étendre ses droits d'accès à toute son académie`,
+        fields: [],
+    };
+
+    await webhook.send(mattermostMessage);
+}
 
 module.exports = {
     triggerShantytownCloseAlert,
@@ -326,4 +344,5 @@ module.exports = {
     triggerDeclaredActor,
     triggerInvitedActor,
     triggerRemoveDeclaredActor,
+    triggerNotifyNewUserFromRectorat,
 };

--- a/packages/api/test/utils/user.js
+++ b/packages/api/test/utils/user.js
@@ -33,6 +33,7 @@ module.exports = {
                 active: true,
                 type: {
                     id: 10,
+                    uid: 'delegation_interministerielle',
                     name_singular: 'Délégation interministérielle',
                     name_plural: 'Délégations interministérielles',
                     abbreviation: null,

--- a/packages/frontend/webapp/src/js/app/components/UserForm/PublicEstablishmentForm.vue
+++ b/packages/frontend/webapp/src/js/app/components/UserForm/PublicEstablishmentForm.vue
@@ -96,6 +96,8 @@ export default {
 
                 if (level === "nation") {
                     label = "France";
+                } else if (organization.organization_type_uid === "rectorat") {
+                    label = organization.name.split(" - ")[1];
                 } else if (level === "departement") {
                     label = `${organization[`${level}_code`]} - ${
                         organization[`${level}_name`]


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Ke0HzFzb/1438

## 🛠 Description de la PR
- création d'une table `academies` qui liste toutes les académies existantes
- ajout d'une colonne `fk_academie` à la table `departements` pour créer le lien entre départements et académies
- ajustement de la requête qui retourne la liste des structures par type de structure de façon à :
  - rajouter l'identifiant unique du type de structure dans la réponse (pour que le front puisse adapter son comportement, voir ci-après)
  - ajuster le tri, spécifiquement pour les rectorats (pour éviter que "Académie d'Orléans" ne se retrouve en début de liste, avant "Académie de Besançon" par exemple)
- ajout d'une notification mattermost à chaque création d'utilisateur de rectorat
- modification du formulaire de demande d'accès pour que, uniquement pour les rectorats, ce ne soit pas le nom du département mais le nom de l'académie qui soit affichée dans la liste
- ajout de tests unitaires sur le service concerné côté API

## 📸 Captures d'écran
- formulaire
![Capture d’écran 2022-05-18 à 18 11 03](https://user-images.githubusercontent.com/1801091/169093973-bc8623ee-70be-4476-9feb-337494ff1758.png)
- l'ordre est correct
![Capture d’écran 2022-05-18 à 18 11 07](https://user-images.githubusercontent.com/1801091/169094000-551a6c6b-5fc1-4fbb-9995-b62ed4b267fd.png)

## 🚨 Notes pour la mise en production
Migrations à faire tourner