### PR TITLE
#patch (1645)  Pb droits utilisateur sur arrondissement

### DIFF
--- a/packages/api/server/models/geoModel/getLocation.ts
+++ b/packages/api/server/models/geoModel/getLocation.ts
@@ -113,6 +113,7 @@ const methods = {
             `SELECT
                 cities.name AS name,
                 cities.code AS code,
+                cities.fk_main as main,
                 epci.name AS "epciName",
                 epci.code AS "epciCode",
                 departements.name AS "departementName",
@@ -151,6 +152,7 @@ const methods = {
             city: {
                 name: city.name,
                 code: city.code,
+                main: city.main,
             },
         };
     },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/bVFyEFg3

## 🛠 Description de la PR
- Correction de la méthode `getLocation` du modèle `geoModel` côté API, utilisé pour compléter l'objet `town` en cours d'édition: ajout du champ fk_main correspondant à la ville sur laquelle l'utilisateur a les droits et à laquelle est rattaché l'arrondissement sur lequel est situé le site en cours de saisie/modification.

## 🚨 Notes pour la mise en production
- supprimer les droits spécifiques qui ont été temporairement rajoutés à l'utilisateur qui a signalé ce bug pour pouvoir modifier les sites sur tout le département (user_permission_id : 707).
- lui répondre via l'adresse support pour la prévenir que le problème est résolu et la remercier de son signalement.