### PR TITLE
#patch (Actions/v3) Corrige la déformation du drapeau sur le bloc info

### DIFF
--- a/packages/frontend/webapp/src/components/FormDeclarationAction/sections/FormDeclarationActionIndicateursInfo.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/sections/FormDeclarationActionIndicateursInfo.vue
@@ -2,7 +2,7 @@
     <div class="bg-yellow-200 mb-4 px-4 py-2 flex items-center justify-between">
         <div class="flex items-center">
             <div
-                class="rounded-full bg-yellow-400 w-6 h-6 text-center text-size-xs leading-6"
+                class="rounded-full bg-yellow-400 w-8 h-6 text-center text-size-xs leading-6"
             >
                 <Icon icon="flag" />
             </div>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/zXMaWhr1

## 🛠 Description de la PR
- L'icône contenant le petit drapeau est déformée. Ce patch corrige la largeur de la div contenant l'icône pour que le disque qui contient l'icône s'affiche correctement