### PR TITLE
#patch (1547) Corrige le lien pour l'entrée du menu Aide, actuellement vide

### DIFF
--- a/packages/frontend/webapp/src/js/app/layouts/Navbar/menuItems.js
+++ b/packages/frontend/webapp/src/js/app/layouts/Navbar/menuItems.js
@@ -1,3 +1,5 @@
+import { VUE_APP_WWW_URL } from "#src/js/env.js";
+
 export default {
     anonymous: [
         {
@@ -12,14 +14,14 @@ export default {
         },
         {
             label: "Aide",
-            target: "/mentions-legales",
+            target: `${VUE_APP_WWW_URL}/mentions-legales`,
             menu: "upper"
         }
     ],
     loading: [
         {
             label: "Aide",
-            target: "/mentions-legales",
+            target: `${VUE_APP_WWW_URL}/mentions-legales`,
             menu: "upper"
         },
         {
@@ -102,7 +104,7 @@ export default {
         },
         {
             label: "Aide",
-            target: "/mentions-legales",
+            target: `${VUE_APP_WWW_URL}/mentions-legales`,
             menu: "upper"
         },
         {


### PR DESCRIPTION
Route vers les mentions légales

## 🧾 Ticket Trello
https://trello.com/c/5AwBltej

## 🛠 Description de la PR
Modification de la cible du lien dont le libellé correspond à "Aide".
On utilise la variable d'environnement  `VUE_APP_WWW_URL` pour récupérer la racine du site en `www`et on ajoute la route `mentions-legales`