### PR TITLE
#minor (1649) Mobile, Fiche site — Naviguer de section en section

### DIFF
--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPage.menu.js
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPage.menu.js
@@ -1,0 +1,22 @@
+export default [
+    {
+        id: "caracteristics",
+        label: "Caractéristiques",
+    },
+    {
+        id: "peoples",
+        label: "Habitants",
+    },
+    {
+        id: "living_conditions",
+        label: "Conditions de vie",
+    },
+    {
+        id: "judicial",
+        label: "Procédures judiciaires",
+    },
+    {
+        id: "actors",
+        label: "Intervenants",
+    },
+];

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPage.menu.js
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPage.menu.js
@@ -1,10 +1,10 @@
 export default [
     {
-        id: "caracteristics",
+        id: "characteristics",
         label: "Caractéristiques",
     },
     {
-        id: "peoples",
+        id: "people",
         label: "Habitants",
     },
     {

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
@@ -35,7 +35,10 @@
                         >
                     </div>
 
-                    <TownPageMenu />
+                    <TownPageMenu
+                        :currentSection="currentSection"
+                        @changeSection="changeSection"
+                    />
                 </header>
             </template>
             <template v-slot:scroll>
@@ -96,6 +99,8 @@ import TownComments from "./comments/TownComments.vue";
 import { Icon, Spinner } from "@resorptionbidonvilles/ui";
 import { mapGetters } from "vuex";
 
+import menu from "./TownPage.menu";
+
 export default {
     components: {
         Layout,
@@ -114,6 +119,7 @@ export default {
         return {
             error: null,
             town: null,
+            currentSection: "caracteristics",
         };
     },
     computed: {
@@ -123,6 +129,7 @@ export default {
     },
     async mounted() {
         const townId = parseInt(this.$route.params.id, 10);
+        window.addEventListener("touchmove", this.onTouch);
         if (this.$store.state.towns.state !== "loaded") {
             await this.$store.dispatch("fetchTowns");
         }
@@ -142,9 +149,26 @@ export default {
             this.error = "Erreur: " + error.message;
         }
     },
+    unmounted() {
+        window.removeEventListener("touchmove", this.onTouch);
+    },
     methods: {
         async toTownsList() {
             this.$router.push(`/liste-des-sites`);
+        },
+        changeSection(value) {
+            this.currentSection = value;
+        },
+        onTouch(ev) {
+            const tab = menu.find(({ id }) => {
+                const el = document.getElementById(id);
+                // la section active celle sur laquelle on a cliqué pour scroller la page
+                return el.contains(ev.target);
+            });
+            if (tab?.id) {
+                history.pushState({}, "", `#${tab.id}`);
+                this.changeSection(tab.id);
+            }
         },
     },
 };

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
@@ -38,35 +38,14 @@
             </template>
             <template v-slot:scroll>
                 <Container>
-                    <div
-                        class="text-primary font-bold text-display-sm mt-4 mb-2"
-                    >
-                        Caractéristiques
-                    </div>
                     <TownPagePanelCharacteristics :town="town" />
-                    <div
-                        class="text-primary font-bold text-display-sm mt-8 mb-2"
-                    >
-                        Habitants
-                    </div>
+
                     <TownPagePanelPeople :town="town" />
-                    <div
-                        class="text-primary font-bold text-display-sm mt-8 mb-2"
-                    >
-                        Conditions de vie
-                    </div>
+
                     <TownPagePanelLivingConditions :town="town" />
-                    <div
-                        class="text-primary font-bold text-display-sm mt-8 mb-2"
-                    >
-                        Procédures judiciaires
-                    </div>
+
                     <TownPagePanelJudicial :town="town" />
-                    <div
-                        class="text-primary font-bold text-display-sm mt-8 mb-2"
-                    >
-                        Intervenants
-                    </div>
+
                     <TownPagePanelActors :town="town" class="mb-3" />
                 </Container>
             </template>

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
@@ -44,11 +44,11 @@
             <template v-slot:scroll>
                 <Container>
                     <TownPagePanelCharacteristics
-                        id="caracteristics"
+                        id="characteristics"
                         :town="town"
                     />
 
-                    <TownPagePanelPeople id="peoples" :town="town" />
+                    <TownPagePanelPeople id="people" :town="town" />
 
                     <TownPagePanelLivingConditions
                         id="living_conditions"
@@ -119,7 +119,7 @@ export default {
         return {
             error: null,
             town: null,
-            currentSection: "caracteristics",
+            currentSection: "characteristics",
         };
     },
     computed: {

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
@@ -34,19 +34,31 @@
                             « {{ town.name }} »</span
                         >
                     </div>
+
+                    <TownPageMenu />
                 </header>
             </template>
             <template v-slot:scroll>
                 <Container>
-                    <TownPagePanelCharacteristics :town="town" />
+                    <TownPagePanelCharacteristics
+                        id="caracteristics"
+                        :town="town"
+                    />
 
-                    <TownPagePanelPeople :town="town" />
+                    <TownPagePanelPeople id="peoples" :town="town" />
 
-                    <TownPagePanelLivingConditions :town="town" />
+                    <TownPagePanelLivingConditions
+                        id="living_conditions"
+                        :town="town"
+                    />
 
-                    <TownPagePanelJudicial :town="town" />
+                    <TownPagePanelJudicial id="judicial" :town="town" />
 
-                    <TownPagePanelActors :town="town" class="mb-3" />
+                    <TownPagePanelActors
+                        id="actors"
+                        :town="town"
+                        class="mb-3"
+                    />
                 </Container>
             </template>
             <template v-slot:footer>
@@ -74,6 +86,7 @@
 <script>
 import Layout from "#src/js/components/Layout.vue";
 import Container from "#src/js/components/Container.vue";
+import TownPageMenu from "./TownPageMenu.vue";
 import TownPagePanelCharacteristics from "./TownPagePanelCharacteristics.vue";
 import TownPagePanelPeople from "./TownPagePanelPeople.vue";
 import TownPagePanelLivingConditions from "./TownPagePanelLivingConditions.vue";
@@ -87,6 +100,7 @@ export default {
     components: {
         Layout,
         Container,
+        TownPageMenu,
         TownComments,
         TownPagePanelCharacteristics,
         TownPagePanelPeople,

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenu.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenu.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="whitespace-nowrap overflow-y-auto py-4">
+        <TownPageMenuItem
+            v-for="(section, index) in menu"
+            :key="section.id"
+            :item="section"
+            :isSelected="section.id === currentSection"
+            @click="changeSection(section.id)"
+            :class="index !== 0 ? 'border-l-1' : ''"
+        />
+    </div>
+</template>
+
+<script>
+import menu from "./TownPage.menu";
+
+import TownPageMenuItem from "./TownPageMenuItem.vue";
+
+export default {
+    data() {
+        return {
+            menu,
+            currentSection: menu[0].id,
+        };
+    },
+    components: {
+        TownPageMenuItem,
+    },
+    methods: {
+        changeSection(value) {
+            this.currentSection = value;
+        },
+    },
+};
+</script>

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenu.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenu.vue
@@ -1,5 +1,7 @@
 <template>
-    <div class="whitespace-nowrap overflow-y-auto py-4">
+    <div
+        class="whitespace-nowrap overflow-y-auto py-4 border-t-1 border-b-1 border-blue600"
+    >
         <TownPageMenuItem
             v-for="(section, index) in menu"
             :key="section.id"

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenu.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenu.vue
@@ -1,9 +1,11 @@
 <template>
     <div
-        class="whitespace-nowrap overflow-y-auto py-4 border-t-1 border-b-1 border-blue600"
+        class="whitespace-nowrap overflow-y-auto py-4 bg-G300 border-b-2 border-G400"
+        ref="menu"
     >
         <TownPageMenuItem
             v-for="(section, index) in menu"
+            :id="`item-${section.id}`"
             :key="section.id"
             :item="section"
             :isSelected="section.id === currentSection"
@@ -33,6 +35,14 @@ export default {
     methods: {
         changeSection(value) {
             this.$emit("changeSection", value);
+        },
+    },
+    watch: {
+        currentSection() {
+            const item = document.getElementById(`item-${this.currentSection}`);
+            if (item) {
+                this.$refs.menu.scrollLeft = item.offsetLeft - 15;
+            }
         },
     },
 };

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenu.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenu.vue
@@ -22,15 +22,17 @@ export default {
     data() {
         return {
             menu,
-            currentSection: menu[0].id,
         };
+    },
+    props: {
+        currentSection: { type: String },
     },
     components: {
         TownPageMenuItem,
     },
     methods: {
         changeSection(value) {
-            this.currentSection = value;
+            this.$emit("changeSection", value);
         },
     },
 };

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenuItem.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenuItem.vue
@@ -1,0 +1,19 @@
+<template>
+    <div
+        :class="[
+            'inline-block border-blue300 px-2 text-primary',
+            isSelected ? 'font-bold' : 'underline',
+        ]"
+    >
+        <a :href="`#${item.id}`"> {{ item.label }}</a>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        item: Object,
+        isSelected: Boolean,
+    },
+};
+</script>

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenuItem.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPageMenuItem.vue
@@ -1,11 +1,9 @@
 <template>
-    <div
-        :class="[
-            'inline-block border-blue300 px-2 text-primary',
-            isSelected ? 'font-bold' : 'underline',
-        ]"
-    >
-        <a :href="`#${item.id}`"> {{ item.label }}</a>
+    <div class="inline-block border-blue300 px-3 text-primary">
+        <span
+            :class="isSelected ? 'bg-primary text-white rounded px-2 py-1' : ''"
+            ><a :href="`#${item.id}`"> {{ item.label }}</a></span
+        >
     </div>
 </template>
 

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelActors.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelActors.vue
@@ -1,5 +1,7 @@
 <template>
     <div>
+        <TownPagePanelTitle :title="'Intervenants'" />
+
         <div v-if="town.actors.length === 0">
             <p class="italic">Aucun intervenant connu sur ce site</p>
         </div>
@@ -24,6 +26,7 @@
 
 <script>
 import TownPageInfo from "./TownPageInfo.vue";
+import TownPagePanelTitle from "./TownPagePanelTitle.vue";
 import { Tag } from "@resorptionbidonvilles/ui";
 
 export default {
@@ -35,6 +38,7 @@ export default {
     components: {
         TownPageInfo,
         Tag,
+        TownPagePanelTitle,
     },
 };
 </script>

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelCharacteristics.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelCharacteristics.vue
@@ -1,5 +1,6 @@
 <template>
     <div>
+        <TownPagePanelTitle :title="'Caractéristiques'" />
         <TownPageInfo :title="'Installé depuis'">
             <div v-if="town.builtAt">
                 <div>
@@ -63,6 +64,7 @@
 import formatDateSince from "./utils/formatDateSince";
 import { Icon } from "@resorptionbidonvilles/ui";
 import TownPageInfo from "./TownPageInfo.vue";
+import TownPagePanelTitle from "./TownPagePanelTitle.vue";
 
 export default {
     props: {
@@ -74,6 +76,7 @@ export default {
     components: {
         Icon,
         TownPageInfo,
+        TownPagePanelTitle,
     },
     methods: {
         formatDateSince,

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelJudicial.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelJudicial.vue
@@ -1,27 +1,31 @@
 <template>
-    <div class="flex flex-col">
-        <TownPageInfo :title="'Dépôt de plainte du propriétaire'">
-            {{ boolToStr(town.ownerComplaint) }}
-        </TownPageInfo>
-        <TownPageInfo :title="'Existence d’une procédure judiciaire'">
-            {{ boolToStr(town.justiceProcedure) }}
-        </TownPageInfo>
-        <TownPageInfo :title="'Décision de justice rendue'">
-            {{ justiceRendered }}
-        </TownPageInfo>
-        <TownPageInfo :title="'contentieux'">
-            {{ boolToStr(town.justiceChallenged) }}
-        </TownPageInfo>
-        <TownPageInfo :title="'Concours de la force publique'">
-            {{ policeStatusLabel }}
-        </TownPageInfo>
-        <TownPageInfo :title="'Nom de l\'étude d\'huissier'">
-            {{ town.bailiff || "Non Communiqué" }}
-        </TownPageInfo>
+    <div>
+        <TownPagePanelTitle :title="'Procédures judiciaires'" />
+        <div class="flex flex-col">
+            <TownPageInfo :title="'Dépôt de plainte du propriétaire'">
+                {{ boolToStr(town.ownerComplaint) }}
+            </TownPageInfo>
+            <TownPageInfo :title="'Existence d’une procédure judiciaire'">
+                {{ boolToStr(town.justiceProcedure) }}
+            </TownPageInfo>
+            <TownPageInfo :title="'Décision de justice rendue'">
+                {{ justiceRendered }}
+            </TownPageInfo>
+            <TownPageInfo :title="'contentieux'">
+                {{ boolToStr(town.justiceChallenged) }}
+            </TownPageInfo>
+            <TownPageInfo :title="'Concours de la force publique'">
+                {{ policeStatusLabel }}
+            </TownPageInfo>
+            <TownPageInfo :title="'Nom de l\'étude d\'huissier'">
+                {{ town.bailiff || "Non Communiqué" }}
+            </TownPageInfo>
+        </div>
     </div>
 </template>
 <script>
 import TownPageInfo from "./TownPageInfo.vue";
+import TownPagePanelTitle from "./TownPagePanelTitle.vue";
 
 export default {
     props: {
@@ -32,6 +36,7 @@ export default {
     },
     components: {
         TownPageInfo,
+        TownPagePanelTitle,
     },
     computed: {
         justiceRendered() {

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelLivingConditions.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelLivingConditions.vue
@@ -1,57 +1,61 @@
 <template>
     <div>
-        <TownPagePanelLivingConditionsSection
-            title="Accès à l’eau"
-            :status="town.livingConditions.water.status"
-            :answers="answers.water"
-        />
-        <TownPagePanelLivingConditionsSection
-            title="Accès aux toilettes"
-            :status="town.livingConditions.sanitary.status"
-            :answers="answers.sanitary"
-        />
+        <TownPagePanelTitle :title="'Conditions de vie'" />
 
-        <TownPagePanelLivingConditionsSection
-            title="Accès à l’électricité"
-            sanitary
-            :status="town.livingConditions.electricity.status"
-            :answers="answers.electricity"
-        />
-
-        <TownPagePanelLivingConditionsSection
-            title="Évacuation des déchets"
-            :status="town.livingConditions.trash.status"
-        />
-
-        <div v-if="town.livingConditions.version === 1">
+        <div>
             <TownPagePanelLivingConditionsSection
-                :title="pestAnimalsWording"
-                :status="town.livingConditions.vermin.status"
-                :showStatus="false"
-                :answers="answers.pest_animals"
-                :inverted="true"
+                title="Accès à l’eau"
+                :status="town.livingConditions.water.status"
+                :answers="answers.water"
+            />
+            <TownPagePanelLivingConditionsSection
+                title="Accès aux toilettes"
+                :status="town.livingConditions.sanitary.status"
+                :answers="answers.sanitary"
             />
 
             <TownPagePanelLivingConditionsSection
-                title="Prévention des incendies"
-                :status="town.livingConditions.firePrevention.status"
-                :answers="answers.fire_prevention"
-            />
-        </div>
-
-        <div v-if="town.livingConditions.version === 2">
-            <TownPagePanelLivingConditionsSection
-                :title="pestAnimalsWording"
-                :status="town.livingConditions.pest_animals.status"
-                :showStatus="false"
-                :inverted="true"
-                :answers="answers.pest_animals"
+                title="Accès à l’électricité"
+                sanitary
+                :status="town.livingConditions.electricity.status"
+                :answers="answers.electricity"
             />
 
             <TownPagePanelLivingConditionsSection
-                title="Prévention des incendies"
-                :status="town.livingConditions.fire_prevention.status"
+                title="Évacuation des déchets"
+                :status="town.livingConditions.trash.status"
             />
+
+            <div v-if="town.livingConditions.version === 1">
+                <TownPagePanelLivingConditionsSection
+                    :title="pestAnimalsWording"
+                    :status="town.livingConditions.vermin.status"
+                    :showStatus="false"
+                    :answers="answers.pest_animals"
+                    :inverted="true"
+                />
+
+                <TownPagePanelLivingConditionsSection
+                    title="Prévention des incendies"
+                    :status="town.livingConditions.firePrevention.status"
+                    :answers="answers.fire_prevention"
+                />
+            </div>
+
+            <div v-if="town.livingConditions.version === 2">
+                <TownPagePanelLivingConditionsSection
+                    :title="pestAnimalsWording"
+                    :status="town.livingConditions.pest_animals.status"
+                    :showStatus="false"
+                    :inverted="true"
+                    :answers="answers.pest_animals"
+                />
+
+                <TownPagePanelLivingConditionsSection
+                    title="Prévention des incendies"
+                    :status="town.livingConditions.fire_prevention.status"
+                />
+            </div>
         </div>
     </div>
 </template>
@@ -59,7 +63,7 @@
 <script>
 import serializeLivingConditions from "#frontend/common/helpers/town/living_conditions/serializeLivingConditions";
 import TownPagePanelLivingConditionsSection from "./LivingConditions/TownPagePanelLivingConditionsSection.vue";
-
+import TownPagePanelTitle from "./TownPagePanelTitle.vue";
 export default {
     props: {
         town: {
@@ -67,7 +71,10 @@ export default {
             required: true,
         },
     },
-    components: { TownPagePanelLivingConditionsSection },
+    components: {
+        TownPagePanelLivingConditionsSection,
+        TownPagePanelTitle,
+    },
     computed: {
         answers() {
             return serializeLivingConditions(this.town);

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelPeople.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelPeople.vue
@@ -1,16 +1,21 @@
 <template>
-    <div class="flex flex-col">
-        <TownPageInfo
-            v-for="section in data"
-            :key="section.title"
-            :title="section.title"
-        >
-            {{ town[section.content] || "Non communiqué" }}
-        </TownPageInfo>
+    <div>
+        <TownPagePanelTitle :title="'Habitants'" />
+        <div class="flex flex-col">
+            <TownPageInfo
+                v-for="section in data"
+                :key="section.title"
+                :title="section.title"
+            >
+                {{ town[section.content] || "Non communiqué" }}
+            </TownPageInfo>
+        </div>
     </div>
 </template>
 <script>
 import TownPageInfo from "./TownPageInfo.vue";
+import TownPagePanelTitle from "./TownPagePanelTitle.vue";
+
 export default {
     data() {
         return {
@@ -40,6 +45,7 @@ export default {
     },
     components: {
         TownPageInfo,
+        TownPagePanelTitle,
     },
 };
 </script>

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelTitle.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelTitle.vue
@@ -1,0 +1,13 @@
+<template>
+    <div class="text-primary font-bold text-display-sm mt-4 mb-2">
+        {{ title }}
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        title: String,
+    },
+};
+</script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/S9INQ8wd/1649-mobile-fiche-site-naviguer-de-section-en-section

## 🛠 Description de la PR
j'écoute un événement 'touchmove' pour détecter la section actuellement à l'écran
La logique choisie est : la section sur laquelle l'utilisateur a touché en dernier est considérée comme la section à l'écran



