### PR TITLE
#patch (1558) ajout d'un bouton d'export des commentaires des actions

### DIFF
--- a/packages/api/db/migrations/30000024-add-permission-plan_comment-export.js
+++ b/packages/api/db/migrations/30000024-add-permission-plan_comment-export.js
@@ -1,0 +1,51 @@
+module.exports = {
+    async up(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        await Promise.all(
+            [
+                queryInterface.sequelize.query(
+                    'INSERT INTO features(name, fk_entity, is_writing) VALUES(\'export\', \'plan_comment\', false)',
+                    {
+                        transaction,
+                    },
+                ),
+                queryInterface.sequelize.query(
+                    `INSERT INTO role_permissions(fk_role_admin, fk_feature, fk_entity, allowed, allow_all)
+                VALUES
+                    ('national_admin', 'export', 'plan_comment', true, true)`,
+                    {
+                        transaction,
+                    },
+                ),
+            ],
+        );
+
+        await transaction.commit();
+    },
+
+    async down(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+
+        await Promise.all(
+            [
+                queryInterface.sequelize.query(
+                    'DELETE FROM role_permissions WHERE fk_feature = \'export\' AND fk_entity = \'plan_comment\'',
+                    {
+                        transaction,
+                    },
+                ),
+                queryInterface.sequelize.query(
+                    'DELETE FROM features WHERE name = \'export\' AND fk_entity = \'plan_comment\'',
+                    {
+                        transaction,
+                    },
+                ),
+            ],
+        );
+
+        await transaction.commit();
+    },
+
+};

--- a/packages/api/server/controllers/index.ts
+++ b/packages/api/server/controllers/index.ts
@@ -36,6 +36,7 @@ const planListExport = require('./planController/listExport');
 const planUpdate = require('./planController/update');
 // plan comments
 const createPlanComment = require('./planCommentController/create');
+const exportComments = require('./planCommentController/export');
 // poi
 const poiFindAll = require('./poiController/findAll');
 // shantytown
@@ -125,6 +126,7 @@ export default {
     },
     planComment: {
         create: createPlanComment,
+        export: exportComments,
     },
     poi: {
         findAll: poiFindAll,

--- a/packages/api/server/controllers/planCommentController/export.js
+++ b/packages/api/server/controllers/planCommentController/export.js
@@ -1,0 +1,30 @@
+const JSONToCSV = require('json2csv');
+const planCommentService = require('#server/services/planComment');
+
+const ERROR_RESPONSES = {
+    fetch_failed: { code: 400, message: 'Une lecture en base de données a échoué' },
+    permission_denied: { code: 403, message: 'Permission refusée' },
+    no_data: { code: 400, message: 'Aucune donnée à exporter' },
+    [undefined]: { code: 500, message: 'Une erreur inconnue est survenue' },
+};
+
+
+module.exports = async (req, res, next) => {
+    let comments;
+    try {
+        comments = await planCommentService.exportAll(req.user);
+    } catch (error) {
+        const { code, message } = ERROR_RESPONSES[error && error.code];
+        res.status(code).send({
+            error: {
+                user_message: message,
+            },
+        });
+
+        return next(error.nativeError || error);
+    }
+
+    return res.status(200).send({
+        csv: JSONToCSV.parse(comments),
+    });
+};

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -397,6 +397,14 @@ export default (app) => {
             return controller(req, res, next);
         },
     );
