### PR TITLE
#patch (1477) Fiche site — Le formulaire de publication d'un message n'attend pas que le message soit effectivement publié avant de rendre la main à l'utilisateur

### DIFF
--- a/packages/frontend/webapp/src/js/app/store/index.js
+++ b/packages/frontend/webapp/src/js/app/store/index.js
@@ -41,6 +41,7 @@ export default new Vuex.Store({
         entrypoint: null,
         towns: {
             data: [],
+            hash: {}, // an hash-table matching townId to an index in data
             loading: true,
             error: null,
             sort: "updatedAt",
@@ -71,6 +72,13 @@ export default new Vuex.Store({
         },
         setTowns(state, towns) {
             state.towns.data = towns;
+            state.towns.hash = towns.reduce(
+                (hash, { id }, index) => ({
+                    ...hash,
+                    [id]: index
+                }),
+                {}
+            );
         },
         setError(state, err) {
             state.towns.error = err;
@@ -90,10 +98,8 @@ export default new Vuex.Store({
         setDetailedTown(state, town) {
             state.detailedTown = town;
 
-            const index = state.towns.data.findIndex(
-                ({ id }) => id === town.id
-            );
-            if (index >= 0) {
+            const index = state.towns.hash[town.id];
+            if (index !== undefined) {
                 state.towns.data[index] = town;
             }
         },
@@ -105,12 +111,10 @@ export default new Vuex.Store({
                 state.detailedTown.comments = comments;
             }
 
-            const townIndex = state.towns.data.findIndex(
-                ({ id }) => id === townId
-            );
-            if (townIndex !== undefined) {
-                state.towns.data.splice(townIndex, 1, {
-                    ...state.towns.data[townIndex],
+            const index = state.towns.hash[townId];
+            if (index !== undefined) {
+                state.towns.data.splice(index, 1, {
+                    ...state.towns.data[index],
                     comments: comments
                 });
             }
@@ -123,12 +127,10 @@ export default new Vuex.Store({
                 state.detailedTown.actors = actors;
             }
 
-            const townIndex = state.towns.data.findIndex(
-                ({ id }) => id === townId
-            );
-            if (townIndex !== undefined) {
-                state.towns.data.splice(townIndex, 1, {
-                    ...state.towns.data[townIndex],
+            const index = state.towns.hash[townId];
+            if (index !== undefined) {
+                state.towns.data.splice(index, 1, {
+                    ...state.towns.data[index],
                     actors: actors
                 });
             }
@@ -146,9 +148,11 @@ export default new Vuex.Store({
                 }
             }
 
-            const town = state.towns.data.find(({ id }) => id === townId);
-            if (town !== undefined) {
-                const actor = town.actors.find(({ id }) => id === userId);
+            const index = state.towns.hash[townId];
+            if (index !== undefined) {
+                const actor = state.towns.data[index].actors.find(
+                    ({ id }) => id === userId
+                );
                 if (actor !== undefined) {
                     actor.themes = themes;
                 }

--- a/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
+++ b/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
@@ -30,6 +30,8 @@ export default {
 
 async function publish(apiMethod, townId, comment, matomoAction, commit) {
     const { comments } = await apiMethod(townId, comment);
+    commit("updateShantytownComments", { townId, comments }, { root: true });
+
     notify({
         group: "notifications",
         type: "success",
@@ -38,6 +40,5 @@ async function publish(apiMethod, townId, comment, matomoAction, commit) {
             "Votre message est bien enregistré et a été envoyé aux acteurs de votre département par mail."
     });
 
-    commit("updateShantytownComments", { townId, comments }, { root: true });
     Vue.prototype.$trackMatomoEvent("Site", matomoAction, `S${townId}`);
 }

--- a/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
+++ b/packages/frontend/webapp/src/js/app/store/modules/shantytownComments.js
@@ -6,8 +6,8 @@ export default {
     namespaced: true,
 
     actions: {
-        async publishComment({ commit }, { townId, comment }) {
-            publish(
+        publishComment({ commit }, { townId, comment }) {
+            return publish(
                 addComment,
                 townId,
                 comment,
@@ -16,8 +16,8 @@ export default {
             );
         },
 
-        async publishCovidComment({ commit }, { townId, comment }) {
-            publish(
+        publishCovidComment({ commit }, { townId, comment }) {
+            return publish(
                 addCovidComment,
                 townId,
                 comment,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/x0xWYGu4/1477

## 🛠 Description de la PR
Le problème était que la page TownDetails faisait un `await` sur la publication d'un message, mais que la fonction `publishComment` ne retournait pas la promise ! Autant dire que c'était (presque) parfaitement synchrone, retourner la promise a suffit à résoudre le problème.

Avant de comprendre, j'ai changé les choses suivantes :
- j'ai mis l'affichage de la notification de succès *après* mise à jour du store
- j'ai optimisé les changements faits dans le store "town" grâce à une hash-table (qui évite de reparcourir toute la liste des sites dès qu'on change un site de la liste)