### PR TITLE
#patch (1657) Ajout du tracking des fiches sites sur mobile

### DIFF
--- a/packages/api/db/migrations/30000034-01-alter-table-mobile_logs-add-origin.js
+++ b/packages/api/db/migrations/30000034-01-alter-table-mobile_logs-add-origin.js
@@ -1,0 +1,17 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.addColumn(
+        'user_mobile_navigation_logs',
+        'origin',
+        {
+            type: Sequelize.STRING,
+            allowNull: true,
+            defaultValue: null,
+
+        },
+    ),
+
+    down: queryInterface => queryInterface.removeColumn(
+        'user_mobile_navigation_logs',
+        'origin',
+    ),
+};

--- a/packages/api/server/controllers/userNavigationLogsController/insert.ts
+++ b/packages/api/server/controllers/userNavigationLogsController/insert.ts
@@ -8,6 +8,7 @@ export default async (req, res, next) => {
             req.user.id,
             req.body.page,
             req.body.domain,
+            req.body.origin,
         );
     } catch (error) {
         let message;

--- a/packages/api/server/middlewares/validators/me/post.navigationLogs.ts
+++ b/packages/api/server/middlewares/validators/me/post.navigationLogs.ts
@@ -9,5 +9,10 @@ export default [
     body('domain')
         .isString().bail().withMessage('Le domaine est invalide')
         .isIn(['webapp', 'mobile']).bail().withMessage('La valeur du domaine est invalide'),
-
+    body('origin')
+        .optional({ nullable: true })
+        .isString().bail().withMessage('L\'origine doit être une chaîne de caractères')
+        .trim(),
+    body('origin')
+        .customSanitizer(value => value || null),
 ];

--- a/packages/api/server/models/userNavigationLogsModel/index.ts
+++ b/packages/api/server/models/userNavigationLogsModel/index.ts
@@ -1,7 +1,9 @@
-import insert from './insert';
 import getAllForSessions from './getAllForSessions';
+import insertMobile from './insertMobile';
+import insertWebapp from './insertWebapp';
 
 export default {
-    insert,
     getAllForSessions,
+    insertMobile,
+    insertWebapp,
 };

--- a/packages/api/server/models/userNavigationLogsModel/insertMobile.ts
+++ b/packages/api/server/models/userNavigationLogsModel/insertMobile.ts
@@ -1,0 +1,29 @@
+import { sequelize } from '#db/sequelize';
+
+export default async (fk_user: number, page: string, origin?: string): Promise<number> => {
+    const response: any = await sequelize.query(
+        `INSERT INTO
+            user_mobile_navigation_logs(
+                fk_user,
+                page,
+                origin
+            )
+
+            VALUES(
+                :fk_user,
+                :page,
+                :origin
+            )
+            
+            RETURNING user_navigation_log_id`,
+        {
+            replacements: {
+                fk_user,
+                page,
+                origin: origin || null,
+            },
+        },
+    );
+
+    return response[0][0].user_navigation_log_id;
+};

--- a/packages/api/server/models/userNavigationLogsModel/insertWebapp.ts
+++ b/packages/api/server/models/userNavigationLogsModel/insertWebapp.ts
@@ -1,20 +1,9 @@
 import { sequelize } from '#db/sequelize';
 
-type Domain = 'webapp' | 'mobile';
-
-export default async (fk_user: Number, page: String, domain: Domain): Promise<number> => {
-    const tables = {
-        webapp: 'user_webapp_navigation_logs',
-        mobile: 'user_mobile_navigation_logs',
-    };
-
-    if (!tables[domain]) {
-        throw new Error('Invalid table name');
-    }
-
+export default async (fk_user: number, page: string): Promise<number> => {
     const response: any = await sequelize.query(
         `INSERT INTO
-            ${tables[domain]}(
+            user_webapp_navigation_logs(
                 fk_user,
                 page
             )

--- a/packages/api/server/services/userNavigationLogs/insert.spec.ts
+++ b/packages/api/server/services/userNavigationLogs/insert.spec.ts
@@ -14,7 +14,7 @@ describe('services/userNavigationLogs/insert()', () => {
     let stubs;
     beforeEach(() => {
         stubs = {
-            insert: sinon.stub(userNavigationLogsModel, 'insert'),
+            insertWebapp: sinon.stub(userNavigationLogsModel, 'insertWebapp'),
             isTracked: sinon.stub(userModel, 'isTracked'),
         };
     });
@@ -26,12 +26,18 @@ describe('services/userNavigationLogs/insert()', () => {
     it('demande l\'insertion du log en base de données', async () => {
         stubs.isTracked.resolves(true);
         await insert(1, 'page', 'webapp');
-        expect(stubs.insert).to.have.been.calledOnceWithExactly(1, 'page', 'webapp');
+        expect(stubs.insertWebapp).to.have.been.calledOnceWithExactly(1, 'page', null);
+    });
+
+    it('demande l\'insertion du log avec l\'origine', async () => {
+        stubs.isTracked.resolves(true);
+        await insert(1, 'page', 'webapp', 'test');
+        expect(stubs.insertWebapp).to.have.been.calledOnceWithExactly(1, 'page', 'test');
     });
 
     it('retourne l\'identifiant du log nouvellement inséré', async () => {
         stubs.isTracked.resolves(true);
-        stubs.insert.resolves(2);
+        stubs.insertWebapp.resolves(2);
         const logId = await insert(1, 'page', 'webapp');
         expect(logId).to.be.equal(2);
     });
@@ -53,12 +59,12 @@ describe('services/userNavigationLogs/insert()', () => {
     it('n\'insère pas de log si l\'utilisateur n\'est pas tracké', async () => {
         stubs.isTracked.resolves(false);
         await insert(1, 'page', 'webapp');
-        expect(stubs.insert).not.to.have.been.called;
+        expect(stubs.insertWebapp).not.to.have.been.called;
     });
 
     it('génère une exception adaptée en cas d\'erreur d\'insertion en base de données', async () => {
         stubs.isTracked.resolves(true);
-        stubs.insert.rejects(new Error('insertion failed'));
+        stubs.insertWebapp.rejects(new Error('insertion failed'));
 
         try {
             await insert(1, 'page', 'webapp');

--- a/packages/api/server/services/userNavigationLogs/insert.ts
+++ b/packages/api/server/services/userNavigationLogs/insert.ts
@@ -2,7 +2,12 @@ import userNavigationLogsModel from '#server/models/userNavigationLogsModel';
 import userModel from '#server/models/userModel';
 import ServiceError from '#server/errors/ServiceError';
 
-export default async (fk_user: number, page: String, domain: 'webapp' | 'mobile'): Promise<number> => {
+export default async (fk_user: number, page: string, domain: 'webapp' | 'mobile', origin?: string): Promise<number> => {
+    const models = {
+        mobile: userNavigationLogsModel.insertMobile,
+        webapp: userNavigationLogsModel.insertWebapp,
+    };
+
     let toBeTracked: boolean;
     try {
         toBeTracked = await userModel.isTracked(fk_user);
@@ -17,10 +22,10 @@ export default async (fk_user: number, page: String, domain: 'webapp' | 'mobile'
     // on insère le log
     let logId: number;
     try {
-        logId = await userNavigationLogsModel.insert(
+        logId = await models[domain](
             fk_user,
             page,
-            domain,
+            origin || null,
         );
     } catch (error) {
         throw new ServiceError('insert_failed', error);

--- a/packages/frontend/mobile/src/js/helpers/navigationLogs.js
+++ b/packages/frontend/mobile/src/js/helpers/navigationLogs.js
@@ -3,6 +3,6 @@ import { postApi } from "#src/js/api";
 /**
  * POST /me/navigationLogs
  */
-export function insert(page) {
-    return postApi("/me/navigationLogs", { page, domain: "mobile" });
+export function insert(page, origin = null) {
+    return postApi("/me/navigationLogs", { page, domain: "mobile", origin });
 }

--- a/packages/frontend/mobile/src/js/pages/NotesForm/NotesFormHeader.vue
+++ b/packages/frontend/mobile/src/js/pages/NotesForm/NotesFormHeader.vue
@@ -51,8 +51,9 @@
                     :key="publication.shantytown"
                     class="text-primary ml-6"
                     @click="
-                        $router.push(
-                            `/site/${publication.shantytown.shantytownId}`
+                        routeToTown(
+                            publication.shantytown.shantytownId,
+                            'note_publications'
                         )
                     "
                 >
@@ -66,6 +67,7 @@
 <script>
 import { Button } from "@resorptionbidonvilles/ui";
 import Container from "#src/js/components/Container.vue";
+import routeToTown from "#src/js/utils/routeToTown";
 
 export default {
     components: {
@@ -88,6 +90,9 @@ export default {
         return {
             showTowns: false,
         };
+    },
+    methods: {
+        routeToTown,
     },
 };
 </script>

--- a/packages/frontend/mobile/src/js/pages/TownsList/MobileTownsList.vue
+++ b/packages/frontend/mobile/src/js/pages/TownsList/MobileTownsList.vue
@@ -44,7 +44,7 @@
                         >
                     </div>
                 </Container>
-                <TownCarousel :towns="myTowns" />
+                <TownCarousel :towns="myTowns" id="mes_sites" />
 
                 <Container class="mt-6">
                     <div class="font-bold text-lg">
@@ -59,7 +59,10 @@
                         >
                     </div>
                 </Container>
-                <TownCarousel :towns="consultedTowns" />
+                <TownCarousel
+                    :towns="consultedTowns"
+                    id="sites_recemment_consultes"
+                />
             </template>
 
             <Container class="mt-24 text-center" v-else>
@@ -90,6 +93,7 @@ import { mapGetters } from "vuex";
 import Layout from "#src/js/components/Layout.vue";
 import SearchInput from "#src/js/components/SearchInput.vue";
 import ENV from "#src/env.js";
+import routeToTown from "#src/js/utils/routeToTown";
 
 export default {
     components: {
@@ -128,7 +132,7 @@ export default {
         },
         onSearch(town) {
             setTimeout(() => {
-                this.$router.push(`/site/${town.id}`);
+                routeToTown(town.id, "recherche");
             }, 100);
         },
         redirectToWebapp() {

--- a/packages/frontend/mobile/src/js/pages/TownsList/TownCarousel.vue
+++ b/packages/frontend/mobile/src/js/pages/TownsList/TownCarousel.vue
@@ -15,10 +15,15 @@
 </template>
 <script>
 import Container from "#src/js/components/Container.vue";
+import routeToTown from "#src/js/utils/routeToTown";
 import TownCard from "./TownCard.vue";
 
 export default {
     props: {
+        id: {
+            type: String,
+            required: true,
+        },
         towns: {
             type: Array,
             required: true,
@@ -28,7 +33,7 @@ export default {
     components: { Container, TownCard },
     methods: {
         showTownPage(town) {
-            this.$router.push(`/site/${town.id}`);
+            routeToTown(town.id, this.id);
         },
     },
 };

--- a/packages/frontend/mobile/src/js/router.js
+++ b/packages/frontend/mobile/src/js/router.js
@@ -25,8 +25,20 @@ function isConfigLoaded() {
     return store.getters["config/loaded"] === true;
 }
 
-function logNavigation(to) {
-    insertNavigationLog(to.path);
+function logNavigation(to, from) {
+    let origin;
+    if (/^\/site\/[0-9]+\/?[?#]?/.test(to.path)) {
+        origin = from.meta.origin;
+        if (from.path === "/launcher") {
+            origin = "acces_direct";
+        }
+
+        if (!origin) {
+            return;
+        }
+    }
+
+    insertNavigationLog(to.path, origin);
     return true;
 }
 
@@ -164,8 +176,6 @@ const guardians = {
         { checker: isPermitted, target: "/", saveEntrypoint: false },
         { checker: hasAcceptedCharte, target: "/signature-charte-engagement" },
         { checker: isUpgraded, target: "/mise-a-niveau" },
-        { checker: saveTabNavigation },
-        { checker: logNavigation },
         { checker: saveTabNavigation },
         { checker: logNavigation },
     ]),

--- a/packages/frontend/mobile/src/js/utils/routeToTown.js
+++ b/packages/frontend/mobile/src/js/utils/routeToTown.js
@@ -1,0 +1,6 @@
+import router from "#src/js/router";
+
+export default function (id, origin = "acces_direct") {
+    router.currentRoute.value.meta.origin = origin;
+    router.push(`/site/${id}`);
+}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/VCwNbxH2/1657

## 🛠 Description de la PR
- ajout d'une colonne "origin" sur les navigation logs mobile (nullable)
- support de cette colonne dans l'api qui insère des lignes dans cette table
- modification de l'app mobile pour faire en sorte que l'origin soit renseignée (uniquement pour les fiches sites)

## 🚨 Notes pour la mise en production
Migrations à faire tourner