### PR TITLE
#patch (1756) Correction des liens vers les images dans le message "Navigateurs obsolète"

### DIFF
--- a/packages/frontend/webapp/index.html
+++ b/packages/frontend/webapp/index.html
@@ -80,14 +80,14 @@
                     </div>
                     <div class="card-content">
                         <div class="card-content-row">
-                            <a class="card-content-link" href="https://www.google.fr/chrome/" target="_blank"><img class="ibutton-icon" src="/public/assets/images/browsers/google_chrome.png"/><span>Google Chrome (version 61 minimum)</span></a>
-                            <a class="card-content-link" href="https://www.mozilla.org/fr/firefox/new/" target="_blank"><img class="ibutton-icon" src="/public/assets/images/browsers/mozilla.png"/><span>Firefox (version 60 minimum)</span></a>
-                            <a class="card-content-link" href="https://www.microsoft.com/fr-fr/edge" target="_blank"><img class="ibutton-icon" src="/public/assets/images/browsers/edge.png"/><span>Microsoft Edge (version 16 minimum)</span></a>
+                            <a class="card-content-link" href="https://www.google.fr/chrome/" target="_blank"><img class="ibutton-icon" src="/assets/images/browsers/google_chrome.png"/><span>Google Chrome (version 61 minimum)</span></a>
+                            <a class="card-content-link" href="https://www.mozilla.org/fr/firefox/new/" target="_blank"><img class="ibutton-icon" src="/assets/images/browsers/mozilla.png"/><span>Firefox (version 60 minimum)</span></a>
+                            <a class="card-content-link" href="https://www.microsoft.com/fr-fr/edge" target="_blank"><img class="ibutton-icon" src="/assets/images/browsers/edge.png"/><span>Microsoft Edge (version 16 minimum)</span></a>
                     </div>
                     <div class="card-content-row">
-                        <a class="card-content-link" href="https://brave.com/fr/" target="_blank"><img class="ibutton-icon" src="/public/assets/images/browsers/brave.png"/><span>Brave</span></a>
-                        <a class="card-content-link" href="https://www.opera.com/fr" target="_blank"><img class="ibutton-icon" src="/public/assets/images/browsers/opera.png"/><span>Opera (version 48 minimum)</span></a>
-                        <a class="card-content-link" href="https://vivaldi.com/fr/" target="_blank"><img class="ibutton-icon" src="/public/assets/images/browsers/vivaldi.png"/><span>Vivaldi</span></a>
+                        <a class="card-content-link" href="https://brave.com/fr/" target="_blank"><img class="ibutton-icon" src="/assets/images/browsers/brave.png"/><span>Brave</span></a>
+                        <a class="card-content-link" href="https://www.opera.com/fr" target="_blank"><img class="ibutton-icon" src="/assets/images/browsers/opera.png"/><span>Opera (version 48 minimum)</span></a>
+                        <a class="card-content-link" href="https://vivaldi.com/fr/" target="_blank"><img class="ibutton-icon" src="/assets/images/browsers/vivaldi.png"/><span>Vivaldi</span></a>
                     </div>
                     <div class="signature">
                         <a href="https://beta.gouv.fr/startups/resorption-bidonvilles.html#equipe">


### PR DESCRIPTION
for the "Obsolete Browser" page

## 🧾 Ticket Trello
https://trello.com/c/bK2y60CD

## 🛠 Description de la PR
- Suppression de la mention du répertoire `public` dans le chemin d'accès aux images.

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/213187836-4d17f6ef-e124-4552-830b-747edf0e7576.png)

## 🚨 Notes pour la mise en production
- Ràs