### PR TITLE
#patch (1642) Tableau de bord — La vue d'ensemble comptabilise plus de sites qu'il n'en existe

### DIFF
--- a/packages/api/server/middlewares/validators/common/writeTown.ts
+++ b/packages/api/server/middlewares/validators/common/writeTown.ts
@@ -120,15 +120,12 @@ export default mode => ([
      ********************************************************************************************* */
     body('updated_at')
         .exists({ checkNull: true }).bail().withMessage('Le champ "Date de mise à jour" est obligatoire')
-        .isDate().bail().withMessage('Le champ "Date de mise à jour" est invalide')
+
         .toDate()
-        .customSanitizer((value) => {
-            value.setHours(0, 0, 0, 0);
-            return value;
-        })
         .custom((value, { req }) => {
+            console.log(value)
+            console.log(typeof value)
             const today = new Date();
-            today.setHours(0, 0, 0, 0);
 
             if (value > today) {
                 throw new Error('La date de mise à jour du site ne peut pas être future');
@@ -136,8 +133,7 @@ export default mode => ([
 
             // for updates only
             if (req.town) {
-                const lastUpdate = new Date(req.town.updatedAt * 1000);
-                lastUpdate.setHours(0, 0, 0, 0);
+                const lastUpdate = new Date(req.town.updatedAt);
 
                 if (value < lastUpdate) {
                     throw new Error('La date de mise à jour du site ne peut pas être antérieure à la précédente mise à jour');

--- a/packages/api/server/middlewares/validators/common/writeTown.ts
+++ b/packages/api/server/middlewares/validators/common/writeTown.ts
@@ -123,14 +123,11 @@ export default mode => ([
 
         .toDate()
         .custom((value, { req }) => {
-            console.log(value)
-            console.log(typeof value)
             const today = new Date();
 
             if (value > today) {
                 throw new Error('La date de mise à jour du site ne peut pas être future');
             }
-
             // for updates only
             if (req.town) {
                 const lastUpdate = new Date(req.town.updatedAt);

--- a/packages/api/server/services/shantytown/close.spec.ts
+++ b/packages/api/server/services/shantytown/close.spec.ts
@@ -26,6 +26,7 @@ rewiremock.disable();
 
 describe.only('services/shantytown', () => {
     describe('close()', () => {
+        const date = new Date()
         const user = {};
         const data = {
             shantytown: {
@@ -36,6 +37,7 @@ describe.only('services/shantytown', () => {
             closing_context: 'contexte',
             status: 'unknown',
             solutions: [],
+            updated_at: date
         };
 
         afterEach(() => {
@@ -53,6 +55,7 @@ describe.only('services/shantytown', () => {
                 status: 'unknown',
                 closing_context: 'contexte',
                 closing_solutions: [],
+                updated_at: date
             });
             expect(response).to.be.eql({});
         });

--- a/packages/api/server/services/shantytown/close.ts
+++ b/packages/api/server/services/shantytown/close.ts
@@ -13,6 +13,7 @@ export default async (user, data) => {
             status: data.status,
             closing_context: data.closing_context,
             closing_solutions: data.solutions,
+            updated_at: new Date(),
         },
     );
     const updatedTown = await shantytownModel.findOne(user, data.shantytown.id);

--- a/packages/api/server/services/shantytown/close.ts
+++ b/packages/api/server/services/shantytown/close.ts
@@ -13,7 +13,7 @@ export default async (user, data) => {
             status: data.status,
             closing_context: data.closing_context,
             closing_solutions: data.solutions,
-            updated_at: new Date(),
+            updated_at: data.updated_at || new Date(),
         },
     );
     const updatedTown = await shantytownModel.findOne(user, data.shantytown.id);

--- a/packages/frontend/webapp/src/js/app/components/TownForm/TownForm.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/TownForm.vue
@@ -47,7 +47,9 @@
                         class="mt-10"
                         v-model="updatedAt"
                         :value="updatedAt"
-                        :disableBefore="new Date(data.updatedAt * 1000)"
+                        :disableBefore="
+                            new Date(data.updatedAt * 1000 + 1000 * 3600 * 24)
+                        "
                     >
                     </TownFormPanelUpdatedAt>
 
@@ -363,7 +365,7 @@ export default {
                     declared_at: this.formatDate(
                         this.town.characteristics.declared_at
                     ),
-                    updated_at: this.formatDate(this.updatedAt),
+                    updated_at: this.updatedAt,
                     field_type: this.town.characteristics.field_type,
                     detailed_address: this.town.characteristics
                         .detailed_address,

--- a/packages/frontend/webapp/src/js/app/components/TownForm/TownFormPanelUpdatedAt.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/TownFormPanelUpdatedAt.vue
@@ -28,6 +28,7 @@
             v-if="checked !== 1"
             v-model="updatedAt"
             :disableBefore="disableBefore"
+            :disableAfter="new Date(new Date().valueOf() - 1000 * 3600 * 24)"
         ></InputUpdatedAt>
     </div>
 </template>
@@ -60,6 +61,7 @@ export default {
     },
     watch: {
         updatedAt() {
+            this.updatedAt.setHours(0, 0, 0, 0);
             this.$emit("input", this.updatedAt);
         }
     }

--- a/packages/frontend/webapp/src/js/app/components/TownForm/inputs/InputUpdatedAt.vue
+++ b/packages/frontend/webapp/src/js/app/components/TownForm/inputs/InputUpdatedAt.vue
@@ -4,7 +4,7 @@
         label="Date de mise à jour"
         v-model="updatedAt"
         rules="required"
-        :disabled-dates="{ to: this.disableBefore, from: new Date() }"
+        :disabled-dates="{ to: this.disableBefore, from: disableAfter }"
         cypressName="updated_at"
     ></DatepickerV2>
 </template>
@@ -23,6 +23,11 @@ export default {
         disableBefore: {
             type: Date,
             required: false
+        },
+        disableAfter: {
+            type: Date,
+            required: false,
+            default: new Date()
         }
     },
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/dsPwDgaP/1642-tableau-de-bord-la-vue-densemble-comptabilise-plus-de-sites-quil-nen-existe



## 🚨 Notes pour la mise en production
Effectuer après MEP les requetes suivantes : 
à faire tourner en boucle tant qu'il y a des lignes modifiées : 

```sql
update "ShantytownHistories" s
set updated_at = updated_at + interval '1 second'
WHERE EXISTS (
	SELECT * from "ShantytownHistories" sh 
  	where sh.hid < s.hid and sh.shantytown_id = s.shantytown_id AND  sh.updated_at = s.updated_at
)
```

à faire tourner une seule fois en remplaçant 'N seconds' par le nombre d'itérations de la requete précédente +1 :

```sql
update shantytowns s
set updated_at = updated_at + interval 'N seconds'
WHERE EXISTS (
	SELECT * from "ShantytownHistories" sh 
  	where  sh.shantytown_id = s.shantytown_id AND  sh.updated_at = s.updated_at
)
```