### PR TITLE
#patch (1700) Lorsque l'on accède à un site depuis la liste des sites, l'historique des modifications ne s'affiche pas

### DIFF
--- a/packages/frontend/webapp/src/stores/towns.store.js
+++ b/packages/frontend/webapp/src/stores/towns.store.js
@@ -208,14 +208,10 @@ export const useTownsStore = defineStore("towns", () => {
             isLoading.value = false;
         },
         async fetchTown(townId) {
-            if (!hash.value[townId]) {
-                hash.value[townId] = enrichShantytown(
-                    await fetch(townId),
-                    configStore.config.field_types
-                );
-            }
-
-            return hash.value[townId];
+            return enrichShantytown(
+                await fetch(townId),
+                configStore.config.field_types
+            );
         },
         setTown,
         async destroy(townId) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/5iQTZZmj/1700-lorsque-lon-acc%C3%A8de-%C3%A0-un-site-depuis-la-liste-des-sites-lhistorique-des-modifications-ne-saffiche-pas

## 🛠 Description de la PR
Au lieu de récupérer l'objet site dans le store, on fait un appel API systématiquement pour récupérer l'objet town complet

