### PR TITLE
#patch (1644)  Permettre la sélection d'un site fermé dans les 90 jours suivant l'installation du site considéré

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -82,7 +82,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "yarn test"
+      "pre-push": "yarn test:unit"
     }
   },
   "lint-staged": {
@@ -95,7 +95,6 @@
     "dev": "ts-node-dev ./server/index.ts",
     "build": "tsc && tsc-alias && cp -r server/mails/dist dist/server/mails && cp -r assets dist && cp .sequelizerc dist && cp -r db/data dist/db/data",
     "start": "nodemon dist/server/index.js",
-    "test": "mocha --recursive --require ./test/bootstrap.ts --bail",
     "test:unit": "yarn mocha -r ts-node/register --require ./test/bootstrap.ts 'server/**/*.spec.ts' 'test/**/*.spec.ts' --bail --exit",
     "test:integration": "yarn test --grep '.*server/models.*'",
     "lint": "eslint  --max-warnings=0",

--- a/packages/frontend/webapp/src/js/app/components/TownForm/TownFormPanelPeople.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/TownFormPanelPeople.vue
@@ -176,12 +176,12 @@ export default {
             const maxDate = new Date(dateRef);
             maxDate.setDate(maxDate.getDate() + 89);
 
-            const min = new Date(dateRef);
-            min.setDate(min.getDate() - 89);
+            const minDate = new Date(dateRef);
+            minDate.setDate(minDate.getDate() - 89);
 
             return (
                 town.closedAt <= maxDate.getTime() / 1000 &&
-                town.closedAt >= min.getTime() / 1000
+                town.closedAt >= minDate.getTime() / 1000
             );
         }
     }

--- a/packages/frontend/webapp/src/js/app/components/TownForm/TownFormPanelPeople.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/TownFormPanelPeople.vue
@@ -68,9 +68,10 @@
                 <template slot="info">
                     À l'aide du tableau ci-dessous sélectionnez les sites où
                     vivaient précédemment les habitants du site en cours de
-                    saisie. La tableau liste les sites ouverts à date et les
-                    sites fermés avant l'installation de celui-ci.</template
-                >
+                    saisie. Le tableau liste les sites ouverts à date et les
+                    sites fermés trois mois avant ou après l'installation de
+                    celui-ci.
+                </template>
             </InputShantytowns>
             <p v-else>
                 <InputLabel
@@ -163,20 +164,23 @@ export default {
                 return false;
             }
 
-            // on ne conserve que les sites ouverts ou les sites fermés 90 jours avant la date
-            // d'installation du site courant
+            // on ne conserve que les sites ouverts ou les sites fermés dans la période allant de
+            // 90 jours avant jusqu'à 90 jours après la date d'installation du site courant
             if (town.closedAt === null) {
                 return true;
             }
 
-            const max = this.reinstallationConfig.builtAt || new Date();
-            max.setHours(0, 0, 0, 0);
+            const dateRef = this.reinstallationConfig.builtAt || new Date();
+            dateRef.setHours(0, 0, 0, 0);
 
-            const min = new Date(max);
+            const maxDate = new Date(dateRef);
+            maxDate.setDate(maxDate.getDate() + 89);
+
+            const min = new Date(dateRef);
             min.setDate(min.getDate() - 89);
 
             return (
-                town.closedAt <= max.getTime() / 1000 &&
+                town.closedAt <= maxDate.getTime() / 1000 &&
                 town.closedAt >= min.getTime() / 1000
             );
         }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/c2NGbogc

## 🛠 Description de la PR
- Les sites fermés 90 jours après la date de déclaration du site en cours de saisie peuvent être sélectionnés pour alimenter la liste des sites fermés dont proviennent les habiatnts du site en cours de saisie
- Changement de wording sur le composant de sélection des sites où vivaient précédemment les habitants du site en cours de saisie.
- Correction du lancement des tests au pre-push

## 🚨 Notes pour la mise en production
- Penser à prévenir Mme. Kerche par courriel depuis la boite support.