### PR TITLE
#patch (1588,1580) intégration des commentaires d'action aux historiques

### DIFF
--- a/packages/api/server/middlewares/validators/activity/list.js
+++ b/packages/api/server/middlewares/validators/activity/list.js
@@ -52,6 +52,7 @@ module.exports = [
                 'highCovidComment',
                 'user',
                 'onlyCovid',
+                'planComment',
             ];
             const unknownFilters = value.filter(s => !knownFilters.includes(s));
 
@@ -70,6 +71,7 @@ module.exports = [
             'shantytownComment',
             'highCovidComment',
             'user',
+            'planComment',
         ]),
 
     // location (type and code)

--- a/packages/api/server/models/planCommentModel/getHistory.js
+++ b/packages/api/server/models/planCommentModel/getHistory.js
@@ -1,0 +1,95 @@
+const sequelize = require('#db/sequelize');
+const userModel = require('#server/models/userModel');
+const { restrict } = require('#server/utils/permission');
+
+module.exports = async (user, location, numberOfActivities, lastDate, maxDate) => {
+    // apply geographic level restrictions
+    const where = [];
+    const replacements = {
+        maxDate,
+    };
+    const limit = numberOfActivities !== -1 ? `limit ${numberOfActivities}` : '';
+
+    const restrictedLocation = restrict(location).for(user).askingTo('list', 'plan_comment');
+    if (restrictedLocation === null) {
+        return [];
+    }
+
+    if (restrictedLocation.type === 'region') {
+        where.push('departements.fk_region = :locationCode');
+        replacements.locationCode = restrictedLocation.region.code;
+    } else if (restrictedLocation.type !== 'nation') {
+        where.push('departements.code = :locationCode');
+        replacements.locationCode = restrictedLocation.departement.code;
+    }
+
+    where.push(`comments.created_at < '${lastDate}'`);
+    if (maxDate) {
+        where.push('comments.created_at >= :maxDate');
+    }
+
+    const activities = await sequelize.query(
+        `
+            SELECT DISTINCT
+                comments.plan_comment_id AS "commentId",
+                comments.created_at AS "date",
+                author.first_name AS author_first_name,
+                author.last_name AS author_last_name,
+                author.fk_organization AS author_organization,
+                comments.description AS description,
+                plans2.plan_id AS plan_id,
+                plans2.name AS plan_name
+            FROM plan_comments comments
+            LEFT JOIN users author ON comments.created_by = author.user_id
+            LEFT JOIN plans2 ON comments.fk_plan = plans2.plan_id
+            LEFT JOIN plan_departements ON plan_departements.fk_plan = comments.fk_plan
+            LEFT JOIN departements ON plan_departements.fk_departement = departements.code
+            LEFT JOIN regions ON departements.fk_region = regions.code
+            LEFT JOIN cities ON cities.fk_departement = departements.code
+            LEFT JOIN epci ON cities.fk_epci = epci.code
+            ${where.length > 0 ? `WHERE (${where.join(') AND (')})` : ''}
+            ORDER BY comments.created_at DESC
+            ${limit}
+            `,
+        {
+            type: sequelize.QueryTypes.SELECT,
+            replacements,
+        },
+    );
+
+    const planComments = {};
+
+    return activities
+        .map((activity) => {
+            if (planComments[activity.commentId] !== undefined) {
+                return null;
+            }
+
+            const o = {
+                entity: 'comment',
+                action: 'creation',
+                date: activity.date.getTime() / 1000,
+                plan: {
+                    id: activity.plan_id,
+                    name: activity.plan_name,
+                },
+                author: {
+                    name: userModel.formatName({
+                        first_name: activity.author_first_name,
+                        last_name: activity.author_last_name,
+                    }),
+                    organization: activity.author_organization,
+                },
+                comment: {
+                    tags: [],
+                    user_target_name: [],
+                    organization_target_name: [],
+                    description: activity.description,
+                },
+            };
+
+            planComments[activity.commentId] = o;
+            return o;
+        })
+        .filter(activity => activity !== null);
+};

