### PR TITLE
#patch (1459) Saisie de site — Ajouter un message d'erreur quand le champ "Adresse du site" n'est pas renseigné

### DIFF
--- a/packages/frontend/webapp/src/js/app/components/TownForm/TownFormPanelLocation.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/TownFormPanelLocation.vue
@@ -79,10 +79,12 @@ export default {
             this.nearbyShantytowns = [];
         },
         "input.coordinates": async function() {
-            const latitude = this.input.coordinates[0];
-            const longitude = this.input.coordinates[1];
             this.$emit("shareClosedTowns", []);
+
             try {
+                const latitude = this.input.coordinates[0];
+                const longitude = this.input.coordinates[1];
+
                 const { towns } = await findNearby(latitude, longitude);
                 const { closedTowns } = await findClosedNearby(
                     latitude,

--- a/packages/frontend/webapp/src/js/app/components/TownForm/inputs/InputAddress.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/inputs/InputAddress.vue
@@ -7,7 +7,7 @@
         :getResultValue="getResultValue"
         validationName="Adresse"
         @submit="submit"
-        rules="required"
+        rules="addressRequired"
         data-cy-field="address"
         :defaultValue="value"
         :disabled="disabled"
@@ -15,7 +15,15 @@
 </template>
 
 <script>
+import { extend } from "vee-validate";
 import { autocomplete } from "#helpers/addressHelper";
+
+extend("addressRequired", {
+    validate(value) {
+        return !!(value && value.citycode && value.label);
+    },
+    message: "L'adresse est obligatoire"
+});
 
 export default {
     props: {

--- a/packages/frontend/webapp/src/js/app/components/ui/Autocomplete.vue
+++ b/packages/frontend/webapp/src/js/app/components/ui/Autocomplete.vue
@@ -267,7 +267,7 @@ export default {
             this.searchInput = "";
             this.$emit("submit", null);
             this.$emit("input", null);
-            this.$refs.provider.syncValue(null);
+            this.$refs.provider.syncValue({});
             this.$refs.provider.validate();
             this.$emit("blur", { value: null, search: "" });
         },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/IIrsQkmT/1459

## 🛠 Description de la PR
Le champ d'adresse a deux valeurs possibles : soit un objet avec le label de l'adresse, le code de la ville, etc ; soit null, quand le champ est vidé avec la croix.

Cela pose deux problèmes :
- la rule "required" fournie par vee-validate ne s'enclenche pas parce que le champ a un objet (certes avec toutes ses clés à undefined) pour valeur, j'ai donc créé une règle custom "addressRequired" qui vérifie que l'objet n'est pas vide
- quand le champ est à null, vee-valide n'applique plus aucune règle, même les custom, j'ai donc modifié le champ d'autocomplete pour que, au clic sur la croix, on demande à vee-validate de faire une validation sur la base non plus de la valeur null mais d'un objet vide. C'était la solution la moins coûteuse.

## 📸 Captures d'écran
![Capture d’écran 2022-05-24 à 18 31 02](https://user-images.githubusercontent.com/1801091/170086515-54990468-288a-45cf-b9af-12aa3ea0c9de.png)