### PR TITLE
#patch (1571) fix store refresh after town update

### DIFF
--- a/packages/frontend/webapp/src/js/app/components/TownForm/TownForm.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/TownForm.vue
@@ -441,10 +441,14 @@ export default {
                     title: "Succès",
                     text: this.successNotificationWording
                 });
-                this.$store.state.towns.data.push(result.town);
+
+                if (this.mode === "create") {
+                    this.$store.state.towns.data.push(result.town);
+                } else {
+                    this.$store.commit("setDetailedTown", result);
+                }
             } catch (err) {
                 this.loading = false;
-
                 if (err && err.fields) {
                     this.$refs.form.setErrors(err.fields);
                     this.errors = err.fields;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/1PFA6YLY/1571

## 🛠 Description de la PR
L'API ne répond plus la même chose entre une création (= un objet avec une clé `town` : `{ town: { id: 1, ... } }`) et une modification (= le town directement : `{ id: 1, ... }`).

Hors, le formulaire traitait la réponse de l'API de la même façon entre create et edit, d'où le problème de mise à jour du store.