### PR TITLE
(1530) ajout picto maison + ligne noire

### DIFF
--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
@@ -35,26 +35,26 @@
                                 :class="section.css"
                                 v-bind:key="index"
                             >
-                                <td
-                                    v-if="index === 0"
-                                    class="align-top pr-2 text-xl"
-                                    :rowspan="sections.length"
-                                >
-                                    <Icon icon="male" class="mr-1"></Icon>
-                                    <Icon icon="male"></Icon>
+                                <td class="align-top pr-2 text-xl">
+                                    <span v-if="section.icon === 'people'">
+                                        <Icon icon="male" class="mr-1"></Icon>
+                                        <Icon icon="male"></Icon>
+                                    </span>
+                                    <span
+                                        v-else-if="section.icon === 'housing'"
+                                    >
+                                        <Icon icon="home"></Icon>
+                                    </span>
                                 </td>
-
                                 <td
                                     class="text-left pr-4 border-b-1"
                                     v-bind:class="{
                                         'border-black':
-                                            section.data === 'minorsInSchool'
+                                            sections[index + 1] &&
+                                            sections[index + 1].icon !==
+                                                undefined
                                     }"
                                 >
-                                    <Icon
-                                        v-if="section.type === 'housing'"
-                                        icon="home"
-                                    ></Icon>
                                     {{ section.title }}
                                 </td>
                                 <td
@@ -64,6 +64,10 @@
                                         'border-r-1':
                                             colIndex > 0 ||
                                             populationHistory.length <= 1,
+                                        'border-b-black-custom':
+                                            sections[index + 1] &&
+                                            sections[index + 1].icon !==
+                                                undefined,
                                         'bg-gray-100': colIndex === 0
                                     }"
                                     v-bind:key="colIndex"
@@ -125,6 +129,12 @@
     </DetailsPanel>
 </template>
 
+<style scoped>
+.border-b-black-custom {
+    border-bottom-color: black;
+}
+</style>
+
 <script>
 import DetailsPanel from "#app/components/ui/details/DetailsPanel.vue";
 import DetailsPanelSection from "#app/components/ui/details/DetailsPanelSection.vue";
@@ -144,7 +154,8 @@ export default {
                 {
                     title: "Personnes",
                     css: "font-bold",
-                    data: "populationTotal"
+                    data: "populationTotal",
+                    icon: "people"
                 },
                 {
                     title: "Ménages",
@@ -164,12 +175,11 @@ export default {
                 {
                     title: "Caravanes",
                     data: "caravans",
-                    type: "housing"
+                    icon: "housing"
                 },
                 {
                     title: "Cabanes",
-                    data: "huts",
-                    type: "housing"
+                    data: "huts"
                 }
             ]
         };

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
@@ -43,7 +43,18 @@
                                     <Icon icon="male" class="mr-1"></Icon>
                                     <Icon icon="male"></Icon>
                                 </td>
-                                <td class="text-left pr-4 border-b-1">
+
+                                <td
+                                    class="text-left pr-4 border-b-1"
+                                    v-bind:class="{
+                                        'border-black':
+                                            section.data === 'minorsInSchool'
+                                    }"
+                                >
+                                    <Icon
+                                        v-if="section.type === 'housing'"
+                                        icon="home"
+                                    ></Icon>
                                     {{ section.title }}
                                 </td>
                                 <td
@@ -152,11 +163,13 @@ export default {
                 },
                 {
                     title: "Caravanes",
-                    data: "caravans"
+                    data: "caravans",
+                    type: "housing"
                 },
                 {
                     title: "Cabanes",
-                    data: "huts"
+                    data: "huts",
+                    type: "housing"
                 }
             ]
         };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/l39s7ndF/1530-mieux-s%C3%A9parer-nb-de-caravanes-nb-de-cabanes-dans-la-visualisation-de-la-fiche-ligne-noire-plus-%C3%A9paisse-picto-maison



## 📸 Captures d'écran

<img width="958" alt="Capture d’écran 2022-08-22 à 10 30 35" src="https://user-images.githubusercontent.com/94321132/185876234-fac1e2ea-b022-43f2-bf17-85834901f639.png">

