### PR TITLE
#patch (1720) fiche site overflow section habitants

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitants.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitants.vue
@@ -6,7 +6,7 @@
             de la connaissance.
         </p>
 
-        <div class="overflow-x-auto mt-4">
+        <div class="overflow-x-auto w-200 mt-4">
             <FicheSiteHabitantsTableau :town="town" />
         </div>
         <FicheSiteHabitantsOrigines :border="false" :town="town" />


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/N9kb4kZO/1720-bug-probl%C3%A8me-d-affichage-sur-certains-sites

## 🛠 Description de la PR
On applique le style overflow-x-auto à la section habitants dans la fiche site pour que le tableau se scrolle s'il dépasse la taille de son parent, mais ça ne fonctionnait car le parent n'avait pas de taille définie