### PR TITLE
#patch (1281) Fix readability of mails on Outlook

### DIFF
--- a/packages/api/server/mails/dist/activity_summary.html
+++ b/packages/api/server/mails/dist/activity_summary.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Semaine du {{ var:from }} au {{ var:to }}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Semaine du {{ var:from }} au {{ var:to }}</div>
     
                 </td>
               </tr>
@@ -167,7 +167,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:bold;line-height:2rem;text-align:left;color:#000000;">{{ summary.code }} – {{ summary.name }}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:bold;line-height:32px;text-align:left;color:#000000;">{{ summary.code }} – {{ summary.name }}</div>
     
                 </td>
               </tr>
@@ -575,7 +575,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:0.5rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#FF6F4c;">Avez-vous effectué d’autres actions ? Il est encore temps de les partager !</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#FF6F4c;">Avez-vous effectué d’autres actions ? Il est encore temps de les partager !</div>
     
                 </td>
               </tr>
@@ -583,7 +583,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.25rem;font-weight:700;line-height:1.5rem;text-align:left;color:#000091;">Le partage d’information entre tous les acteurs est essentiel pour accélérer la résorption des bidonvilles.</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:24px;text-align:left;color:#000091;">Le partage d’information entre tous les acteurs est essentiel pour accélérer la résorption des bidonvilles.</div>
     
                 </td>
               </tr>
@@ -749,7 +749,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-top:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:0.75rem;font-style:italic;font-weight:700;line-height:1.5rem;text-align:left;color:#000000;">Pour ne plus recevoir ces récapitulatifs hebdomadaires, veuillez <a href="{{var:webappUrl}}/mon-compte?{{var:utm}}" target="_blank" rel="noopener noreferrer" class="link" style="color: #000091; text-decoration: none;">le signaler dans votre espace "Mon compte"</a>.</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;font-style:italic;font-weight:700;line-height:15px;text-align:left;color:#000000;">Pour ne plus recevoir ces récapitulatifs hebdomadaires, veuillez <a href="{{var:webappUrl}}/mon-compte?{{var:utm}}" target="_blank" rel="noopener noreferrer" class="link" style="color: #000091; text-decoration: none;">le signaler dans votre espace "Mon compte"</a>.</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_access_activated.html
+++ b/packages/api/server/mails/dist/admin_access_activated.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Une nouvelle personne a rejoint la plateforme</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Une nouvelle personne a rejoint la plateforme</div>
     
                 </td>
               </tr>
@@ -179,7 +179,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.25rem;font-weight:700;line-height:1.5rem;text-align:left;color:#000091;">Vous souhaitez favoriser l’utilisation de la plateforme sur votre territoire ?</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:24px;text-align:left;color:#000091;">Vous souhaitez favoriser l’utilisation de la plateforme sur votre territoire ?</div>
     
                 </td>
               </tr>
