### PR TITLE
(1599) Permettre de générer un lien d'activation à envoyer manuellement

### DIFF
--- a/packages/api/server/controllers/index.ts
+++ b/packages/api/server/controllers/index.ts
@@ -58,6 +58,7 @@ const userCreate = require('./userController/create');
 const userDenyAccess = require('./userController/denyAccess');
 const userEdit = require('./userController/edit');
 const userGet = require('./userController/get');
+const userGetLatestActivationLink = require('./userController/getLatestActivationLink');
 const userList = require('./userController/list');
 const userListExport = require('./userController/listExport');
 const userMe = require('./userController/me');
@@ -150,6 +151,7 @@ export default {
         denyAccess: userDenyAccess,
         edit: userEdit,
         get: userGet,
+        getLatestActivationLink: userGetLatestActivationLink,
         list: userList,
         listExport: userListExport,
         me: userMe,

--- a/packages/api/server/controllers/userController/getLatestActivationLink.js
+++ b/packages/api/server/controllers/userController/getLatestActivationLink.js
@@ -1,0 +1,10 @@
+const auth = require('#server/utils/auth');
+
+module.exports = async (req, res) => res
+    .status(200)
+    .send({
+        link: auth.getAccountActivationLink(
+            req.body.userAccess.user_access_id,
+            req.body.userAccess.expires_at,
+        ),
+    });

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -139,6 +139,16 @@ export default (app) => {
         middlewares.appVersion.sync,
         controllers.user.sendActivationLink,
     );
+    app.get(
+        '/users/:id/activationLink',
+        middlewares.auth.authenticate,
+        (...args) => middlewares.auth.checkPermissions(['user.activate'], ...args),
+        middlewares.charte.check,
+        middlewares.appVersion.sync,
+        validators.user.getLatestActivationLink,
+        middlewares.validation,
+        controllers.user.getLatestActivationLink,
+    );
     app.post(
         '/users/:id/denyAccess',
         middlewares.auth.authenticate,

--- a/packages/api/server/middlewares/validators/index.js
+++ b/packages/api/server/middlewares/validators/index.js
@@ -21,6 +21,7 @@ const findNearbyTowns = require('./findNearbyTowns');
 const exportTown = require('./exportTown');
 const setUserAdminComments = require('./setUserAdminComments');
 const editOrganization = require('./editOrganization');
+const userGetLatestActivationLink = require('./users/getLatestActivationLink');
 const userSetRoleRegular = require('./users/setRoleRegular');
 const mePostNavigationLogs = require('./me/post.navigationLogs');
 
@@ -57,6 +58,7 @@ module.exports = {
         location: dashboardLocation,
     },
     user: {
+        getLatestActivationLink: userGetLatestActivationLink,
         setRoleRegular: userSetRoleRegular,
     },
     me: {

--- a/packages/api/server/middlewares/validators/users/getLatestActivationLink.js
+++ b/packages/api/server/middlewares/validators/users/getLatestActivationLink.js
@@ -1,0 +1,24 @@
+/* eslint-disable newline-per-chained-call */
+const { param } = require('express-validator');
+const userAccessModel = require('#server/models/userAccessModel');
+
+module.exports = [
+    param('id')
+        .toInt()
+        .isInt().bail().withMessage('L\'identifiant de l\'utilisateur est invalide')
+        .custom(async (value, { req }) => {
+            let userAccess;
+            try {
+                userAccess = await userAccessModel.findLatestUserAccess(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la recherche de l\'utilisateur en base de données');
+            }
+
+            if (userAccess === null) {
+                throw new Error('Impossible de trouver un accès envoyé encore valide pour cet utilisateur');
+            }
+
+            req.body.userAccess = userAccess;
+            return true;
+        }),
+];

--- a/packages/api/server/models/userAccessModel/findLatestUserAccess.js
+++ b/packages/api/server/models/userAccessModel/findLatestUserAccess.js
@@ -1,0 +1,30 @@
+const sequelize = require('#db/sequelize');
+
+module.exports = async (userId) => {
+    const rows = await sequelize.query(
+        `
+        SELECT user_accesses.user_access_id,
+                user_accesses.expires_at
+            FROM user_accesses
+        LEFT JOIN users ON user_accesses.fk_user = users.user_id
+            WHERE
+                    user_accesses.expires_at > NOW()
+                AND user_accesses.used_at IS NULL
+                AND user_accesses.fk_user = :userId
+                AND users.fk_status = 'new'
+        ORDER BY user_accesses.created_at DESC
+            LIMIT 1`,
+        {
+            type: sequelize.QueryTypes.SELECT,
+            replacements: {
+                userId,
+            },
+        },
+    );
+
+    if (rows.length !== 1) {
+        return null;
+    }
+
+    return rows[0];
+};

--- a/packages/api/server/models/userAccessModel/index.js
+++ b/packages/api/server/models/userAccessModel/index.js
@@ -1,7 +1,9 @@
 const create = require('./create');
+const findLatestUserAccess = require('./findLatestUserAccess');
 const update = require('./update');
 
 module.exports = {
     create,
+    findLatestUserAccess,
     update,
 };

--- a/packages/api/server/utils/auth.js
+++ b/packages/api/server/utils/auth.js
@@ -59,7 +59,12 @@ module.exports = {
      *
      * @returns {string}
      */
-    getAccountActivationLink(userAccessId) {
+    getAccountActivationLink(userAccessId, expiresAt = null) {
+        let expiresIn = activationTokenExpiresIn;
+        if (expiresAt !== null) {
+            expiresIn = Math.round((expiresAt.getTime() - Date.now()) / 1000);
+        }
+
         const token = jwt.sign(
             {
                 type: 'account_validation',
@@ -67,7 +72,7 @@ module.exports = {
             },
             authConfig.secret,
             {
-                expiresIn: activationTokenExpiresIn,
+                expiresIn,
             },
         );
 

--- a/packages/frontend/webapp/src/js/helpers/api/user.js
+++ b/packages/frontend/webapp/src/js/helpers/api/user.js
@@ -92,6 +92,13 @@ export function sendActivationLink(user, data) {
 }
 
 /**
+ * GET /users/:id/activationLink
+ */
+export function getLatestActivationLink(user) {
+    return getApi(`/users/${user}/activationLink`);
+}
+
+/**
  * POST /users/:id/denyAccess
  */
 export function denyAccess(user) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Vd2i7il9/1599

## 🛠 Description de la PR
- ajout d'une route `GET /users/:id/activationLink` et des contrôleurs et validateurs associés
- cette route ne marche que pour un utilisateur nouveau (ie. pas activé et pas désactivé non plus), qui a reçu un accès, et que cet accès est toujours valide (ie. non utilisé et non expiré). Ces conditions sont imposées dans la requête SQL du nouveau modèle `findLatestUserAccess()`
- ajout côté front d'un bouton réservé aux admins nationaux qui permet de récupérer le lien en question et de le récupérer dans son presse-papier

## 📸 Captures d'écran
![Capture d’écran 2022-10-10 à 11 33 11](https://user-images.githubusercontent.com/1801091/194836967-69d59442-7ef5-4b68-a363-5565abd36da4.png)
![Capture d’écran 2022-10-10 à 11 33 23](https://user-images.githubusercontent.com/1801091/194836979-13c4f80a-ac54-4585-87a1-81c3bff784b8.png)