### PR TITLE
#patch (1548) Remplacer le picto "Excel" par le picto "Word" sur bouton "Exporter"

### DIFF
--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsHeader.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsHeader.vue
@@ -77,7 +77,7 @@
                 >Corriger la fermeture du site</Button
             >
             <Button
-                icon="file-excel"
+                icon="file-word"
                 iconPosition="left"
                 variant="primary"
                 class="mr-8"

--- a/packages/frontend/webapp/src/js/icons/index.js
+++ b/packages/frontend/webapp/src/js/icons/index.js
@@ -26,6 +26,7 @@ import {
     faEnvelope,
     faPlayCircle,
     faFileExcel,
+    faFileWord,
     faSortDown,
     faCaretSquareLeft,
     faCaretSquareRight,
@@ -112,6 +113,7 @@ library.add(faEnvelope);
 library.add(faPhone);
 library.add(faPlayCircle);
 library.add(faFileExcel);
+library.add(faFileWord);
 library.add(faSortDown);
 library.add(faCaretSquareLeft);
 library.add(faCaretSquareRight);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/SVMFGvge/XXX

## 🛠 Description de la PR
- Ajout de l'icône `file-word`à la liste des icônes disponibles pour webapp
- Remplacement de l'icône `file-excel` par l'icône `file-word` sur le bouton "Exporter" de la fiche site

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/187642197-8d27b4e5-0857-42a2-98b0-68f80975e41c.png)

## 🚨 Notes pour la mise en production
Ràs