### PR TITLE
#patch (1667) Vue d'ensemble — Une semaine manque et les chiffres semblent incohérents pour le nombre d'utilisateurs

### DIFF
--- a/packages/api/server/models/statsModel/_common/decomposeForDiagramm.ts
+++ b/packages/api/server/models/statsModel/_common/decomposeForDiagramm.ts
@@ -2,10 +2,30 @@ import moment from 'moment';
 
 export default (towns, connectedUsers, listOfDates) => {
     const date2019 = new Date('2019-01-01T00:00:00');
+    // connectedUsers ne contient pas les semaines sans utilisateur connecté, on les remplit donc ici
+    const filledConnectedUsers = [];
+    let index = 0;
+    for (let compteur = 0; compteur < connectedUsers.length; compteur += 1) {
+        if (connectedUsers[index].week === compteur) {
+            filledConnectedUsers.push(connectedUsers[index]);
+            index += 1;
+        } else {
+            const begginingOfWeek = new Date();
+            const endOfWeek = new Date();
+            begginingOfWeek.setDate(begginingOfWeek.getDate() - 7 * (compteur + 1));
+            endOfWeek.setDate(endOfWeek.getDate() - 1 - 7 * compteur);
+            filledConnectedUsers.push({
+                count: '0',
+                week: compteur,
+                date_debut: moment(begginingOfWeek).format('DD/MM'),
+                date_fin: moment(endOfWeek).format('DD/MM'),
+            });
+        }
+    }
 
     const connectedUserStats = {
         evolution: 0,
-        data: connectedUsers.reverse().map(connectedUser => ({
+        data: filledConnectedUsers.reverse().map(connectedUser => ({
             figure: connectedUser.count,
             formatedDateFrom: connectedUser.date_debut,
             formatedDate: connectedUser.date_fin,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/wP9YOyTM/1667-vue-densemble-une-semaine-manque-et-les-chiffres-semblent-incoh%C3%A9rents-pour-le-nombre-dutilisateurs

## 🛠 Description de la PR

Concernant les chiffres incohérents, c'est dû à une absence d'enregistrements de logs pendant deux semaines
Cette PR corrige le bug des semaines manquantes, dû au fait que le modèle ne renvoie que les semaines pour lesquelles il y a un moins un utilisateur connecté