### PR TITLE
[patch] (1516) Ajout du type d'accès à l'eau sur l'export de la fiche site

### DIFF
--- a/packages/api/server/services/shantytown/export/2_section_living_conditions/accessToWater.js
+++ b/packages/api/server/services/shantytown/export/2_section_living_conditions/accessToWater.js
@@ -8,9 +8,21 @@ module.exports = (shantytown) => {
     };
     const { status, access_comments: comments } = shantytown.livingConditions.water;
 
+    const access_types = {
+        fontaine_publique: 'Fontaine publique',
+        borne_incendie: 'Borne incendie',
+        achat_bouteille: 'Achat bouteille uniquement',
+        reservoir: 'Réservoir / Cuve / Citerne',
+        robinet_connecte_au_reseau: 'Robinet connecté au réseau d\'eau',
+        autre: 'Autre',
+        inconnu: 'Inconnu',
+    };
+
+    const access_type = access_types[shantytown.livingConditions.water.access_type];
+
     let text = labels[status.status] || 'Aucune information concernant l\'accès à l\'eau';
     if (comments) {
-        text = `${text} – ${comments}`;
+        text = `${text} - ${access_type}\n${comments}`;
     }
 
     return createRow(['Accès à l\'eau', text]);


### PR DESCRIPTION
dans la section "Conditions de vie"

## 🧾 Ticket Trello
https://trello.com/c/eL3VQtz1

## 🛠 Description de la PR
A l'origine, il s'agissait d'afficher les 3 nuances pour l'accès à l'eau : oui / non / à améliorer. Or, il s'avère que le calcul de cette nuance existe depuis la mise en production des conditions de vie v2. Un bug empêchait l'affichage correct de la nuance. La [PR 558](https://github.com/MTES-MCT/resorption-bidonvilles/pull/558) corrige ce bug. 

Il restait donc juste à ajouter le type d'accès à l'eau, ce qui fait l'objet de cette PR.

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/182875047-eb7290b2-8cb8-4cd7-b995-ca5dd986b39a.png)

## 🚨 Notes pour la mise en production
- Merger de préférence, en priorité, la [PR corrigeant le statut des conditions de vie sur export fiche site](https://github.com/MTES-MCT/resorption-bidonvilles/pull/558) avant de merger celle-ci.