### PR TITLE
#patch (1507) trier par défaut les sites par date d'actualisation

### DIFF
--- a/packages/api/server/models/shantytownModel/findAll.js
+++ b/packages/api/server/models/shantytownModel/findAll.js
@@ -1,3 +1,3 @@
 const query = require('./_common/query');
 
-module.exports = (user, filters = [], feature = 'list', order = undefined) => query(filters, order, user, feature);
+module.exports = (user, filters = [], feature = 'list', order = ['shantytowns.updated_at DESC']) => query(filters, order, user, feature);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Ie3zjo7f/1507-bug-tb-ordonner-les-vignettes-des-sites-par-date-dactualisation

## 🛠 Description de la PR
Par défaut la liste des sites dans le store n'était pas trié (le tri dans la liste des sites se fait dynamiquement selon la valeur du filtre de tri)
dans cette PR je choisis de trier par défaut dans la requête SQL la liste des sites selon la date d'actualisation