### PR TITLE
#pach (1546) Correction des espacements entre boutons du mail de bienvenue

### DIFF
--- a/packages/api/server/mails/dist/admin_welcome.html
+++ b/packages/api/server/mails/dist/admin_welcome.html
@@ -195,7 +195,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>

--- a/packages/api/server/mails/dist/demo_invitation.html
+++ b/packages/api/server/mails/dist/demo_invitation.html
@@ -169,7 +169,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>

--- a/packages/api/server/mails/dist/platform_invitation.html
+++ b/packages/api/server/mails/dist/platform_invitation.html
@@ -203,7 +203,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>

--- a/packages/api/server/mails/dist/user_access_activated_welcome.html
+++ b/packages/api/server/mails/dist/user_access_activated_welcome.html
@@ -169,7 +169,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:1rem 0 0 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>
@@ -187,7 +187,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>
@@ -213,7 +213,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>

--- a/packages/api/server/mails/dist/user_access_granted.html
+++ b/packages/api/server/mails/dist/user_access_granted.html
@@ -203,7 +203,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>

--- a/packages/api/server/mails/dist/user_access_pending.html
+++ b/packages/api/server/mails/dist/user_access_pending.html
@@ -241,7 +241,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>

--- a/packages/api/server/mails/dist/user_features.html
+++ b/packages/api/server/mails/dist/user_features.html
@@ -227,7 +227,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>

--- a/packages/api/server/mails/dist/user_review.html
+++ b/packages/api/server/mails/dist/user_review.html
@@ -195,7 +195,7 @@
               </tr>
             
               <tr>
-                <td align="center" vertical-align="middle" style="font-size:0px;padding:2rem 0;word-break:break-word;">
+                <td align="center" vertical-align="middle" style="font-size:0px;padding:16px 0 16px 0;word-break:break-word;">
                   
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
         <tbody>

--- a/packages/api/server/mails/src/common/connect_cta.mjml
+++ b/packages/api/server/mails/src/common/connect_cta.mjml
@@ -1,3 +1,3 @@
-<mj-button mj-class="button-primary" href="{{var:connexionUrl}}" rel="noopener noreferrer">
+<mj-button mj-class="button-primary" padding="16px 0 16px 0" href="{{var:connexionUrl}}" rel="noopener noreferrer">
     Me connecter
 </mj-button>

--- a/packages/api/server/mails/src/common/formation_cta_me.mjml
+++ b/packages/api/server/mails/src/common/formation_cta_me.mjml
@@ -1,3 +1,3 @@
-<mj-button mj-class="button-secondary" href="{{var:formationUrl}}" rel="noopener noreferrer">
+<mj-button mj-class="button-secondary" padding="16px 0 16px 0" href="{{var:formationUrl}}" rel="noopener noreferrer">
     M'inscrire à une session de formation
 </mj-button>

--- a/packages/api/server/mails/src/user_access_activated_welcome.mjml
+++ b/packages/api/server/mails/src/user_access_activated_welcome.mjml
@@ -19,7 +19,7 @@
                 <mj-text>
                     Pour prendre en main rapidement la plateforme, téléchargez le court guide de l’utilisateur et participez à une session de formation personnalisée, nous répondrons à toutes vos questions.
                 </mj-text>
-                <mj-button mj-class="button-secondary" padding="1rem 0 0 0" href="{{var:userGuideUrl}}" rel="noopener noreferrer">
+                <mj-button mj-class="button-secondary" padding="16px 0 16px 0" href="{{var:userGuideUrl}}" rel="noopener noreferrer">
                     Télécharger mon guide utilisateur
                 </mj-button>
                 <mj-include path='common/formation_cta_me.mjml' />


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/9211UexH

## 🛠 Description de la PR
Correction des styles pour un affichage plus "aéré".

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/187675972-2b00e21d-29e9-4289-aa24-02ad44c400c3.png)