### PR TITLE
#patch (1544) Formulaire saisie de site — La page affiche un ascenseur en largeur qui peut décentrer le contenu

### DIFF
--- a/packages/frontend/webapp/src/js/app/components/ui/Form/input/Checkbox.vue
+++ b/packages/frontend/webapp/src/js/app/components/ui/Form/input/Checkbox.vue
@@ -11,7 +11,7 @@
         >
             <input
                 type="checkbox"
-                class="appearance-none absolute invisible"
+                class="w-0 invisible"
                 v-bind="filteredProps"
                 :checked="isChecked"
                 @change="onChange"
@@ -108,7 +108,7 @@ export default {
         checkboxClasses() {
             return {
                 classic: "form-checkbox h-5 w-5",
-                invisible: "appearance-none absolute invisible",
+                invisible: "w-0 invisible",
                 default: `checkbox-town-input ${
                     this.disabled ? "bg-G300" : "bg-white"
                 }`

--- a/packages/frontend/webapp/src/js/app/components/ui/Form/input/Radio.vue
+++ b/packages/frontend/webapp/src/js/app/components/ui/Form/input/Radio.vue
@@ -11,7 +11,7 @@
         >
             <input
                 :type="type"
-                class="appearance-none absolute invisible"
+                class="w-0 invisible"
                 v-bind="filteredProps"
                 :checked="isChecked"
                 @change="onChange"
@@ -111,7 +111,7 @@ export default {
         radioClasses() {
             const base = {
                 classic: "form-checkbox h-5 w-5",
-                invisible: "appearance-none absolute invisible",
+                invisible: "w-0 invisible",
                 default: "radio-town-input"
             }[this.variant];
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/MmG0NcP0/1544-formulaire-saisie-de-site-la-page-affiche-un-ascenseur-en-largeur-qui-peut-d%C3%A9centrer-le-contenu

## 🛠 Description de la PR
le soucis était aussi présent sur la fiche site, et probablement ailleurs
provenant d'un style "absolute" sur des composants input