@@ -187,7 +187,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.25rem;font-weight:700;line-height:1.5rem;text-align:left;color:#000091;">Vous souhaitez promouvoir l’outil auprès de vos partenaires ?</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:24px;text-align:left;color:#000091;">Vous souhaitez promouvoir l’outil auprès de vos partenaires ?</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_access_expired.html
+++ b/packages/api/server/mails/dist/admin_access_expired.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">En savoir plus sur une demande d’accès non activée</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">En savoir plus sur une demande d’accès non activée</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_new_request_notification.html
+++ b/packages/api/server/mails/dist/admin_new_request_notification.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Vous avez reçu une nouvelle demande d'accès à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> de <span class="font-bold" style="font-weight: bold;">{{var:userName}}</span>, {{var:orgName}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Vous avez reçu une nouvelle demande d'accès à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> de <span class="font-bold" style="font-weight: bold;">{{var:userName}}</span>, {{var:orgName}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_request_pending_reminder_1.html
+++ b/packages/api/server/mails/dist/admin_request_pending_reminder_1.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Vous avez reçu une nouvelle demande d'accès à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> de <span class="font-bold" style="font-weight: bold;">{{var:userName}}</span>, {{var:orgName}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Vous avez reçu une nouvelle demande d'accès à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> de <span class="font-bold" style="font-weight: bold;">{{var:userName}}</span>, {{var:orgName}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_request_pending_reminder_2.html
+++ b/packages/api/server/mails/dist/admin_request_pending_reminder_2.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Vous avez reçu une nouvelle demande d'accès à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> de <span class="font-bold" style="font-weight: bold;">{{var:userName}}</span>, {{var:orgName}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Vous avez reçu une nouvelle demande d'accès à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> de <span class="font-bold" style="font-weight: bold;">{{var:userName}}</span>, {{var:orgName}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_welcome.html
+++ b/packages/api/server/mails/dist/admin_welcome.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Bienvenue sur la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> !</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Bienvenue sur la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> !</div>
     
                 </td>
               </tr>
@@ -147,7 +147,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.25rem;font-weight:700;line-height:1.5rem;text-align:left;color:#000091;">Vous avez maintenant le rôle d’administrateur local sur votre territoire !</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:24px;text-align:left;color:#000091;">Vous avez maintenant le rôle d’administrateur local sur votre territoire !</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/contact_newsletter_registration.html
+++ b/packages/api/server/mails/dist/contact_newsletter_registration.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Une personne a demandé à être abonnée à la lettre d'info</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Une personne a demandé à être abonnée à la lettre d'info</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/demo_invitation.html
+++ b/packages/api/server/mails/dist/demo_invitation.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Participez à une session de formation à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Participez à une session de formation à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/platform_invitation.html
+++ b/packages/api/server/mails/dist/platform_invitation.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Un de vos partenaires vous invite à rejoindre la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Un de vos partenaires vous invite à rejoindre la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/shantytown_actor_invitation.html
+++ b/packages/api/server/mails/dist/shantytown_actor_invitation.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Un de vos partenaire vous invite à partager sur le site {{var:siteAddress}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Un de vos partenaire vous invite à partager sur le site {{var:siteAddress}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/shantytown_actor_notification.html
+++ b/packages/api/server/mails/dist/shantytown_actor_notification.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Vous êtes invité·e à confirmer votre intervention sur le site {{var:siteAddress}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Vous êtes invité·e à confirmer votre intervention sur le site {{var:siteAddress}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_activated_welcome.html
+++ b/packages/api/server/mails/dist/user_access_activated_welcome.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Bienvenue sur la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> !</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Bienvenue sur la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> !</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_denied.html
+++ b/packages/api/server/mails/dist/user_access_denied.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Suivi de votre demande d’accès</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Suivi de votre demande d’accès</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_expired.html
+++ b/packages/api/server/mails/dist/user_access_expired.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Expiration de votre lien d’accès à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Expiration de votre lien d’accès à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
     
                 </td>
               </tr>
@@ -163,7 +163,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.25rem;font-weight:700;line-height:1.5rem;text-align:left;color:#000091;">Bonne nouvelle, vous pouvez demander un nouveau lien !</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:24px;text-align:left;color:#000091;">Bonne nouvelle, vous pouvez demander un nouveau lien !</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_granted.html
+++ b/packages/api/server/mails/dist/user_access_granted.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Activez votre compte pour accéder à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Activez votre compte pour accéder à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_pending.html
+++ b/packages/api/server/mails/dist/user_access_pending.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Activez votre compte pour accéder à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> avant expiration du lien</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Activez votre compte pour accéder à la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> avant expiration du lien</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_request_confirmation.html
+++ b/packages/api/server/mails/dist/user_access_request_confirmation.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Prise en compte de votre demande</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Prise en compte de votre demande</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_features.html
+++ b/packages/api/server/mails/dist/user_features.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Et si vous partagiez votre intervention sur un site aux autres acteurs et actrices ?</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Et si vous partagiez votre intervention sur un site aux autres acteurs et actrices ?</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_idealco_invitation.html
+++ b/packages/api/server/mails/dist/user_idealco_invitation.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Nous vous invitons à rejoindre le groupe IdealCo de la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Nous vous invitons à rejoindre le groupe IdealCo de la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_review.html
+++ b/packages/api/server/mails/dist/user_review.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Vous utilisez la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> depuis trois mois, votre avis nous intéresse !</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Vous utilisez la plateforme <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span> depuis trois mois, votre avis nous intéresse !</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_shantytown_closed.html
+++ b/packages/api/server/mails/dist/user_shantytown_closed.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">{{var:departementName}} - Un site a été fermé</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">{{var:departementName}} - Un site a été fermé</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_shantytown_declared.html
+++ b/packages/api/server/mails/dist/user_shantytown_declared.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">{{var:departementName}} - Un nouveau site a été déclaré</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">{{var:departementName}} - Un nouveau site a été déclaré</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_share.html
+++ b/packages/api/server/mails/dist/user_share.html
@@ -139,7 +139,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.75rem;font-weight:700;line-height:2rem;text-align:left;color:#000091;">Tous vos partenaires de la résorption des bidonvilles sont-ils sur la plateforme ?</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Tous vos partenaires de la résorption des bidonvilles sont-ils sur la plateforme ?</div>
     
                 </td>
               </tr>
@@ -181,7 +181,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.25rem;font-weight:700;line-height:1.5rem;text-align:left;color:#000091;">Vous souhaitez favoriser l’utilisation de la plateforme sur votre territoire ?</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:24px;text-align:left;color:#000091;">Vous souhaitez favoriser l’utilisation de la plateforme sur votre territoire ?</div>
     
                 </td>
               </tr>
@@ -189,7 +189,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:1.25rem;font-weight:700;line-height:1.5rem;text-align:left;color:#000091;">Vous souhaitez promouvoir l’outil auprès de vos partenaires ?</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:24px;text-align:left;color:#000091;">Vous souhaitez promouvoir l’outil auprès de vos partenaires ?</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/src/common/attributes.mjml
+++ b/packages/api/server/mails/src/common/attributes.mjml
@@ -11,9 +11,9 @@
     <mj-class name='button-primary' background-color="#000091" color="#FFFFFF" padding="2rem 0"/>
     <mj-class name='button-secondary' background-color="#FF6F4c" color="#FFFFFF" padding="2rem 0"/>
     <!-- text-size -->
-    <mj-class name='text-sm' font-size="0.75rem" line-height="1.5rem" font-weight="700" />
-    <mj-class name='text-lg' font-size="1.25rem" line-height="1.5rem" font-weight="700" />
-    <mj-class name='text-display' font-size="1.75rem" line-height="2rem" font-weight="700" />
+    <mj-class name='text-sm' font-size="12px" line-height="15px" font-weight="700" />
+    <mj-class name='text-lg' font-size="20px" line-height="24px" font-weight="700" />
+    <mj-class name='text-display' font-size="28px" line-height="32px" font-weight="700" />
     <!-- font-options -->
     <mj-class name='font-bold' font-weight='bold'/>
     <mj-class name='font-italic' font-style='italic'/>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ehrYHkjH/1281

## 🛠 Description de la PR
Sur certains clients Outlook le mail récap contient du texte illisible : la faute à des classes dont les styles utilisent une font-size en `rem`, ce qui est visiblement mal rendu dans ces cas là.
Le passage en `px` règle le problème : confirmé par une utilisatrice via des mails de test.

## 🚨 Notes pour la mise en production
RàS