+    app.get(
+        '/plans/comments/export',
+        middlewares.auth.authenticate,
+        (...args) => middlewares.auth.checkPermissions(['plan_comment.export'], ...args),
+        middlewares.charte.check,
+        middlewares.appVersion.sync,
+        controllers.planComment.export,
+    );
 
     // towns
     app.get(

--- a/packages/api/server/models/planCommentModel/findAll.js
+++ b/packages/api/server/models/planCommentModel/findAll.js
@@ -1,0 +1,33 @@
+const sequelize = require('#db/sequelize');
+const { serializeComment } = require('#server/models/planModel');
+
+
+module.exports = async () => {
+    const rows = await sequelize.query(
+        `
+        SELECT
+            pc.plan_comment_id AS "commentId",
+            pc.description AS "commentDescription",
+            pc.fk_plan AS "planId",
+            pc.created_at AS "commentCreatedAt",
+            pc.created_by "commentCreatedBy",
+            u.user_id AS "userId",
+            u.first_name AS "userFirstName",
+            u.last_name AS "userLastName",
+            u.position AS "userPosition",
+            o.organization_id AS "organizationId",
+            o.name AS "organizationName",
+            o.abbreviation AS "organizationAbbreviation"
+        FROM
+            plan_comments pc
+        LEFT JOIN
+            users u ON pc.created_by = u.user_id
+        LEFT JOIN
+            organizations o ON u.fk_organization = o.organization_id
+        `,
+        {
+            type: sequelize.QueryTypes.SELECT,
+        },
+    );
+    return rows.map(row => serializeComment(row));
+};

--- a/packages/api/server/models/planCommentModel/findAll.js
+++ b/packages/api/server/models/planCommentModel/findAll.js
@@ -15,6 +15,7 @@ module.exports = async () => {
             u.first_name AS "userFirstName",
             u.last_name AS "userLastName",
             u.position AS "userPosition",
+            rr.name AS "userRole",
             o.organization_id AS "organizationId",
             o.name AS "organizationName",
             o.abbreviation AS "organizationAbbreviation"
@@ -23,11 +24,13 @@ module.exports = async () => {
         LEFT JOIN
             users u ON pc.created_by = u.user_id
         LEFT JOIN
+            roles_regular rr ON u.fk_role_regular = rr.role_id
+        LEFT JOIN
             organizations o ON u.fk_organization = o.organization_id
         `,
         {
             type: sequelize.QueryTypes.SELECT,
         },
     );
-    return rows.map(row => serializeComment(row));
+    return rows.map(serializeComment);
 };

--- a/packages/api/server/models/planCommentModel/findOne.js
+++ b/packages/api/server/models/planCommentModel/findOne.js
@@ -17,6 +17,7 @@ module.exports = async (id) => {
             u.first_name AS "userFirstName",
             u.last_name AS "userLastName",
             u.position AS "userPosition",
+            rr.name AS "userRole",
             o.organization_id AS "organizationId",
             o.name AS "organizationName",
             o.abbreviation AS "organizationAbbreviation"
@@ -26,6 +27,8 @@ module.exports = async (id) => {
             users u ON pc.created_by = u.user_id
         LEFT JOIN
             organizations o ON u.fk_organization = o.organization_id
+        LEFT JOIN
+            roles_regular rr ON u.fk_role_regular = rr.role_id
         WHERE
             pc.plan_comment_id = :id`,
         {

--- a/packages/api/server/models/planCommentModel/index.js
+++ b/packages/api/server/models/planCommentModel/index.js
@@ -1,7 +1,10 @@
 const create = require('./create');
 const findOne = require('./findOne');
+const findAll = require('./findAll');
+
 
 module.exports = {
     create,
     findOne,
+    findAll,
 };

--- a/packages/api/server/models/planModel/_common/serializeComment.js
+++ b/packages/api/server/models/planModel/_common/serializeComment.js
@@ -7,6 +7,7 @@ module.exports = comment => Object.assign(
             id: comment.commentCreatedBy,
             first_name: comment.userFirstName,
             last_name: comment.userLastName,
+            role: comment.userRole,
             position: comment.userPosition,
             organization: comment.organizationAbbreviation || comment.organizationName,
             organization_id: comment.organizationId,

--- a/packages/api/server/services/planComment/exportAll.js
+++ b/packages/api/server/services/planComment/exportAll.js
@@ -1,0 +1,40 @@
+const moment = require('moment');
+const planCommentModel = require('#server/models/planCommentModel');
+const ServiceError = require('#server/errors/ServiceError');
+const permissionUtils = require('#server/utils/permission');
+
+module.exports = async (user) => {
+    const nationalLevel = { type: 'nation' };
+
+    if (!permissionUtils.can(user).do('export', 'plan_comment').on(nationalLevel)) {
+        throw new ServiceError('permission_denied', new Error('Vous n\'avez pas la permission d\'exporter les commentaires'));
+    }
+
+
+    let comments;
+    try {
+        comments = await planCommentModel.findAll();
+    } catch (error) {
+        throw new ServiceError('fetch_failed', error);
+    }
+
+    if (comments.length === 0) {
+        throw new ServiceError('no_data', new Error('Il n\'y a aucun commentaire à exporter'));
+    }
+    // build excel file
+    return comments.map((row) => {
+        const createdAt = moment(row.commentCreatedAt).utcOffset(2);
+
+        return {
+            S: createdAt.format('w'),
+            'ID du commentaire': row.id,
+            'ID de l\'action': row.plan,
+            'Publié le': createdAt.format('DD/MM/YYYY'),
+            Description: row.description,
+            'ID de l\'auteur(e)': row.createdBy.id,
+            'Nom de famille': row.createdBy.last_name,
+            Structure: row.createdBy.organization,
+            Role: row.createdBy.role,
+        };
+    });
+};

--- a/packages/api/server/services/planComment/exportAll.spec.js
+++ b/packages/api/server/services/planComment/exportAll.spec.js
@@ -1,0 +1,73 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+const planCommentModel = require('#server/models/planCommentModel');
+
+const { serialized: fakePlanComment } = require('#test/utils/planComment');
+const { serialized: fakeUser } = require('#test/utils/user');
+const permissionUtils = require('#server/utils/permission');
+const moment = require('moment');
+
+
+const exportAllService = require('./exportAll');
+
+
+describe.only('services/exportAll', () => {
+    describe('exportAll()', () => {
+        const user = fakeUser();
+        const planComment = fakePlanComment();
+        let stubs;
+
+        beforeEach(() => {
+            stubs = {
+                findAll: sinon.stub(planCommentModel, 'findAll'),
+                can: sinon.stub(permissionUtils, 'can'),
+                do: sinon.stub(),
+                on: sinon.stub(),
+            };
+            stubs.can.returns({
+                do: stubs.do,
+            });
+            stubs.do.returns({
+                on: stubs.on,
+            });
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('vérifie que l\'utilisateur a le droit d\'exporter les commentaires des actions au niveau national', async () => {
+            try {
+                await exportAllService(user);
+            } catch (e) {
+                // ignore
+            }
+            expect(stubs.can).to.have.been.calledOnceWith(user);
+            expect(stubs.do).to.have.been.calledOnceWith('export', 'plan_comment');
+            // eslint-disable-next-line no-unused-expressions
+            expect(stubs.on).to.have.been.calledOnceWith({ type: 'nation' });
+        });
+        it('récupère les commentaires en bdd et les renvoie au formal excel', async () => {
+            stubs.on.returns(true);
+            const createdAt = moment(planComment.commentCreatedAt).utcOffset(2);
+            stubs.findAll.resolves([planComment]);
+            const response = await exportAllService(user);
+            expect(response).to.be.eql([{
+                S: createdAt.format('w'),
+                'ID du commentaire': planComment.id,
+                'ID de l\'action': planComment.plan,
+                'Publié le': createdAt.format('DD/MM/YYYY'),
+                Description: planComment.description,
+                'ID de l\'auteur(e)': planComment.createdBy.id,
+                'Nom de famille': planComment.createdBy.last_name,
+                Structure: planComment.createdBy.organization,
+                Role: planComment.createdBy.role,
+            }]);
+        });
+    });
+});

--- a/packages/api/server/services/planComment/index.js
+++ b/packages/api/server/services/planComment/index.js
@@ -1,5 +1,8 @@
 const createComment = require('./createComment');
+const exportAll = require('./exportAll');
+
 
 module.exports = {
     createComment,
+    exportAll,
 };

--- a/packages/api/test/utils/planComment.js
+++ b/packages/api/test/utils/planComment.js
@@ -1,0 +1,21 @@
+module.exports = {
+    serialized(override = {}) {
+        const defaultObj = {
+            id: 1,
+            description: 'Un commentaire',
+            createdAt: (new Date(2020, 0, 1, 0, 0, 0)).getTime() / 1000,
+            createdBy: {
+                id: 2,
+                first_name: 'Jean',
+                last_name: 'Dupont',
+                position: 'Mock',
+                organization: 'DIHAL',
+                organizationId: 2,
+                role: 'direct_collaborator',
+            },
+            plan: 1,
+        };
+
+        return Object.assign(defaultObj, override);
+    },
+};

--- a/packages/frontend/webapp/src/js/app/pages/PlanList/PlanListHeader/PlanListHeader.vue
+++ b/packages/frontend/webapp/src/js/app/pages/PlanList/PlanListHeader/PlanListHeader.vue
@@ -72,7 +72,6 @@ export default {
                 hiddenElement.download = "messages.csv";
                 hiddenElement.click();
             } catch (error) {
-                console.log(error);
                 let message = "Une erreur inconnue est survenue";
                 if (error && error.user_message) {
                     message = error.user_message;

--- a/packages/frontend/webapp/src/js/app/pages/PlanList/PlanListHeader/PlanListHeader.vue
+++ b/packages/frontend/webapp/src/js/app/pages/PlanList/PlanListHeader/PlanListHeader.vue
@@ -8,6 +8,19 @@
             </h1>
 
             <div class="flex items-end space-x-6">
+                <Button
+                    v-if="
+                        $store.getters['config/hasPermission'](
+                            'plan_comment.export'
+                        )
+                    "
+                    icon="file-excel"
+                    iconPosition="left"
+                    :loading="exportCommentIsPending"
+                    variant="primary"
+                    @click="exportComments"
+                    >Exporter tous les commentaires</Button
+                >
                 <div v-if="hasPermission('plan.create')">
                     <router-link to="/nouvelle-action">
                         <Button
@@ -36,7 +49,7 @@
 
 <script>
 import TabList from "#app/components/TabList/TabList.vue";
-import { exportPlans } from "#helpers/api/plan";
+import { exportPlans, exportComments } from "#helpers/api/plan";
 import { mapGetters } from "vuex";
 import { notify } from "#helpers/notificationHelper";
 
@@ -45,6 +58,35 @@ export default {
         TabList
     },
     methods: {
+        async exportComments() {
+            if (this.exportCommentIsPending === true) {
+                return;
+            }
+            this.exportCommentIsPending = true;
+            try {
+                const { csv } = await exportComments();
+                const hiddenElement = document.createElement("a");
+                hiddenElement.href =
+                    "data:text/csv;charset=utf-8," + encodeURI(csv);
+                hiddenElement.target = "_blank";
+                hiddenElement.download = "messages.csv";
+                hiddenElement.click();
+            } catch (error) {
+                console.log(error);
+                let message = "Une erreur inconnue est survenue";
+                if (error && error.user_message) {
+                    message = error.user_message;
+                }
+                notify({
+                    group: "notifications",
+                    type: "error",
+                    title: "Une erreur est survenue",
+                    text: message
+                });
+            }
+
+            this.exportCommentIsPending = false;
+        },
         async exportPlans() {
             if (this.exportIsPending === true) {
                 return;
@@ -75,10 +117,10 @@ export default {
 
     data() {
         return {
-            exportIsPending: false
+            exportIsPending: false,
+            exportCommentIsPending: false
         };
     },
-
     computed: {
         ...mapGetters({
             hasPermission: "config/hasPermission",

--- a/packages/frontend/webapp/src/js/helpers/api/plan.js
+++ b/packages/frontend/webapp/src/js/helpers/api/plan.js
@@ -69,6 +69,13 @@ export function addComment(id, data) {
 /**
  *
  */
+export function exportComments() {
+    return getApi("/plans/comments/export");
+}
+
+/**
+ *
+ */
 export async function close(planId, data) {
     return patchApi(`/plans/${planId}`, {
         operation: "close",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/0FTfDBU9/1558-journal-des-actions-cr%C3%A9er-une-requ%C3%AAte-sql-de-suivi-des-messages-sur-le-journal

## 🛠 Description de la PR
création d'une permission plan_comment.export disponible uniquement pour les admin nationaux
création d'un bouton sur la page de la liste des actions permettant d'en exporter tous les commentaires
création des modèles, services, controlleurs permettant de réaliser l'export



## 🚨 Notes pour la mise en production
Une migration à faire tourner