### PR TITLE
#minor (1597) Mobile - Ajouter une section "Sites à proximité"

### DIFF
--- a/packages/frontend/mobile/src/js/helpers/town.js
+++ b/packages/frontend/mobile/src/js/helpers/town.js
@@ -14,3 +14,9 @@ export function findTown(townId) {
 export function searchTowns(search) {
     return getApi(`/towns?q=${encodeURIComponent(search)}`);
 }
+
+export function findNearby(latitude, longitude) {
+    return getApi(
+        `/towns/findNearby?latitude=${latitude}&longitude=${longitude}`
+    );
+}

--- a/packages/frontend/mobile/src/js/pages/TownsList/TownCarousel.vue
+++ b/packages/frontend/mobile/src/js/pages/TownsList/TownCarousel.vue
@@ -1,8 +1,5 @@
 <template>
-    <div
-        v-if="towns.length > 0"
-        class="whitespace-nowrap overflow-y-auto mb-8 mt-2"
-    >
+    <div v-if="towns.length > 0" class="whitespace-nowrap overflow-y-auto mt-2">
         <Container>
             <TownCard
                 v-for="town in towns"

--- a/packages/frontend/mobile/src/store/modules/towns.js
+++ b/packages/frontend/mobile/src/store/modules/towns.js
@@ -8,6 +8,7 @@ export default {
         hash: {},
         myTowns: [],
         consultedTowns: [],
+        nearbyTowns: [],
         commentsAreOpen: false,
         commentsScroll: 0,
     },
@@ -32,6 +33,14 @@ export default {
             towns.forEach((town) => {
                 if (!state.hash[town.id]) {
                     state.hash[town.id] = town;
+                }
+            });
+        },
+        SET_NEARBY_TOWNS_ITEMS(state, nearbyTowns) {
+            state.nearbyTowns = nearbyTowns;
+            nearbyTowns.forEach((nearbyTown) => {
+                if (!state.hash[nearbyTown.id]) {
+                    state.hash[nearbyTown.id] = nearbyTown;
                 }
             });
         },
@@ -90,6 +99,15 @@ export default {
             }
         },
 
+        async setNearbyTowns({ commit, rootState }, towns) {
+            commit("SET_NEARBY_TOWNS_ITEMS", []);
+            const { field_types: fieldTypes } = rootState.config.configuration;
+            commit(
+                "SET_NEARBY_TOWNS_ITEMS",
+                towns.map((s) => enrichShantytown(s, fieldTypes))
+            );
+        },
+
         async fetchShantytown({ state, rootState }, shantytownId) {
             const { field_types: fieldTypes } = rootState.config.configuration;
             // fetch locally first
@@ -121,6 +139,9 @@ export default {
         },
         consultedTowns(state) {
             return state.consultedTowns;
+        },
+        nearbyTowns(state) {
+            return state.nearbyTowns;
         },
     },
 };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/6RLiIG6D

## 🛠 Description de la PR
** FRONT**
- Dans `MobileTownsList.vue`, créer une méthode pour récupérer les coordonnées géographiques du terminal en utilisant la méthode `Geolocation.getCurrentPosition()`
- Dans `MobileTownsList.vue`, ajouter une méthode pour actualiser les coordonnées géographiques du terminal
- Dans `MobileTownsList.vue`, ajouter un bouton déclenchant l'actualisation de la position géographique du terminal
- Récupérer côté front la route vers la méthode de l'API retournant les sites à proximité d'une position géographique
- Dans `MobileTownsList.vue`, surveiller la position géographique du terminal. Si elle change, recharger depuis l'API les sites à proximité et mettre à jour les sites à proximité dans le store
- Ajouter une propriété `nearbyTowns` dans le store `towns`
- Ajouter une mutation mettant à jour la propriété `nearbyTowns` du store `towns`
- Ajouter une action pour mettre à jour la propriété `nearbyTowns` du store `towns`
- Dans `MobileTownsList.vue`, ajouter un carrousel pour afficher la liste des sites à proximité
- Dans `MobileTownsList.vue`, gérer les éventuels messages d'erreur en cas de problème de géolocalisation du terminal 

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/226561228-31f77e23-74ac-4f13-a6e8-93a6994aa3f8.png)

## 🚨 Notes pour la mise en production
- ràs