--- a/packages/api/server/models/planCommentModel/getHistory.js
+++ b/packages/api/server/models/planCommentModel/getHistory.js
@@ -61,10 +61,6 @@ module.exports = async (user, location, numberOfActivities, lastDate, maxDate) =
 
     return activities
         .map((activity) => {
-            if (planComments[activity.commentId] !== undefined) {
-                return null;
-            }
-
             const o = {
                 entity: 'comment',
                 action: 'creation',
@@ -90,6 +86,5 @@ module.exports = async (user, location, numberOfActivities, lastDate, maxDate) =
 
             planComments[activity.commentId] = o;
             return o;
-        })
-        .filter(activity => activity !== null);
+        });
 };

--- a/packages/api/server/models/planCommentModel/index.js
+++ b/packages/api/server/models/planCommentModel/index.js
@@ -1,10 +1,11 @@
 const create = require('./create');
 const findOne = require('./findOne');
 const findAll = require('./findAll');
-
+const getHistory = require('./getHistory');
 
 module.exports = {
     create,
     findOne,
     findAll,
+    getHistory,
 };

--- a/packages/api/server/models/userActivityModel/getHistory.js
+++ b/packages/api/server/models/userActivityModel/getHistory.js
@@ -2,6 +2,7 @@ const shantytownModel = require('#server/models/shantytownModel');
 const shantytownCommentModel = require('#server/models/shantytownCommentModel');
 const highCovidCommentModel = require('#server/models/highCovidCommentModel');
 const userModel = require('#server/models/userModel');
