### PR TITLE
#patch (1535) correction chargement dernières activités

### DIFF
--- a/packages/api/server/models/shantytownModel/_common/livingConditions/v2/serialize.js
+++ b/packages/api/server/models/shantytownModel/_common/livingConditions/v2/serialize.js
@@ -11,7 +11,7 @@ module.exports = (town) => {
                 unknown: [],
             },
             access: town.electricityAccess,
-            access_types: town.electricityAccessTypes,
+            access_types: town.electricityAccessTypes || [],
             access_is_unequal: town.electricityAccessIsUnequal,
         },
         water: {
@@ -55,7 +55,7 @@ module.exports = (town) => {
             },
             open_air_defecation: town.sanitaryAccessOpenAirDefecation,
             working_toilets: town.sanitaryAccessWorkingToilets,
-            toilet_types: town.toiletTypes,
+            toilet_types: town.toiletTypes || [],
             toilets_are_inside: town.sanitaryAccessToiletsAreInside,
             toilets_are_lighted: town.sanitaryAccessToiletsAreLighted,
             hand_washing: town.sanitaryAccessHandWashing,

--- a/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/electricity/access_types.js
+++ b/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/electricity/access_types.js
@@ -8,7 +8,7 @@ module.exports = (town) => {
         return status;
     }
 
-    if (town.electricityAccessTypes.length === 0) {
+    if (town.electricityAccessTypes === undefined || town.electricityAccessTypes.length === 0) {
         status.details = 'unknown';
     }
 

--- a/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/sanitary/hand_washing.js
+++ b/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/sanitary/hand_washing.js
@@ -4,7 +4,7 @@ module.exports = (town) => {
         details: null,
     };
 
-    if (town.toiletTypes.length === 0 || (town.toiletTypes.length === 1 && town.toiletTypes.includes('latrines'))) {
+    if (town.toiletTypes === undefined || town.toiletTypes.length === 0 || (town.toiletTypes.length === 1 && town.toiletTypes.includes('latrines'))) {
         return status;
     }
 

--- a/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/sanitary/toilet_types.js
+++ b/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/sanitary/toilet_types.js
@@ -8,7 +8,7 @@ module.exports = (town) => {
         return status;
     }
 
-    if (town.toiletTypes.length === 0) {
+    if (town.toiletTypes === undefined || town.toiletTypes.length === 0) {
         status.globalImpact = 'unknown';
         status.details = 'unknown';
     } else if (!town.toiletTypes.includes('latrines')) {

--- a/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/sanitary/toilets_are_inside.js
+++ b/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/sanitary/toilets_are_inside.js
@@ -4,7 +4,7 @@ module.exports = (town) => {
         details: null,
     };
 
-    if (town.toiletTypes.length === 0 || (town.toiletTypes.length === 1 && town.toiletTypes.includes('latrines'))) {
+    if (town.toiletTypes === undefined || town.toiletTypes.length === 0 || (town.toiletTypes.length === 1 && town.toiletTypes.includes('latrines'))) {
         return status;
     }
 

--- a/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/sanitary/toilets_are_lighted.js
+++ b/packages/api/server/models/shantytownModel/_common/livingConditions/v2/statuses/sanitary/toilets_are_lighted.js
@@ -4,7 +4,7 @@ module.exports = (town) => {
         details: null,
     };
 
-    if (town.toiletTypes.length === 0 || (town.toiletTypes.length === 1 && town.toiletTypes.includes('latrines'))) {
+    if (town.toiletTypes === undefined || town.toiletTypes.length === 0 || (town.toiletTypes.length === 1 && town.toiletTypes.includes('latrines'))) {
         return status;
     }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/LSzBRGoK/1535-bug-les-derni%C3%A8res-activit%C3%A9s-ne-chargent-plus

## 🛠 Description de la PR
Le bug concerne le fait que lorsque l'accès à l'électricité et/ou aux toilettes est renseigné à oui mais qu'aucun type d'accès n'est renseigné, après serialization les champs étaient undefined alors que l'API testait uniquement s'ils étaient égaux à []