### PR TITLE
#patch (1695) Landing page — Il manque une page 404

### DIFF
--- a/packages/frontend/webapp/src/views/NotFoundView.vue
+++ b/packages/frontend/webapp/src/views/NotFoundView.vue
@@ -20,9 +20,7 @@
                     notre travail
                 </li>
                 <li>
-                    <Link :to="`${WWW_URL}/statistiques`"
-                        >quelques statistiques</Link
-                    >
+                    <Link :to="`${WWW_URL}/stats`">quelques statistiques</Link>
                     sur notre mesure d'impact
                 </li>
             </ul>

--- a/packages/frontend/www/components/Error/Error.vue
+++ b/packages/frontend/www/components/Error/Error.vue
@@ -1,5 +1,3 @@
-layouts/error.vue
-
 <template>
     <Container class="mb-10">
         <p>

--- a/packages/frontend/www/components/Error/Error.vue
+++ b/packages/frontend/www/components/Error/Error.vue
@@ -1,0 +1,46 @@
+layouts/error.vue
+
+<template>
+    <Container class="mb-10">
+        <p>
+            Bonjour !<br />Vous souhaitiez agir pour la résorption des
+            bidonvilles mais il semblerait que vous ayez saisi ou suivi un
+            lien vers une page qui n'existe pas.
+        </p>
+
+        <p class="mt-6">
+            Vous êtes bien sur la plateforme
+            <Link to="/"><em class="italic">Résorption-bidonvilles</em></Link>, alors voici quelques pages qui
+            pourraient vous intéresser :
+        </p>
+        <ul class="mt-6 ml-5 list-disc">
+            <li>
+                <Link to="/">la page d'accueil</Link> qui présente
+                notre travail
+            </li>
+            <li>
+                <Link to="/stats">quelques statistiques</Link>
+                sur notre mesure d'impact
+            </li>
+        </ul>
+        <p class="mt-6">
+            Et si vous ne trouvez vraiment pas ce que vous cherchez, vous
+            pouvez aussi
+            <Button class="underline" variant="primaryText" @click="() => redirectToContact()">nous contacter</Button>
+        </p>
+        <p class="mt-8">
+            <Link to="https://beta.gouv.fr/startups/resorption-bidonvilles.html#equipe">— L'équipe de
+            <em class="italic">Résorption-bidonvilles</em></Link>
+        </p>
+    </Container>
+
+</template>
+
+<script setup>
+import redirectToContact from "~~/utils/redirectToContact";
+
+import { Link, Button } from "@resorptionbidonvilles/ui";
+import Container from "../Layout/Container/Container.vue";
+</script>
+
+

--- a/packages/frontend/www/error.vue
+++ b/packages/frontend/www/error.vue
@@ -1,0 +1,13 @@
+layouts/error.vue
+
+<template>
+    <NuxtLayout>
+        <Error />
+    </NuxtLayout>
+</template>
+
+<script>
+import Error from "~/components/Error/Error.vue";
+</script>
+
+

--- a/packages/frontend/www/error.vue
+++ b/packages/frontend/www/error.vue
@@ -1,5 +1,3 @@
-layouts/error.vue
-
 <template>
     <NuxtLayout>
         <Error />


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/2u781UhW/1695-landing-page-il-manque-une-page-404

## 🛠 Description de la PR
- création d'une page générique error.vue pour gérer les cas d'erreur sur la landing 
- correction d'un lien erroné  vers les stats publiques sur la page d'erreur côté webapp

## 📸 Captures d'écran

<img width="1432" alt="Capture d’écran 2023-01-17 à 10 43 16" src="https://user-images.githubusercontent.com/94321132/212864048-06d34a76-0a6c-4f8c-8583-50aebd695cd4.png">

