### PR TITLE
#patch (1704) BUG- Certains champs mal validés par le formulaire

### DIFF
--- a/packages/api/server/middlewares/validators/common/writeTown.ts
+++ b/packages/api/server/middlewares/validators/common/writeTown.ts
@@ -169,6 +169,10 @@ export default mode => ([
         .optional({ nullable: true })
         .isDate().bail().withMessage('Le champ "Date d\'installation du site" est invalide')
         .toDate()
+        .customSanitizer((value) => {
+            value.setHours(0, 0, 0, 0);
+            return value;
+        })
         .custom((value) => {
             const today = new Date();
             today.setHours(0, 0, 0, 0);

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.schema.js
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.schema.js
@@ -243,7 +243,7 @@ export default function (mode = "create") {
     schema.water_access_is_unequal_details = string()
         .nullable()
         .when("water_access_is_unequal", {
-            is: 0,
+            is: 1,
             then: (schema) => schema.required(),
         })
         .label(labels.water_access_is_unequal_details);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/CFLa6B4l/1704-bug-certains-champs-mal-valid%C3%A9s-par-le-formulaire

## 🛠 Description de la PR
- concernant le champ d'inégalité d'accès à l'eau : dans le schéma de validation des données, on imposait de renseigner les détails quand il n'y avait pas d'inégalité alors que c'est censé être l'inverse
- concernant la date de signalement : quand on set l'heure à 00:00:00, la méthode setHours se sert de la date locale et peut dans certains cas changer le jour. Dans notre cas on veut comparer deux dates: built_at et declared_at. Si on ne veut pas d'incohérence, il faut appliquer setHours(0,0,0,0) aux deux dates avant de les comparer, ce qu'on ne faisait pas