### PR TITLE
#patch (1753) [Bug Solidarité International] Modification des conditions de vie et Origine

### DIFF
--- a/packages/api/server/models/shantytownModel/getHistory.ts
+++ b/packages/api/server/models/shantytownModel/getHistory.ts
@@ -169,13 +169,41 @@ export default async (user, location, shantytownFilter, resorbedFilter, myTownsF
     // on récupère les précédentes versions des éléments de listIdOldestVersions afin de pouvoir appliquer getDiff
     const queryPreviousVersions = listIdOldestVersions.length === 0 ? [] : await sequelize.query(
         `
+            WITH
+            shantytown_computed_origins AS (SELECT
+                s.hid AS fk_shantytown,
+                string_to_array(array_to_string(array_agg(soo.social_origin_id::VARCHAR || '|' || soo.uid || '|' || soo.label), ','), ',') AS origins
+            FROM "ShantytownHistories" s
+            LEFT JOIN "ShantytownOriginHistories" so ON so.fk_shantytown = s.hid
+            LEFT JOIN social_origins soo ON so.fk_social_origin = soo.social_origin_id
+            GROUP BY s.hid),
+
+            electricity_access_types AS (SELECT
+                s.hid AS fk_shantytown,
+                array_remove(array_agg(eat.electricity_access_type::text), NULL) AS electricity_access_types
+            FROM "ShantytownHistories" s
+            LEFT JOIN electricity_access_types_history eat ON eat.fk_shantytown = s.hid
+            GROUP BY s.hid),
+
+            shantytown_toilet_types AS (SELECT
+                s.hid AS fk_shantytown,
+                array_remove(array_agg(stt.toilet_type::text), NULL) AS toilet_types
+            FROM "ShantytownHistories" s
+            LEFT JOIN shantytown_toilet_types_history stt ON stt.fk_shantytown = s.hid
+            GROUP BY s.hid)
             SELECT
                 shantytowns.updated_at AS "date",
+                sco.origins AS "socialOrigins",
+                eat.electricity_access_types AS "electricityAccessTypes",
+                stt.toilet_types AS "toiletTypes",
                 COALESCE(shantytowns.updated_by, shantytowns.created_by) AS author_id,
                 ${Object.keys(SQL.selection).map(key => `${key} AS "${SQL.selection[key]}"`).join(', ')}
             FROM
                 "ShantytownHistories"  AS shantytowns
             LEFT JOIN shantytowns AS s ON shantytowns.shantytown_id = s.shantytown_id
+            LEFT JOIN shantytown_computed_origins sco ON sco.fk_shantytown = shantytowns.hid
+            LEFT JOIN electricity_access_types eat ON eat.fk_shantytown = shantytowns.hid
+            LEFT JOIN shantytown_toilet_types stt ON stt.fk_shantytown = shantytowns.hid
             LEFT JOIN users author ON COALESCE(shantytowns.updated_by, shantytowns.created_by) = author.user_id
             ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
             WHERE (shantytowns.shantytown_id, shantytowns.updated_at) IN


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kEBSWlzc/1753-bug-solidarit%C3%A9-international-modification-des-conditions-de-vie-et-origine

## 🛠 Description de la PR
Lorsque l'on récupère 10 sites dans l'historique des sites, on envoie à la suite une requête pour récupérer des anciennes versions afin de calculer le diff
sauf que dans cette requete on ne récupérait pas les données concernant les origines, et les types d'accès à l'électricité et aux toilettes