### PR TITLE
#patch (966) correction position bandeau du résumé du site et des conditions alimentaires sur carte

### DIFF
--- a/packages/frontend/webapp/src/js/app/pages/CartoPage/POIView.vue
+++ b/packages/frontend/webapp/src/js/app/pages/CartoPage/POIView.vue
@@ -135,7 +135,7 @@ export default {
 .quickview {
     z-index: 7000;
     position: fixed;
-    top: 71px;
+    top: 186px;
     bottom: 0;
     right: -320px;
     width: 320px;

--- a/packages/frontend/webapp/src/js/app/pages/CartoPage/TownView/TownView.scss
+++ b/packages/frontend/webapp/src/js/app/pages/CartoPage/TownView/TownView.scss
@@ -17,7 +17,7 @@
 .quickview {
     z-index: 7000;
     position: fixed;
-    top: 71px;
+    top: 186px;
     bottom: 0;
     right: -320px;
     width: 320px;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JGBWGtYF

## 🛠 Description de la PR
- Correction de style pour permettre aux fiches de:
    - résumé d'un site,
    - point de distribution alimentaire
de ne pas empiéter sur la zone d'affichage du bandeau "Menu"

![image](https://user-images.githubusercontent.com/50863659/187222214-76276270-dc12-4bef-a93a-732b6b04adc6.png)

## 🚨 Notes pour la mise en production
- Ràs