### PR TITLE
#patch (1545) Changement de formulation du critère "Présence de nuisible" 

### DIFF
--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
@@ -228,9 +228,8 @@ export default {
             return response;
         },
         pestAnimalsWording() {
-            return ["good"].includes(
-                this.town.livingConditions.pest_animals.status.status
-            )
+            return this.town.livingConditions.pest_animals.status.status ===
+                "good"
                 ? "Absence de nuisible"
                 : "Présence de nuisibles";
         }

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
@@ -2,6 +2,7 @@
     <DetailsPanel>
         <template v-slot:title>Conditions de vie et environnement</template>
         <template v-slot:body>
+            <span>{{ town.livingConditions.pest_animals.status.status }}</span>
             <Tag
                 variant="pin_red"
                 :uppercase="false"
@@ -74,7 +75,7 @@
 
             <div v-if="town.livingConditions.version === 2">
                 <TownDetailsPanelLivingConditionsSection
-                    title="Présence de nuisibles"
+                    :title="pestAnimalsWording"
                     :status="town.livingConditions.pest_animals.status"
                     :inverted="true"
                     :answers="answers.pest_animals"
@@ -226,6 +227,13 @@ export default {
             }
 
             return response;
+        },
+        pestAnimalsWording() {
+            return ["good"].includes(
+                this.town.livingConditions.pest_animals.status.status
+            )
+                ? "Absence de nuisibles"
+                : "Présence de nuisibles";
         }
     }
 };

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
@@ -57,6 +57,7 @@
                 <TownDetailsPanelLivingConditionsSection
                     :title="pestAnimalsWording"
                     :status="town.livingConditions.vermin.status"
+                    :showStatus="false"
                     cypressName="vermin"
                     cypressDetailsPrefix="vermin"
                     :answers="answers.pest_animals"
@@ -76,6 +77,7 @@
                 <TownDetailsPanelLivingConditionsSection
                     :title="pestAnimalsWording"
                     :status="town.livingConditions.pest_animals.status"
+                    :showStatus="false"
                     :inverted="true"
                     :answers="answers.pest_animals"
                 />

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
@@ -55,7 +55,7 @@
 
             <div v-if="town.livingConditions.version === 1">
                 <TownDetailsPanelLivingConditionsSection
-                    title="Présence de nuisibles"
+                    :title="pestAnimalsWording"
                     :status="town.livingConditions.vermin.status"
                     cypressName="vermin"
                     cypressDetailsPrefix="vermin"

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/TownDetailsPanelLivingConditions.vue
@@ -2,7 +2,6 @@
     <DetailsPanel>
         <template v-slot:title>Conditions de vie et environnement</template>
         <template v-slot:body>
-            <span>{{ town.livingConditions.pest_animals.status.status }}</span>
             <Tag
                 variant="pin_red"
                 :uppercase="false"
@@ -232,7 +231,7 @@ export default {
             return ["good"].includes(
                 this.town.livingConditions.pest_animals.status.status
             )
-                ? "Absence de nuisibles"
+                ? "Absence de nuisible"
                 : "Présence de nuisibles";
         }
     }

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/ui/TownDetailsPanelLivingConditionsSection.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/ui/TownDetailsPanelLivingConditionsSection.vue
@@ -177,6 +177,15 @@ export default {
                 }
             }
 
+            // Le libellé (text) ce ce critère est "Présence de nuisible" si le statut est "bad" et "Absence de nuisible" si le statut est good
+            // Dans ces 2 cas, il faut donc que la valeur affichée soit "oui", e qui correspond à la propriété "good" de l'objet' "texts"
+            if (
+                this.title.includes("nuisible") &&
+                ["good", "bad"].includes(this.status.status)
+            ) {
+                status = "good";
+            }
+
             return this.texts[status] || "inconnu";
         }
     }

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/ui/TownDetailsPanelLivingConditionsSection.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/ui/TownDetailsPanelLivingConditionsSection.vue
@@ -5,27 +5,9 @@
             <div>
                 <div class="flex items-center">
                     <div :class="[colorClass, 'font-bold', 'mr-1']">
-                        {{ title
-                        }}<span
-                            v-if="
-                                ![
-                                    'Absence de nuisible',
-                                    'Présence de nuisibles'
-                                ].includes(title) || text === 'inconnu'
-                            "
-                        >
-                            :</span
-                        >
+                        {{ title }}<span v-if="showStatus"> :</span>
                     </div>
