### PR TITLE
#patch (1748) Éviter des erreurs à cause d'updated_at à la déclaration de site

### DIFF
--- a/packages/api/server/middlewares/validators/common/writeTown.ts
+++ b/packages/api/server/middlewares/validators/common/writeTown.ts
@@ -119,6 +119,13 @@ export default mode => ([
      * Date de mise à jour des données du site
      ********************************************************************************************* */
     body('updated_at')
+        .customSanitizer((value) => {
+            if (mode === 'update') {
+                return value;
+            }
+
+            return new Date();
+        })
         .exists({ checkNull: true }).bail().withMessage('Le champ "Date de mise à jour" est obligatoire')
         .toDate()
         .custom((value, { req }) => {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ELx6bwjG/1748

## 🛠 Description de la PR
La solution mise en place est d'utiliser la date du serveur pour le champ `updated_at` dans le cas d'une déclaration de site, et donc d'ignorer l'éventuelle valeur passée par le client.