### PR TITLE
#patch (1469) Liste des sites — L'impression de la liste des sites fermés est vide

### DIFF
--- a/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
@@ -361,25 +361,35 @@ export default {
 }
 
 .closedShantytown {
+    .cardGridTemplateColumns {
+        @media print {
+            grid-template-columns: 140px 91px 150px 154px 0px;
+        }
+    }
+}
+
+.closedShantytown {
     position: relative;
     overflow: hidden;
 }
 
-.closedShantytown:before {
-    position: absolute;
-    pointer-events: none;
-    content: "";
-    background: linear-gradient(
-        to left bottom,
-        transparent 50%,
-        currentColor 49.8%,
-        currentColor 50.2%,
-        transparent 50%
-    );
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
+@media not print {
+    .closedShantytown:before {
+        position: absolute;
+        pointer-events: none;
+        content: "";
+        background: linear-gradient(
+            to left bottom,
+            transparent 50%,
+            currentColor 49.8%,
+            currentColor 50.2%,
+            transparent 50%
+        );
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+    }
 }
 
 .preventPrintBreak {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kjFbNQyz/1469

## 🛠 Description de la PR
- Retrait de la barre oblique (qui causait le problème d'impression)
- Ajustement de la taille des colonnes pour améliorer la lisibilité (pas de place pour les intervenants, qui n'apparaissent du coup pas à l'impression)