### PR TITLE
#patch (1476) Fiche site — Le bouton "Annuler" des panneaux commentaires ne devrait pas être visible quand le champ est vide

### DIFF
--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
@@ -103,12 +103,15 @@
                             :disabled="loading"
                         />
                         <div class="flex items-center justify-between">
-                            <Button
-                                variant="primaryText"
-                                type="button"
-                                @click="cancelComment"
-                                >Annuler</Button
-                            >
+                            <p>
+                                <Button
+                                    variant="primaryText"
+                                    type="button"
+                                    v-if="form.newComment"
+                                    @click="cancelComment"
+                                    >Annuler</Button
+                                >
+                            </p>
                             <Button
                                 variant="tertiary"
                                 type="primary"

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
@@ -49,9 +49,14 @@
                 </CheckableGroup>
             </div>
             <div class="flex items-center justify-between">
-                <Button variant="primaryText" @click="cancelComment"
-                    >Annuler</Button
-                >
+                <p>
+                    <Button
+                        variant="primaryText"
+                        @click="cancelComment"
+                        v-if="newComment"
+                        >Annuler</Button
+                    >
+                </p>
                 <Button
                     variant="tertiary"
                     @click="addComment"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/x0xWYGu4/1477

## 🛠 Description de la PR
RàS