### PR TITLE
#patch (1610) Amélioration du temps de réponse de l'API sur get/activities

### DIFF
--- a/packages/api/db/migrations/30000028-01-create-index-on-localized_organizations.js
+++ b/packages/api/db/migrations/30000028-01-create-index-on-localized_organizations.js
@@ -1,0 +1,11 @@
+module.exports = {
+    async up(queryInterface) {
+        await queryInterface.sequelize.query('CREATE UNIQUE INDEX localized_organizations_pkey ON localized_organizations (organization_id)');
+    },
+
+    async down(queryInterface) {
+        await queryInterface.sequelize.query(
+            'DROP INDEX localized_organizations_pkey',
+        );
+    },
+};

--- a/packages/api/server/models/highCovidCommentModel/getHistory.js
+++ b/packages/api/server/models/highCovidCommentModel/getHistory.js
@@ -30,7 +30,7 @@ module.exports = async (user, location, numberOfActivities, lastDate, maxDate) =
 
     const activities = await sequelize.query(
         `
-            SELECT DISTINCT
+            SELECT
                 comments.high_covid_comment_id AS "highCommentId",
                 comments.created_at AS "date",
                 author.first_name AS author_first_name,
@@ -44,8 +44,6 @@ module.exports = async (user, location, numberOfActivities, lastDate, maxDate) =
             LEFT JOIN high_covid_comment_territories territories ON territories.fk_comment = comments.high_covid_comment_id
             LEFT JOIN departements ON territories.fk_departement = departements.code
             LEFT JOIN regions ON departements.fk_region = regions.code
-            LEFT JOIN cities ON cities.fk_departement = departements.code
-            LEFT JOIN epci ON cities.fk_epci = epci.code
             ${where.length > 0 ? `WHERE (${where.join(') AND (')})` : ''}
             ORDER BY comments.created_at DESC
             ${limit}

--- a/packages/api/server/models/shantytownModel/getHistory.js
+++ b/packages/api/server/models/shantytownModel/getHistory.js
@@ -78,7 +78,10 @@ module.exports = async (user, location, shantytownFilter, numberOfActivities, la
                     LEFT JOIN shantytown_toilet_types stt ON stt.fk_shantytown = shantytowns.hid
                     ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
                     ${where.length > 0 ? `WHERE ((${where.join(') OR (')}))` : ''}
-                )
+                    ${where.length > 0 ? 'AND' : 'WHERE'} shantytowns.updated_at < '${lastDate}'
+                    ORDER BY shantytowns.updated_at DESC
+                    ${limit}
+                    )
                 UNION
                 (
                     WITH
@@ -120,6 +123,9 @@ module.exports = async (user, location, shantytownFilter, numberOfActivities, la
                     LEFT JOIN shantytown_toilet_types stt ON stt.fk_shantytown = shantytowns.shantytown_id
                     ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
                     ${where.length > 0 ? `WHERE (${where.join(') OR (')})` : ''}
+                    ${where.length > 0 ? 'AND' : 'WHERE'} shantytowns.updated_at < '${lastDate}'
+                    ORDER BY shantytowns.updated_at DESC
+                    ${limit}
                 )) activities
             LEFT JOIN users author ON activities.author_id = author.user_id
             WHERE activities.date < '${lastDate}'


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/goWyeiFz/1610-dette-technique-am%C3%A9lioration-du-temps-de-r%C3%A9ponse-de-lapi-sur-get-activities

## 🛠 Description de la PR
Trois changements dans cette PR, présentés ci-dessous dans leur ordre d'impact sur le temps de réponse de l'API
- création d'un index sur la clé primaire de la vue matérialisée localized_organizations (à noter que ce changement occasionne des gains de temps de réponse sur d'autres pages en théorie, notamment l'annuaire, mais je n'ai pas fait de test précis pour le mesurer) 
- dans la requete de récupération de l'historique des sites :  déplacement (duplication) de la logique where/orderby/limit à l'intérieur des sous-requetes
- dans la requete de récupération de l'historique des high-covid-comments: suppression du select Distinct et de deux left join inutiles