### PR TITLE
#patch (1705) Droits d'accès — Permettre aux administrateurs (locaux et nationaux) de modifier les options d'un utilisateur

### DIFF
--- a/packages/api/server/controllers/index.ts
+++ b/packages/api/server/controllers/index.ts
@@ -78,6 +78,7 @@ import userSetRoleRegular from './userController/setRoleRegular';
 import userSignin from './userController/signin';
 import userUpdateLocalAdmin from './userController/updateLocalAdmin';
 import userUpgrade from './userController/upgrade';
+import userUpdatePermissionOptions from './userController/updatePermissionOptions';
 // user activity
 import userActivityRegular from './userActivityController/regular';
 // user navigation logs
@@ -166,6 +167,7 @@ export default () => ({
         list: userList,
         listExport: userListExport,
         me: userMe,
+        modifyOptions: userUpdatePermissionOptions,
         remove: userRemove,
         renewToken: userRenewToken,
         requestNewPassword: userRequestNewPassword,

--- a/packages/api/server/controllers/index.ts
+++ b/packages/api/server/controllers/index.ts
@@ -167,7 +167,7 @@ export default () => ({
         list: userList,
         listExport: userListExport,
         me: userMe,
-        modifyOptions: userUpdatePermissionOptions,
+        updatePermissionOptions: userUpdatePermissionOptions,
         remove: userRemove,
         renewToken: userRenewToken,
         requestNewPassword: userRequestNewPassword,

--- a/packages/api/server/controllers/userController/updatePermissionOptions.ts
+++ b/packages/api/server/controllers/userController/updatePermissionOptions.ts
@@ -1,0 +1,35 @@
+import userService from '#server/services/user';
+
+export default async (req, res, next) => {
+    let user;
+
+    try {
+        user = await userService.updatePermissionOptions(
+            req.params.id,
+            req.body.options,
+        );
+    } catch (error) {
+        let message;
+        switch (error && error.code) {
+            case 'insert_failed':
+                message = 'Les options n\'ont pas pu être enregistrées';
+                break;
+
+            case 'fetch_failed':
+                message = 'Impossible de trouver l\'utilisateur en base de données';
+                break;
+
+            default:
+                message = 'Une erreur inconnue est survenue.';
+        }
+
+        res.status(500).send({
+            user_message: message,
+        });
+        return next((error && error.nativeError) || error);
+    }
+
+    return res.status(201).send({
+        user,
+    });
+};

--- a/packages/api/server/controllers/userController/updatePermissionOptions.ts
+++ b/packages/api/server/controllers/userController/updatePermissionOptions.ts
@@ -1,35 +1,26 @@
 import userService from '#server/services/user';
 
+const ERROR_RESPONSES = {
+    insert_failed: 'Les options n\'ont pas pu être enregistrées',
+    undefined: 'Une erreur inconnue est survenue.',
+};
+
 export default async (req, res, next) => {
-    let user;
+    let updatedUser;
 
     try {
-        user = await userService.updatePermissionOptions(
-            req.params.id,
+        updatedUser = await userService.updatePermissionOptions(
+            req.body.user.id,
             req.body.options,
         );
     } catch (error) {
-        let message;
-        switch (error && error.code) {
-            case 'insert_failed':
-                message = 'Les options n\'ont pas pu être enregistrées';
-                break;
-
-            case 'fetch_failed':
-                message = 'Impossible de trouver l\'utilisateur en base de données';
-                break;
-
-            default:
-                message = 'Une erreur inconnue est survenue.';
-        }
-
         res.status(500).send({
-            user_message: message,
+            user_message: ERROR_RESPONSES[error?.code] || ERROR_RESPONSES.undefined,
         });
         return next((error && error.nativeError) || error);
     }
 
     return res.status(201).send({
-        user,
+        user: updatedUser,
     });
 };

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -183,6 +183,12 @@ export default (app) => {
         middlewares.appVersion.sync,
         controllers.user.upgrade,
     );
+    app.post(
+        '/users/:id/options',
+        middlewares.auth.authenticate,
+        middlewares.appVersion.sync,
+        controllers.user.modifyOptions,
+    );
     app.put(
         '/users/:id/admin_comments',
         middlewares.auth.authenticate,

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -188,7 +188,9 @@ export default (app) => {
         middlewares.auth.authenticate,
         (...args: [express.Request, express.Response, Function]) => middlewares.auth.checkPermissions(['user.activate'], ...args),
         middlewares.appVersion.sync,
-        controllers.user.modifyOptions,
+        validators.user.updatePermissionOptions,
+        middlewares.validation,
+        controllers.user.updatePermissionOptions,
     );
     app.put(
         '/users/:id/admin_comments',

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -186,6 +186,7 @@ export default (app) => {
     app.post(
         '/users/:id/options',
         middlewares.auth.authenticate,
+        (...args: [express.Request, express.Response, Function]) => middlewares.auth.checkPermissions(['user.activate'], ...args),
         middlewares.appVersion.sync,
         controllers.user.modifyOptions,
     );

--- a/packages/api/server/middlewares/validators/index.ts
+++ b/packages/api/server/middlewares/validators/index.ts
@@ -21,6 +21,7 @@ import findNearbyTowns from './findNearbyTowns';
 import exportTown from './exportTown';
 import setUserAdminComments from './setUserAdminComments';
 import editOrganization from './editOrganization';
+import userUpdatePermissionOptions from './users/updatePermissionOptions';
 import userGetLatestActivationLink from './users/getLatestActivationLink';
 import userSetRoleRegular from './users/setRoleRegular';
 import mePostNavigationLogs from './me/post.navigationLogs';
@@ -63,6 +64,7 @@ export default {
     user: {
         getLatestActivationLink: userGetLatestActivationLink,
         setRoleRegular: userSetRoleRegular,
+        updatePermissionOptions: userUpdatePermissionOptions,
     },
     me: {
         postNavigationLogs: mePostNavigationLogs,

--- a/packages/api/server/middlewares/validators/users/updatePermissionOptions.ts
+++ b/packages/api/server/middlewares/validators/users/updatePermissionOptions.ts
@@ -1,0 +1,39 @@
+/* eslint-disable newline-per-chained-call */
+import { body, param } from 'express-validator';
+import permissionsDescription from '#server/permissions_description';
+import userModel from '#server/models/userModel';
+
+export default [
+    param('id')
+        .toInt()
+        .isInt().bail().withMessage('L\'identifiant de l\'utilisateur est invalide')
+        .custom(async (value, { req }) => {
+            let user;
+            try {
+                user = await userModel.findOne(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la recherche de l\'utilisateur en base de données');
+            }
+
+            if (user === null) {
+                throw new Error('L\'utilisateur à mettre à jour est introuvable en base de données');
+            }
+
+            req.body.user = user;
+            return true;
+        }),
+
+    body('options')
+        .customSanitizer(value => value || [])
+        .isArray().bail().withMessage('La liste des options est techniquement invalide')
+        .customSanitizer((value, { req }) => {
+            if (!req.body.user) {
+                return value;
+            }
+
+            const { options: allowedOptions } = permissionsDescription[req.body.user.role_id];
+            return allowedOptions
+                .filter(({ id }) => value.includes(id))
+                .map(({ id }) => id);
+        }),
+];

--- a/packages/api/server/models/userModel/setPermissionOptions.ts
+++ b/packages/api/server/models/userModel/setPermissionOptions.ts
@@ -1,6 +1,6 @@
 import { sequelize } from '#db/sequelize';
 
-export default async (userId, options, argTransaction) => {
+export default async (userId, options, argTransaction = undefined) => {
     let transaction = argTransaction;
     let commitTransaction = false;
     if (!transaction) {

--- a/packages/api/server/services/user/index.ts
+++ b/packages/api/server/services/user/index.ts
@@ -1,0 +1,6 @@
+import updatePermissionOptions from './updatePermissionOptions';
+
+
+export default {
+    updatePermissionOptions,
+};

--- a/packages/api/server/services/user/updatePermissionOptions.spec.ts
+++ b/packages/api/server/services/user/updatePermissionOptions.spec.ts
@@ -5,7 +5,6 @@ import sinonChai from 'sinon-chai';
 import ServiceError from '#server/errors/ServiceError';
 import userModel from '#server/models/userModel';
 
-
 import { serialized as fakeUser } from '#test/utils/user';
 
 import updatePermissionOptionsService from './updatePermissionOptions';
@@ -15,52 +14,47 @@ chai.use(sinonChai);
 
 describe('services/user', () => {
     describe('updatePermissionOptions()', () => {
-        const user = { ...fakeUser(), role_id: 'collaborator' };
-
-        const options = ['access_justice'];
-        let stubs;
+        const stubs = {
+            setPermissionOptions: null,
+        };
 
         beforeEach(() => {
-            stubs = {
-                findOne: sinon.stub(userModel, 'findOne'),
-                updatePermissionOptions: sinon.stub(userModel, 'setPermissionOptions'),
-            };
+            stubs.setPermissionOptions = sinon.stub(userModel, 'setPermissionOptions');
         });
 
         afterEach(() => {
             sinon.restore();
         });
 
-        it('modifie les options en base de données renvoie l\'objet user', async () => {
-            stubs.updatePermissionOptions.resolves(user);
-            stubs.findOne.resolves(user);
+        it('modifie les options de l\'utilisateur en base de données', async () => {
+            const user = fakeUser();
+            const options = ['access_justice'];
+            await updatePermissionOptionsService(user.id, options);
+            expect(stubs.setPermissionOptions).to.have.been.calledOnceWith(user.id, options);
+        });
 
-            const response = await updatePermissionOptionsService(user.id, options);
-            expect(stubs.updatePermissionOptions).to.have.been.calledOnceWith(user.id, options);
-            expect(response).to.be.eql(user);
+        it('renvoie le user mis à jour', async () => {
+            const updatedUser = fakeUser({ first_name: 'updated' });
+            stubs.setPermissionOptions.resolves(updatedUser);
+
+            const response = await updatePermissionOptionsService(1, []);
+            expect(response).to.be.eql(updatedUser);
         });
-        it('renvoie une exception ServiceError \'fetch_failed\' si le service échoue à retrouver l\'utilisateur en base de données', async () => {
-            stubs.findOne.rejects(new Error());
-            let responseError;
-            try {
-                await updatePermissionOptionsService(user.id, options);
-            } catch (error) {
-                responseError = error;
-            }
-            expect(responseError).to.be.instanceOf(ServiceError);
-            expect(responseError.code).to.be.eql('fetch_failed');
-        });
+
         it('renvoie une exception ServiceError \'insert_failed\' si le service échoue à modifier les options en base de données', async () => {
-            stubs.findOne.resolves(user);
-            stubs.updatePermissionOptions.rejects(new Error());
+            const originalError = new Error('une erreur');
+            stubs.setPermissionOptions.rejects(originalError);
+
             let responseError;
             try {
-                await updatePermissionOptionsService(user.id, options);
+                await updatePermissionOptionsService(1, []);
             } catch (error) {
                 responseError = error;
             }
+
             expect(responseError).to.be.instanceOf(ServiceError);
             expect(responseError.code).to.be.eql('insert_failed');
+            expect(responseError.nativeError).to.be.eql(originalError);
         });
     });
 });

--- a/packages/api/server/services/user/updatePermissionOptions.spec.ts
+++ b/packages/api/server/services/user/updatePermissionOptions.spec.ts
@@ -1,0 +1,66 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import ServiceError from '#server/errors/ServiceError';
+import userModel from '#server/models/userModel';
+
+
+import { serialized as fakeUser } from '#test/utils/user';
+
+import updatePermissionOptionsService from './updatePermissionOptions';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+describe('services/user', () => {
+    describe('updatePermissionOptions()', () => {
+        const user = { ...fakeUser(), role_id: 'collaborator' };
+
+        const options = ['access_justice'];
+        let stubs;
+
+        beforeEach(() => {
+            stubs = {
+                findOne: sinon.stub(userModel, 'findOne'),
+                updatePermissionOptions: sinon.stub(userModel, 'setPermissionOptions'),
+            };
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('modifie les options en base de données renvoie l\'objet user', async () => {
+            stubs.updatePermissionOptions.resolves(user);
+            stubs.findOne.resolves(user);
+
+            const response = await updatePermissionOptionsService(user.id, options);
+            expect(stubs.updatePermissionOptions).to.have.been.calledOnceWith(user.id, options);
+            expect(response).to.be.eql(user);
+        });
+        it('renvoie une exception ServiceError \'fetch_failed\' si le service échoue à retrouver l\'utilisateur en base de données', async () => {
+            stubs.findOne.rejects(new Error());
+            let responseError;
+            try {
+                await updatePermissionOptionsService(user.id, options);
+            } catch (error) {
+                responseError = error;
+            }
+            expect(responseError).to.be.instanceOf(ServiceError);
+            expect(responseError.code).to.be.eql('fetch_failed');
+        });
+        it('renvoie une exception ServiceError \'insert_failed\' si le service échoue à modifier les options en base de données', async () => {
+            stubs.findOne.resolves(user);
+            stubs.updatePermissionOptions.rejects(new Error());
+            let responseError;
+            try {
+                await updatePermissionOptionsService(user.id, options);
+            } catch (error) {
+                responseError = error;
+            }
+            expect(responseError).to.be.instanceOf(ServiceError);
+            expect(responseError.code).to.be.eql('insert_failed');
+        });
+    });
+});

--- a/packages/api/server/services/user/updatePermissionOptions.ts
+++ b/packages/api/server/services/user/updatePermissionOptions.ts
@@ -1,25 +1,10 @@
 import userModel from '#server/models/userModel';
-import permissionsDescription from '#server/permissions_description';
 import ServiceError from '#server/errors/ServiceError';
 
 export default async (userId, options) => {
-    let user;
     try {
-        user = await userModel.findOne(userId);
-    } catch (error) {
-        throw new ServiceError('fetch_failed', error);
-    }
-    const allOptions = permissionsDescription[user.role_id].options;
-    const requestedOptions = allOptions
-        .filter(({ id }) => options && options.includes(id))
-        .map(({ id }) => id);
-
-    try {
-        user = await userModel.setPermissionOptions(user.id, requestedOptions, undefined);
+        return await userModel.setPermissionOptions(userId, options);
     } catch (error) {
         throw new ServiceError('insert_failed', error);
     }
-
-
-    return user;
 };

--- a/packages/api/server/services/user/updatePermissionOptions.ts
+++ b/packages/api/server/services/user/updatePermissionOptions.ts
@@ -1,0 +1,25 @@
+import userModel from '#server/models/userModel';
+import permissionsDescription from '#server/permissions_description';
+import ServiceError from '#server/errors/ServiceError';
+
+export default async (userId, options) => {
+    let user;
+    try {
+        user = await userModel.findOne(userId);
+    } catch (error) {
+        throw new ServiceError('fetch_failed', error);
+    }
+    const allOptions = permissionsDescription[user.role_id].options;
+    const requestedOptions = allOptions
+        .filter(({ id }) => options && options.includes(id))
+        .map(({ id }) => id);
+
+    try {
+        user = await userModel.setPermissionOptions(user.id, requestedOptions, undefined);
+    } catch (error) {
+        throw new ServiceError('insert_failed', error);
+    }
+
+
+    return user;
+};

--- a/packages/frontend/webapp/src/api/users.api.js
+++ b/packages/frontend/webapp/src/api/users.api.js
@@ -49,6 +49,11 @@ export function list() {
     return axios.get("/users");
 }
 
+export function modifyOptions(userId, options) {
+    return axios.post(`/users/${encodeURI(userId)}/options`, {
+        options,
+    });
+}
 export function newPassword(email) {
     return axios.post("/users/new-password", {
         email,

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionModifyOptions.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionModifyOptions.vue
@@ -1,0 +1,23 @@
+<template>
+    <Button
+        v-if="!['inactive', 'new'].includes(user.status)"
+        variant="tertiary"
+        icon="paper-plane"
+        iconPosition="left"
+        :loading="isLoading"
+        :disabled="disabled"
+        >Modifier les options de cet utilisateur</Button
+    >
+</template>
+
+<script setup>
+import { defineProps, toRefs } from "vue";
+import { Button } from "@resorptionbidonvilles/ui";
+
+const props = defineProps({
+    user: Object,
+    isLoading: Boolean,
+    disabled: Boolean,
+});
+const { user, isLoading, disabled } = toRefs(props);
+</script>

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActions.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActions.vue
@@ -27,6 +27,7 @@ import copyActivationLink from "./actions/copyActivationLink.action";
 import deactivate from "./actions/deactivate.action";
 import denyAccess from "./actions/denyAccess.action";
 import grantAccess from "./actions/grantAccess.action";
+import modifyOptions from "./actions/modifyOptions.action";
 import ACTION_DESCRIPTIONS from "./FicheAccesActions.descriptions";
 
 // boutons d'action
@@ -37,6 +38,7 @@ import FicheAccesActionCopyActivationLink from "./FicheAccesActionCopyActivation
 import FicheAccesActionDeactivate from "./FicheAccesActionDeactivate.vue";
 import FicheAccesActionDenyAccess from "./FicheAccesActionDenyAccess.vue";
 import FicheAccesActionGrantAccess from "./FicheAccesActionGrantAccess.vue";
+import FicheAccesActionModifyOptions from "./FicheAccesActionModifyOptions.vue";
 
 const props = defineProps({
     user: {
@@ -90,6 +92,13 @@ const actions = [
         component: FicheAccesActionGrantAccess,
         action: (...args) => {
             return grantAccess(...args, options.value);
+        },
+    },
+    {
+        id: "modify_options",
+        component: FicheAccesActionModifyOptions,
+        action: (...args) => {
+            return modifyOptions(...args, options.value);
         },
     },
 ];

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/actions/modifyOptions.action.js
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/actions/modifyOptions.action.js
@@ -1,0 +1,12 @@
+import { modifyOptions } from "@/api/users.api";
+import { useNotificationStore } from "@/stores/notification.store";
+
+export default async function (user, options) {
+    const notificationStore = useNotificationStore();
+    const updatedUser = await modifyOptions(user.id, options);
+    notificationStore.success(
+        "Succès",
+        "Les options de l'utilisateur ont bien été modifiées"
+    );
+    return updatedUser;
+}

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyOptions.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyOptions.vue
@@ -18,7 +18,7 @@
                 name="options"
                 variant="checkbox"
                 direction="col"
-                :disabled="user.status !== 'new'"
+                :disabled="user.status === 'inactive'"
             />
         </p>
     </div>
@@ -41,7 +41,6 @@ const props = defineProps({
 });
 const { user, options } = toRefs(props);
 const emit = defineEmits(["update:options"]);
-
 const accessPermission = computed(() => {
     const configStore = useConfigStore();
     return configStore.config.permissions_description[user.value.role_id];


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/PX4UMNL4/1705-droits-dacc%C3%A8s-permettre-aux-administrateurs-locaux-et-nationaux-de-modifier-les-options-dun-utilisateur

Dégrisage des   options sur la fiche utilisateur + ajout d'un bouton pour valider la modification des options

<img width="1381" alt="Capture d’écran 2023-01-10 à 15 42 04" src="https://user-images.githubusercontent.com/94321132/211581128-d93dd7d8-5207-484f-bfb9-1ed3b646b598.png">