-                    <div
-                        :data-cy-data="cypressName"
-                        v-if="
-                            ![
-                                'Absence de nuisible',
-                                'Présence de nuisibles'
-                            ].includes(title) || text === 'inconnu'
-                        "
-                    >
+                    <div :data-cy-data="cypressName" v-if="showStatus">
                         {{ text }}
                     </div>
                 </div>
@@ -134,6 +116,11 @@ export default {
         },
         status: {
             type: Object
+        },
+        showStatus: {
+            type: Boolean,
+            default: true,
+            required: false
         },
         cypressName: {
             type: String

--- a/packages/frontend/webapp/src/js/app/pages/TownDetails/ui/TownDetailsPanelLivingConditionsSection.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownDetails/ui/TownDetailsPanelLivingConditionsSection.vue
@@ -5,9 +5,29 @@
             <div>
                 <div class="flex items-center">
                     <div :class="[colorClass, 'font-bold', 'mr-1']">
-                        {{ title }} :
+                        {{ title
+                        }}<span
+                            v-if="
+                                ![
+                                    'Absence de nuisible',
+                                    'Présence de nuisibles'
+                                ].includes(title) || text === 'inconnu'
+                            "
+                        >
+                            :</span
+                        >
                     </div>
-                    <div :data-cy-data="cypressName">{{ text }}</div>
+                    <div
+                        :data-cy-data="cypressName"
+                        v-if="
+                            ![
+                                'Absence de nuisible',
+                                'Présence de nuisibles'
+                            ].includes(title) || text === 'inconnu'
+                        "
+                    >
+                        {{ text }}
+                    </div>
                 </div>
                 <slot />
             </div>
@@ -175,15 +195,6 @@ export default {
                 } else if (status === "bad") {
                     status = "good";
                 }
-            }
-
-            // Le libellé (text) ce ce critère est "Présence de nuisible" si le statut est "bad" et "Absence de nuisible" si le statut est good
-            // Dans ces 2 cas, il faut donc que la valeur affichée soit "oui", e qui correspond à la propriété "good" de l'objet' "texts"
-            if (
-                this.title.includes("nuisible") &&
-                ["good", "bad"].includes(this.status.status)
-            ) {
-                status = "good";
             }
 
             return this.texts[status] || "inconnu";

--- a/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
@@ -147,8 +147,15 @@
                                     shantytown.livingConditions[verminKey]
                                         .status.status
                                 "
-                                >pres. de nuisibles</TownCardIcon
-                            >
+                                >{{
+                                    ["good"].includes(
+                                        shantytown.livingConditions[verminKey]
+                                            .status.status
+                                    )
+                                        ? "abs. de nuisibles"
+                                        : "pres. de nuisibles"
+                                }}
+                            </TownCardIcon>
                             <TownCardIcon
                                 :status="
                                     shantytown.livingConditions[fireKey].status

--- a/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
+++ b/packages/frontend/webapp/src/js/app/pages/TownsList/TownCard.vue
@@ -148,10 +148,8 @@
                                         .status.status
                                 "
                                 >{{
-                                    ["good"].includes(
-                                        shantytown.livingConditions[verminKey]
-                                            .status.status
-                                    )
+                                    shantytown.livingConditions[verminKey]
+                                        .status.status === "good"
                                         ? "abs. de nuisibles"
                                         : "pres. de nuisibles"
                                 }}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/UC1xD73I

## 🛠 Description de la PR
- Impacte la liste des sites et la fiche site
- Sur la liste des sites, on affiche:
    - "prés. de nuisible" avec une icône de type croix rouge si le critère est à "bad"
    -  "prés. de nuisible" avec une icône de type point d'interrogation si le critère est à "unknown"
    -  "abs. de nuisible" avec une icône de type coche verte si le critère est à "good"
- Sur la fiche site, c'est un peu plus compliqué:
    - Si le critère est à "good", on affiche "Absence de nuisible"
    - SI le critère est à "bad", on affiche "Présence de nuisible"
    et dans ces deux cas, on n'affiche pas le statut "Oui" ou "Non"
    Par contre, le statut est précisé s'il est "unknown" (inconnu)
    
## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/187877117-44bf5342-7f4c-41cc-ad69-7550a9bbbe1a.png)

![image](https://user-images.githubusercontent.com/50863659/187877222-b63afb82-289b-4a6d-9cee-948e1ec68136.png)

![image](https://user-images.githubusercontent.com/50863659/187877360-3fa4355c-0a73-4e81-b5da-b798a49a9ecb.png)

 