### PR TITLE
#patch (1462) Certaines icônes sont décentrées, et les cases à cocher affichent deux "checks"

### DIFF
--- a/packages/frontend/webapp/src/js/app/components/ActivityCard/ActivityCardIcon.vue
+++ b/packages/frontend/webapp/src/js/app/components/ActivityCard/ActivityCardIcon.vue
@@ -1,7 +1,7 @@
 <template>
     <aside
         :class="
-            `text-xl w-10 h-10 leading-10 rounded-full text-white text-center ${color}`
+            `text-size-xl w-10 h-10 leading-10 rounded-full text-white text-center ${color}`
         "
     >
         <Icon :icon="icon"></Icon>

--- a/packages/frontend/webapp/src/js/app/components/map/map.scss
+++ b/packages/frontend/webapp/src/js/app/components/map/map.scss
@@ -388,96 +388,99 @@ input {
     }
 }
 
-input[type=radio],
-input[type=checkbox] {
-    margin: 0;
-    margin-right: 0.5em;
-    margin-right: var(--space-xs);
-}
+.dashboard .filters {
 
-input[type=radio] {
-    height: 1.25em;
-    width: 1.25em;
-    border-radius: 50%;
-    display: inline-block;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    padding: 0;
-}
+    input[type=radio],
+    input[type=checkbox] {
+        margin: 0;
+        margin-right: 0.5em;
+        margin-right: var(--space-xs);
+    }
 
-input[type=radio]::before {
-    content: '';
-    border-color: #0053b3;
-    border-color: var(--theme-primary);
-    border-radius: 50%;
-    position: absolute;
-    top: 0.3em;
-    left: 0.35em;
-    width: 0.5em;
-    height: 0.5em;
-    -webkit-transform: scale(0);
-    transform: scale(0);
-}
+    input[type=radio] {
+        height: 1.25em;
+        width: 1.25em;
+        border-radius: 50%;
+        display: inline-block;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        padding: 0;
+    }
 
-input[type=radio]:checked {
-    background-color: #fff;
-    background-color: var(--theme-background-white);
-    border-color: #0053b3;
-    border-color: var(--theme-primary);
-    opacity: 1;
-}
+    input[type=radio]::before {
+        content: '';
+        border-color: #0053b3;
+        border-color: var(--theme-primary);
+        border-radius: 50%;
+        position: absolute;
+        top: 0.3em;
+        left: 0.35em;
+        width: 0.5em;
+        height: 0.5em;
+        -webkit-transform: scale(0);
+        transform: scale(0);
+    }
 
-input[type=radio]:checked::before {
-    background-color: #0053b3;
-    background-color: var(--theme-primary);
-    -webkit-transform: scale(1);
-    transform: scale(1);
-    -webkit-transition: -webkit-transform 0.2s ease-out;
-    transition: -webkit-transform 0.2s ease-out;
-    transition: transform 0.2s ease-out;
-    transition: transform 0.2s ease-out, -webkit-transform 0.2s ease-out;
-}
+    input[type=radio]:checked {
+        background-color: #fff;
+        background-color: var(--theme-background-white);
+        border-color: #0053b3;
+        border-color: var(--theme-primary);
+        opacity: 1;
+    }
 
-input[type="checkbox"] {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    height: 1.4em;
-    width: 1.5em;
-    padding: 0;
-}
+    input[type=radio]:checked::before {
+        background-color: #0053b3;
+        background-color: var(--theme-primary);
+        -webkit-transform: scale(1);
+        transform: scale(1);
+        -webkit-transition: -webkit-transform 0.2s ease-out;
+        transition: -webkit-transform 0.2s ease-out;
+        transition: transform 0.2s ease-out;
+        transition: transform 0.2s ease-out, -webkit-transform 0.2s ease-out;
+    }
 
-input[type="checkbox"]:checked {
-    background-color: #000091;
-    border-color: #000091;
-    opacity: 1;
-    -webkit-transition: border-color 0.2s ease-in, background-color 0.2s ease-out;
-    transition: border-color 0.2s ease-in, background-color 0.2s ease-out;
-}
+    input[type="checkbox"] {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        height: 1.4em;
+        width: 1.5em;
+        padding: 0;
+    }
 
-input[type="checkbox"]::before {
-    -webkit-transform: scale(0);
-    transform: scale(0);
-    content: '';
-    position: absolute;
-    top: 0.2em;
-    left: 0.15em;
-    height: 1em;
-    width: 1em;
-    background: url('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" class="svg-inline--fa fa-check fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="white" d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"></path></svg>') center center no-repeat;
-}
+    input[type="checkbox"]:checked {
+        background-color: #000091;
+        border-color: #000091;
+        opacity: 1;
+        -webkit-transition: border-color 0.2s ease-in, background-color 0.2s ease-out;
+        transition: border-color 0.2s ease-in, background-color 0.2s ease-out;
+    }
 
-input[type="checkbox"]:checked::before {
-    color: #fff;
-    color: var(--white);
-    display: block;
-    -webkit-transform: scale(1);
-    transform: scale(1);
-    -webkit-transition: -webkit-transform 0.2s ease-out;
-    transition: -webkit-transform 0.2s ease-out;
-    transition: transform 0.2s ease-out;
-    transition: transform 0.2s ease-out, -webkit-transform 0.2s ease-out;
+    input[type="checkbox"]::before {
+        -webkit-transform: scale(0);
+        transform: scale(0);
+        content: '';
+        position: absolute;
+        top: 0.2em;
+        left: 0.15em;
+        height: 1em;
+        width: 1em;
+        background: url('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" class="svg-inline--fa fa-check fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="white" d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"></path></svg>') center center no-repeat;
+    }
+
+    input[type="checkbox"]:checked::before {
+        color: #fff;
+        color: var(--white);
+        display: block;
+        -webkit-transform: scale(1);
+        transform: scale(1);
+        -webkit-transition: -webkit-transform 0.2s ease-out;
+        transition: -webkit-transform 0.2s ease-out;
+        transition: transform 0.2s ease-out;
+        transition: transform 0.2s ease-out, -webkit-transform 0.2s ease-out;
+    }
 }
 
 .leaflet-popup-content-wrapper {

--- a/packages/frontend/webapp/src/js/app/components/ui/InfoBanner.vue
+++ b/packages/frontend/webapp/src/js/app/components/ui/InfoBanner.vue
@@ -3,7 +3,7 @@
         <div class="flex items-center">
             <div
                 v-if="icon"
-                class="rounded-full bg-yellow-400 w-6 h-6 text-center text-xs leading-6"
+                class="rounded-full bg-yellow-400 w-6 h-6 text-center text-size-xs leading-6"
             >
                 <Icon :icon="icon"></Icon>
             </div>

--- a/packages/frontend/webapp/src/js/app/components/ui/PanelInfo.vue
+++ b/packages/frontend/webapp/src/js/app/components/ui/PanelInfo.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div
-            class="rounded-full inline-block bg-yellow-400 w-6 h-6 text-center text-xs align-middle leading-6"
+            class="rounded-full inline-block bg-yellow-400 w-6 h-6 text-center text-size-xs align-middle leading-6"
         >
             <Icon :icon="icon"></Icon>
         </div>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/811Ai3CX/1462

## 🛠 Description de la PR 
- les double checks sur les boutons radio étaient causés par des styles de map.scss qui, n'étant pas scoped, se retrouvaient appliquées sur toutes les pages
- les icônes décentrées étaient causées par un conflit de line-height : la classe text-xl imposait un certain line-height, et la classe leading un autre, et ce n'était pas le bon qui était appliqué

## 📸 Captures d'écran
- Il n'y a plus de double check dans les boutons radios :
![Capture d’écran 2022-05-24 à 17 05 16](https://user-images.githubusercontent.com/1801091/170068832-b39b0edd-3330-4b2e-9e29-dde307a44fda.png)
- Les icônes sont centrées
![Capture d’écran 2022-05-24 à 17 05 44](https://user-images.githubusercontent.com/1801091/170068925-70a464d5-38ca-4a1b-8497-2919c1fb8c5a.png)