### PR TITLE
#patch (1759) Certains utilisateurs ne parviennent pas à modifier un site : "la date de modification ne peut-être future".

### DIFF
--- a/packages/api/server/middlewares/validators/common/writeTown.ts
+++ b/packages/api/server/middlewares/validators/common/writeTown.ts
@@ -126,6 +126,8 @@ export default mode => ([
 
             return new Date();
         })
+        .exists({ checkNull: true }).bail().withMessage('Le champ "Date de mise à jour" est obligatoire')
+        .toDate()
         .customSanitizer((value) => {
             const today = new Date();
 
@@ -134,8 +136,6 @@ export default mode => ([
             }
             return value;
         })
-        .exists({ checkNull: true }).bail().withMessage('Le champ "Date de mise à jour" est obligatoire')
-        .toDate()
         .custom((value, { req }) => {
             // for updates only
             if (req.town) {

--- a/packages/api/server/middlewares/validators/common/writeTown.ts
+++ b/packages/api/server/middlewares/validators/common/writeTown.ts
@@ -126,15 +126,17 @@ export default mode => ([
 
             return new Date();
         })
-        .exists({ checkNull: true }).bail().withMessage('Le champ "Date de mise à jour" est obligatoire')
-        .toDate()
-        .custom((value, { req }) => {
+        .customSanitizer((value) => {
             const today = new Date();
 
             if (value > today) {
-                throw new Error('La date de mise à jour du site ne peut pas être future');
+                return today;
             }
-
+            return value;
+        })
+        .exists({ checkNull: true }).bail().withMessage('Le champ "Date de mise à jour" est obligatoire')
+        .toDate()
+        .custom((value, { req }) => {
             // for updates only
             if (req.town) {
                 const lastUpdate = new Date(req.town.updatedAt);

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -252,20 +252,20 @@ function formatValuesForApi(v) {
 defineExpose({
     submit: handleSubmit(async (sentValues) => {
         const formattedValues = formatValuesForApi(sentValues);
+
+        /* eslint-disable no-unused-vars */
         let {
-            // eslint-disable-next-line no-unused-vars
-            updated_at: date1,
-            // eslint-disable-next-line no-unused-vars
-            update_to_date: update_to_date1,
+            updated_at: _1,
+            update_to_date: _2,
             ...originalValuesRest
         } = originalValues;
         let {
-            // eslint-disable-next-line no-unused-vars
-            updated_at: date2,
-            // eslint-disable-next-line no-unused-vars
-            update_to_date: update_to_date2,
+            updated_at: _3,
+            update_to_date: _4,
             ...formattedValuesRest
         } = formattedValues;
+        /* eslint-enable no-unused-vars */
+
         if (
             mode.value === "edit" &&
             isDeepEqual(originalValuesRest, formattedValuesRest)

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -252,9 +252,23 @@ function formatValuesForApi(v) {
 defineExpose({
     submit: handleSubmit(async (sentValues) => {
         const formattedValues = formatValuesForApi(sentValues);
+        let {
+            // eslint-disable-next-line no-unused-vars
+            updated_at: date1,
+            // eslint-disable-next-line no-unused-vars
+            update_to_date: update_to_date1,
+            ...originalValuesRest
+        } = originalValues;
+        let {
+            // eslint-disable-next-line no-unused-vars
+            updated_at: date2,
+            // eslint-disable-next-line no-unused-vars
+            update_to_date: update_to_date2,
+            ...formattedValuesRest
+        } = formattedValues;
         if (
             mode.value === "edit" &&
-            isDeepEqual(originalValues, formattedValues)
+            isDeepEqual(originalValuesRest, formattedValuesRest)
         ) {
             router.replace("#erreurs");
             error.value =


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/zITOhcc5/1759-certains-utilisateurs-ne-parviennent-pas-%C3%A0-modifier-un-site-la-date-de-modification-ne-peut-%C3%AAtre-future

## 🛠 Description de la PR
- Solution au bug: le validator transforme automatique la date à la date courante si elle est future
- cette PR embarque le correctif d'un autre bug : si on modifie la date de MAJ, mais qu'on ne modifie aucun autre champ, on ne renvoie pas d'erreur à la validation du formulaire. Corrigé en retirant les champs updated_at et update_to_date lors de l'appel à la méthode isEqual. Pas hyper satisfait de mon code ceci-dit