+const planCommentModel = require('#server/models/planCommentModel');
 
 /**
  * @param {Object} userLocation Location to be used for 'local' permissions
@@ -32,6 +33,9 @@ module.exports = async (user, location, entities, numberOfActivities, lastDate, 
     }
     if (entities.includes('user')) {
         promises.push(userModel.getHistory(location, numberOfActivities, lastDate, maxDate));
+    }
+    if (entities.includes('planComment')) {
+        promises.push(planCommentModel.getHistory(user, location, numberOfActivities, lastDate, maxDate));
     }
     const activities = await Promise.all(promises);
     const sortedActivities = activities.flat().sort((a, b) => (a.date > b.date ? -1 : 1));

--- a/packages/frontend/webapp/src/js/app/components/ActivityCard/ActivityCard.vue
+++ b/packages/frontend/webapp/src/js/app/components/ActivityCard/ActivityCard.vue
@@ -5,7 +5,7 @@
         @mouseleave="isHover = false"
     >
         <CommentModerationModal
-            v-if="activity.comment"
+            v-if="activity.comment && !activity.plan"
             ref="moderationModal"
             :comment="activity.comment"
         />
@@ -43,6 +43,12 @@
                             >({{ activity.shantytown.departement.code }})</span
                         ></Link
                     >
+                </p>
+                <p v-if="activity.plan">
+                    action :
+                    <Link :to="`/action/${activity.plan.id}`">{{
+                        activity.plan.name
+                    }}</Link>
                 </p>
                 <p v-if="activity.highCovidComment">
                     territoire(s) :
@@ -172,6 +178,13 @@ export default {
                 };
             }
 
+            if (this.activity.plan) {
+                return {
+                    text: "text-green600",
+                    bg: "bg-green500"
+                };
+            }
+
             return {
                 text: "text-orange600",
                 bg: "bg-orange600"
@@ -201,7 +214,11 @@ export default {
                         return "Nouveau message Covid-19";
                     }
 
-                    return "Nouveau message";
+                    if (this.activity.plan) {
+                        return "Nouveau message action";
+                    }
+
+                    return "Nouveau message site";
             }
         },
         bodyComponent() {
@@ -238,6 +255,10 @@ export default {
                     return "/covid-19";
                 }
 
+                if (this.activity.plan) {
+                    return `/action/${this.activity.plan.id}#comment`;
+                }
+
                 return `/site/${this.activity.shantytown.id}#message${this.activity.comment.id}`;
             }
 
@@ -266,6 +287,7 @@ export default {
             if (
                 this.activity.entity !== "comment" ||
                 this.activity.highCovidComment ||
+                this.activity.plan ||
                 this.variant === "small"
             ) {
                 return false;

--- a/packages/frontend/webapp/src/js/app/pages/Dashboard/DashboardActivities/DashboardActivity.vue
+++ b/packages/frontend/webapp/src/js/app/pages/Dashboard/DashboardActivities/DashboardActivity.vue
@@ -7,7 +7,7 @@
         "
         @click="routeToDetails"
     >
-        <aside class="mr-6">
+        <aside class="mr-6 self-start">
             <span
                 :class="
                     `${iconColor.background} ${iconColor.text} text-xl rounded-full inline-flex items-center justify-center w-12 h-12`
@@ -31,6 +31,9 @@
                         >({{ activity.shantytown.departement.code }})</span
                     >
                 </span>
+            </p>
+            <p class="mt-1" v-if="activity.plan">
+                <span class="font-bold">{{ activity.plan.name }}</span>
             </p>
             <ResorptionTargetTag
                 v-if="resorptionTarget"
@@ -170,6 +173,10 @@ export default {
                         return "";
                     }
 
+                    if (this.activity.plan) {
+                        return "dans le journal de l'action";
+                    }
+
                     return "dans le journal du site";
 
                 case "shantytown-creation":
@@ -249,6 +256,10 @@ export default {
                         return this.colors.red;
                     }
 
+                    if (this.activity.plan) {
+                        return this.colors.green;
+                    }
+
                     return this.colors.blue;
 
                 case "shantytown-creation":
@@ -279,6 +290,10 @@ export default {
             if (this.activity.entity === "comment") {
                 if (this.activity.highCovidComment) {
                     return this.$router.push("/covid-19");
+                } else if (this.activity.plan) {
+                    return this.$router.push(
+                        `/action/${this.activity.plan.id}/#comment`
+                    );
                 } else {
                     return this.$router.push(
                         `/site/${this.activity.shantytown.id}#message${this.activity.comment.id}`

--- a/packages/frontend/webapp/src/js/app/pages/History/HistoryFilters.vue
+++ b/packages/frontend/webapp/src/js/app/pages/History/HistoryFilters.vue
@@ -29,8 +29,12 @@ export default {
                         value: "shantytownUpdate"
                     },
                     {
-                        label: "Nouveaux messages",
+                        label: "Nouveaux messages site",
                         value: "shantytownComment_highCovidComment"
+                    },
+                    {
+                        label: "Nouveaux messages action",
+                        value: "planComment"
                     },
                     {
                         label: "Nouveaux utilisateurs",

--- a/packages/frontend/webapp/src/js/helpers/api/userActivity.js
+++ b/packages/frontend/webapp/src/js/helpers/api/userActivity.js
@@ -22,7 +22,8 @@ export function listRegular(
                   "shantytownUpdate",
                   "shantytownComment",
                   "highCovidComment",
-                  "user"
+                  "user",
+                  "planComment"
               ]
             : activityFilter;
 


### PR DESCRIPTION
[## 🧾 Ticket Trello
- https://trello.com/c/DeALq9w0/1588
- https://trello.com/c/roNk4JRW/1580

## 🛠 Description de la PR
- Ajout d'une méthode `getHistory()` au modèle `planCommentModel`
- Ajout d'un filtre "plan_comment" à la route `GET /activites`
- Adaptation du front en conséquence (dans "Dernières activités" j'ai créé deux filtres séparés pour messages site et messages action, en revanche ils sont mélangés dans le fil des activités du tableau de bord).

## 📸 Captures d'écran
![Capture d’écran 2022-09-28 à 18 19 39](https://user-images.githubusercontent.com/1801091/192832938-fa3cf95a-7b4f-4258-95dc-ca165d38b9d6.png)
![Capture d’écran 2022-09-28 à 18 19 57](https://user-images.githubusercontent.com/1801091/192832990-d08abe05-4f91-42e3-ad41-89b2af493737.png)

## 🚨 Notes pour la mise en production
RàS