### PR TITLE
#patch (1576) Corrige le souci d'affichage de la carte sur fiche action

### DIFF
--- a/packages/api/server/mails/mails.js
+++ b/packages/api/server/mails/mails.js
@@ -311,7 +311,6 @@ module.exports = {
                 blogUrl,
                 formationUrl,
                 connexionUrl: `${connexionUrl}?${utm}`,
-                blogUrl,
             },
             preserveRecipient,
         });

--- a/packages/frontend/webapp/src/js/app/components/map/map.vue
+++ b/packages/frontend/webapp/src/js/app/components/map/map.vue
@@ -375,9 +375,6 @@ export default {
     },
 
     computed: {
-        getPathResource() {
-            return this.$route.path.split("/")[1];
-        },
         fieldTypes() {
             return this.$store.state.config.configuration.field_types;
         },
@@ -985,6 +982,14 @@ export default {
         },
 
         getTownWaterImage(town) {
+            if (
+                !town ||
+                !town.livingConditions ||
+                !town.livingConditions.water
+            ) {
+                return genericMarkerImage;
+            }
+
             const { status } = town.livingConditions.water.status;
             const hash = {
                 unknown: waterNull,
@@ -1028,11 +1033,7 @@ export default {
             const address = this.getTownAddress(town);
             const coordinates = this.getTownCoordinates(town);
             const color = this.getTownColor(town);
-            const waterImage = ["site", "cartographie"].includes(
-                this.getPathResource
-            )
-                ? this.getTownWaterImage(town)
-                : genericMarkerImage;
+            const waterImage = this.getTownWaterImage(town);
             const style = town.style ? `style="${town.style}"` : "";
 
             const marker = L.marker(coordinates, {

--- a/packages/frontend/webapp/src/js/app/components/map/map.vue
+++ b/packages/frontend/webapp/src/js/app/components/map/map.vue
@@ -68,6 +68,7 @@ import waterYes from "../../../../img/water-yes.png";
 import waterNo from "../../../../img/water-no.png";
 import waterToImprove from "../../../../img/water-to-improve.png";
 import waterNull from "../../../../img/water-null.png";
+import genericMarkerImage from "./assets/map-marker.svg";
 
 // données tirées de https://github.com/gregoiredavid/france-geojson
 import departements from "#src/geojson/departements.json";
@@ -374,6 +375,9 @@ export default {
     },
 
     computed: {
+        getPathResource() {
+            return this.$route.path.split("/")[1];
+        },
         fieldTypes() {
             return this.$store.state.config.configuration.field_types;
         },
@@ -1024,7 +1028,11 @@ export default {
             const address = this.getTownAddress(town);
             const coordinates = this.getTownCoordinates(town);
             const color = this.getTownColor(town);
-            const waterImage = this.getTownWaterImage(town);
+            const waterImage = ["site", "cartographie"].includes(
+                this.getPathResource
+            )
+                ? this.getTownWaterImage(town)
+                : genericMarkerImage;
             const style = town.style ? `style="${town.style}"` : "";
 
             const marker = L.marker(coordinates, {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/vSRJkPbI

## 🛠 Description de la PR
- Remplace l'icône basée sur le statu de l'accès à l'eau du marqueur utilisé pour les sites par une icône générique quand le composant `map` est utilisé hors de la fiche site ou de la page de cartographie des sites.

## 📸 Captures d'écran
Exemple d'affichage de la carto sur une fiche action dont le lieu est un terrain d'insertion:
![image](https://user-images.githubusercontent.com/50863659/191726649-30119b9c-72b7-4d65-8af5-226b65c13cae.png)
