### PR TITLE
#patch (1656) Tracking mobile — Export basique des sessions

### DIFF
--- a/packages/api/server/controllers/index.ts
+++ b/packages/api/server/controllers/index.ts
@@ -78,6 +78,9 @@ import userUpgrade from './userController/upgrade';
 import userActivityRegular from './userActivityController/regular';
 // user navigation logs
 import insertUserNavigationLogs from './userNavigationLogsController/insert';
+import exportMobileUserNavigationLogs from './userNavigationLogsController/exportMobileSessions';
+import exportWebappUserNavigationLogs from './userNavigationLogsController/exportWebappSessions';
+
 
 export default () => ({
     config: {
@@ -173,5 +176,7 @@ export default () => ({
     },
     userNavigationLogs: {
         insert: insertUserNavigationLogs,
+        exportForMobile: exportMobileUserNavigationLogs,
+        exportForWebapp: exportWebappUserNavigationLogs
     },
 });

--- a/packages/api/server/controllers/index.ts
+++ b/packages/api/server/controllers/index.ts
@@ -81,7 +81,6 @@ import insertUserNavigationLogs from './userNavigationLogsController/insert';
 import exportMobileUserNavigationLogs from './userNavigationLogsController/exportMobileSessions';
 import exportWebappUserNavigationLogs from './userNavigationLogsController/exportWebappSessions';
 
-
 export default () => ({
     config: {
         list: configList,
@@ -177,6 +176,6 @@ export default () => ({
     userNavigationLogs: {
         insert: insertUserNavigationLogs,
         exportForMobile: exportMobileUserNavigationLogs,
-        exportForWebapp: exportWebappUserNavigationLogs
+        exportForWebapp: exportWebappUserNavigationLogs,
     },
 });

--- a/packages/api/server/controllers/planCommentController/export.ts
+++ b/packages/api/server/controllers/planCommentController/export.ts
@@ -8,7 +8,6 @@ const ERROR_RESPONSES = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
 
-
 export default async (req, res, next) => {
     let comments;
     try {

--- a/packages/api/server/controllers/userNavigationLogsController/exportMobileSessions.ts
+++ b/packages/api/server/controllers/userNavigationLogsController/exportMobileSessions.ts
@@ -1,29 +1,25 @@
 import userNavigationLogs from '#server/services/userNavigationLogs/index';
 import JSONToCSV from 'json2csv';
 
-export default async (req, res, next) => {
+const ERROR_RESPONSES = {
+    fetch_failed: { code: 400, message: 'Les logs n\'ont pas pu être récupérés' },
+    undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
+};
 
+export default async (req, res, next) => {
     let logs;
     try {
         logs = await userNavigationLogs.exportSessions('mobile');
     } catch (error) {
-        let message;
-        switch (error && error.code) {
-            case 'fetch_failed':
-                message = 'Les logs n\'ont pas pu être récupérés';
-                break;
-
-            default:
-                message = 'Une erreur inconnue est survenue.';
-        }
-
-        res.status(500).send({
+        const { code, message } = ERROR_RESPONSES[error && error.code] || ERROR_RESPONSES.undefined;
+        res.status(code).send({
             user_message: message,
         });
+
         return next((error && error.nativeError) || error);
     }
 
-    return res.status(201).send({
-        csv: JSONToCSV.parse(logs)
+    return res.status(200).send({
+        csv: JSONToCSV.parse(logs),
     });
 };

--- a/packages/api/server/controllers/userNavigationLogsController/exportMobileSessions.ts
+++ b/packages/api/server/controllers/userNavigationLogsController/exportMobileSessions.ts
@@ -1,0 +1,29 @@
+import userNavigationLogs from '#server/services/userNavigationLogs/index';
+import JSONToCSV from 'json2csv';
+
+export default async (req, res, next) => {
+
+    let logs;
+    try {
+        logs = await userNavigationLogs.exportSessions('mobile');
+    } catch (error) {
+        let message;
+        switch (error && error.code) {
+            case 'fetch_failed':
+                message = 'Les logs n\'ont pas pu être récupérés';
+                break;
+
+            default:
+                message = 'Une erreur inconnue est survenue.';
+        }
+
+        res.status(500).send({
+            user_message: message,
+        });
+        return next((error && error.nativeError) || error);
+    }
+
+    return res.status(201).send({
+        csv: JSONToCSV.parse(logs)
+    });
+};

--- a/packages/api/server/controllers/userNavigationLogsController/exportWebappSessions.ts
+++ b/packages/api/server/controllers/userNavigationLogsController/exportWebappSessions.ts
@@ -1,0 +1,29 @@
+import userNavigationLogs from '#server/services/userNavigationLogs/index';
+import JSONToCSV from 'json2csv';
+
+export default async (req, res, next) => {
+    console.log('on exporte pour la webapp');
+    let logs;
+    try {
+        logs = await userNavigationLogs.exportSessions('webapp');
+    } catch (error) {
+        let message;
+        switch (error && error.code) {
+            case 'fetch_failed':
+                message = 'Les logs n\'ont pas pu être récupérés';
+                break;
+
+            default:
+                message = 'Une erreur inconnue est survenue.';
+        }
+
+        res.status(500).send({
+            user_message: message,
+        });
+        return next((error && error.nativeError) || error);
+    }
+
+    return res.status(201).send({
+        csv: JSONToCSV.parse(logs)
+    });
+};

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -64,6 +64,20 @@ export default (app) => {
         controllers.user.listExport,
     );
     app.get(
+        '/navigationLogs/mobile/export',
+        middlewares.auth.authenticate,
+        middlewares.auth.isSuperAdmin,
+        controllers.userNavigationLogs.exportForMobile,
+
+    );
+    app.get(
+        '/navigationLogs/webapp/export',
+        middlewares.auth.authenticate,
+        middlewares.auth.isSuperAdmin,
+        controllers.userNavigationLogs.exportForWebapp,
+
+    );
+    app.get(
         '/me',
         middlewares.auth.authenticate,
         middlewares.appVersion.sync,

--- a/packages/api/server/models/userNavigationLogsModel/getAllForSessions.ts
+++ b/packages/api/server/models/userNavigationLogsModel/getAllForSessions.ts
@@ -8,25 +8,20 @@ export default async (domain: Domain): Promise<Array<Object>> => {
         mobile: 'user_mobile_navigation_logs',
     };
 
-    if (!tables[domain]) {
-        throw new Error('Invalid table name');
-    }
-
-
     const response: any = await sequelize.query(
         `SELECT 
-        navigation_logs.user_navigation_log_id AS log_id,
-        navigation_logs.fk_user AS user_id,
-        navigation_logs.datetime as date,
-        navigation_logs.page,
-        users.fk_role_regular AS role,
-        lo.location_type,
-        lo.region_code,
-        lo.region_name,
-        lo.departement_code,
-        lo.departement_name,
-        ot.name_singular AS organization_type,
-        oc.name_singular AS organization_category
+            navigation_logs.user_navigation_log_id AS log_id,
+            navigation_logs.fk_user AS user_id,
+            navigation_logs.datetime as date,
+            navigation_logs.page,
+            users.fk_role_regular AS role,
+            lo.location_type,
+            lo.region_code,
+            lo.region_name,
+            lo.departement_code,
+            lo.departement_name,
+            ot.name_singular AS organization_type,
+            oc.name_singular AS organization_category
         FROM ${tables[domain]} navigation_logs
         LEFT JOIN users ON users.user_id = navigation_logs.fk_user
         LEFT JOIN localized_organizations lo ON lo.organization_id = users.fk_organization

--- a/packages/api/server/models/userNavigationLogsModel/getAllForSessions.ts
+++ b/packages/api/server/models/userNavigationLogsModel/getAllForSessions.ts
@@ -1,4 +1,4 @@
-import { sequelize } from "#db/sequelize";
+import { sequelize } from '#db/sequelize';
 
 type Domain = 'webapp' | 'mobile';
 
@@ -19,7 +19,7 @@ export default async (domain: Domain): Promise<Array<Object>> => {
         navigation_logs.fk_user AS user_id,
         navigation_logs.datetime as date,
         navigation_logs.page,
-        users.fk_role AS role,
+        users.fk_role_regular AS role,
         lo.location_type,
         lo.region_code,
         lo.region_name,

--- a/packages/api/server/models/userNavigationLogsModel/getAllForSessions.ts
+++ b/packages/api/server/models/userNavigationLogsModel/getAllForSessions.ts
@@ -1,0 +1,39 @@
+import { sequelize } from "#db/sequelize";
+
+type Domain = 'webapp' | 'mobile';
+
+export default async (domain: Domain): Promise<Array<Object>> => {
+    const tables = {
+        webapp: 'user_webapp_navigation_logs',
+        mobile: 'user_mobile_navigation_logs',
+    };
+
+    if (!tables[domain]) {
+        throw new Error('Invalid table name');
+    }
+
+
+    const response: any = await sequelize.query(
+        `SELECT 
+        navigation_logs.user_navigation_log_id AS log_id,
+        navigation_logs.fk_user AS user_id,
+        navigation_logs.datetime as date,
+        navigation_logs.page,
+        users.fk_role AS role,
+        lo.location_type,
+        lo.region_code,
+        lo.region_name,
+        lo.departement_code,
+        lo.departement_name,
+        ot.name_singular AS organization_type,
+        oc.name_singular AS organization_category
+        FROM ${tables[domain]} navigation_logs
+        LEFT JOIN users ON users.user_id = navigation_logs.fk_user
+        LEFT JOIN localized_organizations lo ON lo.organization_id = users.fk_organization
+        LEFT JOIN organization_types ot ON ot.organization_type_id = lo.fk_type
+        LEFT JOIN organization_categories oc ON oc.uid = ot.fk_category
+        ORDER BY navigation_logs.fk_user ASC, navigation_logs.datetime ASC`,
+    );
+
+    return response[0];
+};

--- a/packages/api/server/models/userNavigationLogsModel/index.ts
+++ b/packages/api/server/models/userNavigationLogsModel/index.ts
@@ -1,5 +1,7 @@
 import insert from './insert';
+import getAllForSessions from './getAllForSessions';
 
 export default {
     insert,
+    getAllForSessions,
 };

--- a/packages/api/server/services/userNavigationLogs/exportSessions.ts
+++ b/packages/api/server/services/userNavigationLogs/exportSessions.ts
@@ -1,0 +1,76 @@
+
+import userNavigationLogsModel from '#server/models/userNavigationLogsModel';
+import ServiceError from '#server/errors/ServiceError';
+import moment from 'moment';
+
+export default async (domain: 'webapp' | 'mobile'): Promise<Array<Object>> => {
+    let logs;
+    try {
+        logs = await userNavigationLogsModel.getAllForSessions(
+            domain
+        );
+    } catch (error) {
+        throw new ServiceError('fetch_failed', error);
+    }
+
+    const sessions = []
+    let currentUser = logs[0].user_id
+    let beginningOfSession = logs[0].date
+    let durationOfSession = 0
+
+    logs.forEach((log, index) => {
+        if (log.user_id != currentUser) {
+            sessions.push({
+                'Id de l\'utilisateur': currentUser,
+                'Niveau géographique de l\'utilisateur': logs[index - 1].location_type,
+                'Nom de la région': logs[index - 1].region_name,
+                'Code de la région': logs[index - 1].region_code,
+                'Nom du département': logs[index - 1].departement_name,
+                'Code du département': logs[index - 1].departement_code,
+                'Catégorie de structure de l\'utilisateur': logs[index - 1].organization_category,
+                'Type de structure de l\'utilisateur': logs[index - 1].organization_type,
+                'Rôle de l\'utilisateur': logs[index - 1].role,
+                'Début de la session': moment(beginningOfSession).utcOffset(2).format('DD/MM/YYYY-HH:mm:ss'),
+                'Durée de la session': durationOfSession / 60000
+            })
+            currentUser = log.user_id
+            durationOfSession = 0
+            beginningOfSession = log.date
+        }
+        else if (log.date - beginningOfSession > 3600000) {
+            sessions.push({
+                'Id de l\'utilisateur': currentUser,
+                'Niveau géographique de l\'utilisateur': log.location_type,
+                'Nom de la région': log.region_name,
+                'Code de la région': log.region_code,
+                'Nom du département': log.departement_name,
+                'Code du département': log.departement_code,
+                'Catégorie de structure de l\'utilisateur': log.organization_category,
+                'Type de structure de l\'utilisateur': log.organization_type,
+                'Rôle de l\'utilisateur': log.role,
+                'Début de la session': moment(beginningOfSession).utcOffset(2).format('DD/MM/YYYY-HH:mm:ss'),
+                'Durée de la session': durationOfSession / 60000
+            })
+            durationOfSession = 0
+            beginningOfSession = log.date
+        } else {
+            durationOfSession = log.date - beginningOfSession
+        }
+    })
+    const lastSession = logs[logs.length - 1];
+    sessions.push({
+        'Id de l\'utilisateur': currentUser,
+        'Niveau géographique de l\'utilisateur': lastSession.location_type,
+        'Nom de la région': lastSession.region_name,
+        'Code de la région': lastSession.region_code,
+        'Nom du département': lastSession.departement_name,
+        'Code du département': lastSession.departement_code,
+        'Catégorie de structure de l\'utilisateur': lastSession.organization_category,
+        'Type de structure de l\'utilisateur': lastSession.organization_type,
+        'Rôle de l\'utilisateur': lastSession.role,
+        'Début de la session': moment(beginningOfSession).utcOffset(2).format('DD/MM/YYYY-HH:mm:ss'),
+        'Durée de la session': durationOfSession / 60000
+    })
+    return sessions;
+};
+

--- a/packages/api/server/services/userNavigationLogs/exportSessions.ts
+++ b/packages/api/server/services/userNavigationLogs/exportSessions.ts
@@ -7,19 +7,22 @@ export default async (domain: 'webapp' | 'mobile'): Promise<Array<Object>> => {
     let logs;
     try {
         logs = await userNavigationLogsModel.getAllForSessions(
-            domain
+            domain,
         );
     } catch (error) {
         throw new ServiceError('fetch_failed', error);
     }
 
-    const sessions = []
-    let currentUser = logs[0].user_id
-    let beginningOfSession = logs[0].date
-    let durationOfSession = 0
+    const sessions = [];
+    let currentUser = logs[0].user_id;
+    let beginningOfSession = logs[0].date;
+    let durationOfSession = 0;
 
+    // La liste des logs est triée par utilisateur, puis date
     logs.forEach((log, index) => {
-        if (log.user_id != currentUser) {
+        if (log.user_id !== currentUser || log.date - beginningOfSession > 3600000) {
+            // si on change d'utilisateur ou que la session dépasse l'heure,
+            // on commence une nouvelle session
             sessions.push({
                 'Id de l\'utilisateur': currentUser,
                 'Niveau géographique de l\'utilisateur': logs[index - 1].location_type,
@@ -31,32 +34,15 @@ export default async (domain: 'webapp' | 'mobile'): Promise<Array<Object>> => {
                 'Type de structure de l\'utilisateur': logs[index - 1].organization_type,
                 'Rôle de l\'utilisateur': logs[index - 1].role,
                 'Début de la session': moment(beginningOfSession).utcOffset(2).format('DD/MM/YYYY-HH:mm:ss'),
-                'Durée de la session': durationOfSession / 60000
-            })
-            currentUser = log.user_id
-            durationOfSession = 0
-            beginningOfSession = log.date
-        }
-        else if (log.date - beginningOfSession > 3600000) {
-            sessions.push({
-                'Id de l\'utilisateur': currentUser,
-                'Niveau géographique de l\'utilisateur': log.location_type,
-                'Nom de la région': log.region_name,
-                'Code de la région': log.region_code,
-                'Nom du département': log.departement_name,
-                'Code du département': log.departement_code,
-                'Catégorie de structure de l\'utilisateur': log.organization_category,
-                'Type de structure de l\'utilisateur': log.organization_type,
-                'Rôle de l\'utilisateur': log.role,
-                'Début de la session': moment(beginningOfSession).utcOffset(2).format('DD/MM/YYYY-HH:mm:ss'),
-                'Durée de la session': durationOfSession / 60000
-            })
-            durationOfSession = 0
-            beginningOfSession = log.date
+                'Durée de la session (en minutes)': Math.round(durationOfSession / 60000),
+            });
+            currentUser = log.user_id;
+            durationOfSession = 0;
+            beginningOfSession = log.date;
         } else {
-            durationOfSession = log.date - beginningOfSession
+            durationOfSession = log.date - beginningOfSession;
         }
-    })
+    });
     const lastSession = logs[logs.length - 1];
     sessions.push({
         'Id de l\'utilisateur': currentUser,
@@ -69,8 +55,7 @@ export default async (domain: 'webapp' | 'mobile'): Promise<Array<Object>> => {
         'Type de structure de l\'utilisateur': lastSession.organization_type,
         'Rôle de l\'utilisateur': lastSession.role,
         'Début de la session': moment(beginningOfSession).utcOffset(2).format('DD/MM/YYYY-HH:mm:ss'),
-        'Durée de la session': durationOfSession / 60000
-    })
+        'Durée de la session (en minutes)': Math.round(durationOfSession / 60000),
+    });
     return sessions;
 };
-

--- a/packages/api/server/services/userNavigationLogs/index.ts
+++ b/packages/api/server/services/userNavigationLogs/index.ts
@@ -1,5 +1,7 @@
 import insert from './insert';
+import exportSessions from './exportSessions';
 
 export default {
     insert,
+    exportSessions,
 };

--- a/packages/frontend/webapp/src/api/navigation_logs.api.js
+++ b/packages/frontend/webapp/src/api/navigation_logs.api.js
@@ -1,0 +1,9 @@
+import { axios } from "@/helpers/axios";
+
+export function exportMobileSessions() {
+    return axios.get("/navigationLogs/mobile/export");
+}
+
+export function exportWebappSessions() {
+    return axios.get("/navigationLogs/webapp/export");
+}

--- a/packages/frontend/webapp/src/components/ListeDemandeAcces/ListeDemandeAcces.exports.js
+++ b/packages/frontend/webapp/src/components/ListeDemandeAcces/ListeDemandeAcces.exports.js
@@ -4,8 +4,10 @@ import { useUserStore } from "@/stores/user.store";
 import { exportList as exportUsers } from "@/api/users.api";
 import { exportList as exportActors } from "@/api/actors.api";
 import { exportList as exportReferrals } from "@/api/contact_form_referrals.api";
-import { exportMobileSessions } from "@/api/navigation_logs.api";
-import { exportWebappSessions } from "@/api/navigation_logs.api";
+import {
+    exportMobileSessions,
+    exportWebappSessions,
+} from "@/api/navigation_logs.api";
 
 const exportList = {
     users: {

--- a/packages/frontend/webapp/src/components/ListeDemandeAcces/ListeDemandeAcces.exports.js
+++ b/packages/frontend/webapp/src/components/ListeDemandeAcces/ListeDemandeAcces.exports.js
@@ -4,6 +4,8 @@ import { useUserStore } from "@/stores/user.store";
 import { exportList as exportUsers } from "@/api/users.api";
 import { exportList as exportActors } from "@/api/actors.api";
 import { exportList as exportReferrals } from "@/api/contact_form_referrals.api";
+import { exportMobileSessions } from "@/api/navigation_logs.api";
+import { exportWebappSessions } from "@/api/navigation_logs.api";
 
 const exportList = {
     users: {
@@ -21,6 +23,16 @@ const exportList = {
         filename: "referrals",
         downloadFn: exportReferrals,
     },
+    mobileSessions: {
+        label: "Export des sessions sur mobile",
+        filename: "sessions_mobile",
+        downloadFn: exportMobileSessions,
+    },
+    webappSessions: {
+        label: "Export des sessions sur navigateur",
+        filename: "sessions_navigateur",
+        downloadFn: exportWebappSessions,
+    },
 };
 
 export default computed(() => {
@@ -29,6 +41,8 @@ export default computed(() => {
     const filteredExportList = [];
     if (userStore.user?.is_superuser) {
         filteredExportList.push(exportList.users);
+        filteredExportList.push(exportList.mobileSessions);
+        filteredExportList.push(exportList.webappSessions);
     }
 
     if (userStore.hasPermission("shantytown_actor.export")) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/wqDQVTWv/1656-tracking-mobile-export-basique-des-sessions

## 🛠 Description de la PR
Dans l'onglet Administration, rajout de deux possibilité d'export pour les admins nationaux : 
- export des sessions sur mobile
- export des sessions sur navigateur

<img width="849" alt="Capture d’écran 2022-11-28 à 16 01 40" src="https://user-images.githubusercontent.com/94321132/204310269-7afaa8bc-4671-4371-9263-9f245c94e7ae.png">
