### PR TITLE
#patch (actions/v3) Remplacer "Espace temporaire d'insertion"

### DIFF
--- a/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.labels.js
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.labels.js
@@ -6,8 +6,9 @@ export default {
     goals: "Quels sont les objectifs de l'action ?",
     location_type: "Où se déroule l'action ?",
     location_departement: "Département d'intervention principal",
-    location_eti: "Adresse de l'ETI",
-    location_eti_coordinates: "Coordonnées GPS l'ETI",
+    location_eti: "Adresse de l'espace temporaire d'accompagnement",
+    location_eti_coordinates:
+        "Coordonnées GPS l'espace temporaire d'accompagnement",
     location_autre: "Veuillez préciser",
     location_shantytowns: "Sites concernés",
     managers: "Pilote(s) de l'action",
@@ -31,7 +32,7 @@ export default {
     indicateurs_hebergement: {
         raw: "Nombre de personnes ayant accédé à un hébergement ou logement adapté",
         formatted:
-            "_à un hébergement ou logement adapté_ longue durée avec accompagnement, dont espace terrain d'insertion",
+            "_à un hébergement ou logement adapté_ longue durée avec accompagnement, dont espace temporaire d'accompagnement",
     },
     indicateurs_logement: {
         raw: "Nombre de personnes ayant accédé à un logement",

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
@@ -71,7 +71,7 @@ const schema = computed(() => {
 
 const actualSolutionIds = computed(() => {
     const actualSolutions = [
-        "Hébergement ou logement adapté longue durée avec accompagnement, dont espace temporaire d’insertion",
+        "Hébergement ou logement adapté longue durée avec accompagnement, dont espace temporaire d’accompagnement",
         "Logement",
     ];
 

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
@@ -53,6 +53,6 @@ const info = computed(() => {
         des habitants du site ont été
         orientées vers une solution d’hébergement, de
         logement adapté longue durée avec accompagnement,
-        dont espace temporaire d’insertion, ou logement`;
+        dont espace temporaire accompagnement, ou logement`;
 });
 </script>

--- a/packages/frontend/webapp/src/components/IndicateursLabel/IndicateursLabelHebergement.vue
+++ b/packages/frontend/webapp/src/components/IndicateursLabel/IndicateursLabelHebergement.vue
@@ -3,7 +3,7 @@
         >accès à un
         <span class="text-tertiary">hébergement ou logement adapté</span>
         longue durée avec accompagnement, dont espace temporaire
-        d'insertion</IndicateursLabel
+        d'accompagnement</IndicateursLabel
     >
 </template>
 

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActions.filtres.js
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActions.filtres.js
@@ -14,8 +14,8 @@ export default [
         label: "Lieu d'intervention",
         id: "interventionLocation",
         options: [
-            { value: "sur_site", label: "Sur Site" },
-            { value: "eti", label: "Sur terrain d'insertion" },
+            { value: "sur_site", label: "Sur site" },
+            { value: "eti", label: "Sur espace temporaire d'accompagnement" },
             {
                 value: "logement",
                 label: "Dans le logement",

--- a/packages/frontend/webapp/src/utils/action_location_types.js
+++ b/packages/frontend/webapp/src/utils/action_location_types.js
@@ -1,5 +1,5 @@
 export default [
-    { uid: "eti", label: "Espace Temporaire d'Insertion" },
+    { uid: "eti", label: "Espace temporaire d'accompagnement" },
     { uid: "logement", label: "Dans le logement" },
     { uid: "sur_site", label: "Sur site" },
     { uid: "autre", label: "Autre" },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/zXMaWhr1

## 🛠 Description de la PR
Wording : remplacer "Espace temporaire d'insertion" par "Espace temporaire d'accompagnement" 
Ne jamais utiliser l’acronyme, toujours mettre en toutes lettres  à remplacer dans:
    - la fiche en édition, consultation et
    - dans la liste des sites (à la question champ d'intervention, à l'indicateur "accès à un hébergement ou logement adapté longue durée avec accompagnement, dont espace temporaire d'insertion"...)
