### PR TITLE
#patch (1325) Export des commentaires pas exhaustif

### DIFF
--- a/packages/api/server/services/shantytownComment/exportAll.ts
+++ b/packages/api/server/services/shantytownComment/exportAll.ts
@@ -27,6 +27,10 @@ export default async (user) => {
     return comments.map((raw) => {
         const createdAt = moment(raw.commentCreatedAt).utcOffset(2);
 
+        // Replaces the problematic sharps characters in the csv file
+        const stringToReplace = /#/gi;
+        raw.commentDescription = raw.commentDescription.replace(stringToReplace, "♯");
+
         return {
             S: createdAt.format('w'),
             'ID du commentaire': raw.commentId,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/uaRv7ICe

## 🛠 Description de la PR
- Un caractère **#** dans un commentaire posait problème lors de l'export au format `csv` car le format `csv` considère que ce caractère initie un commentaire.
- LE service vérifie la présence de ce caractère dans la description du commentaire et le remplace par un `♯` légèrement différent.

## 🚨 Notes pour la mise en production
- Ràs