### PR TITLE
#patch (1830) Actions - Remplacer optionnel par effective dans le libellé de la date de fin

### DIFF
--- a/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.labels.js
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.labels.js
@@ -1,7 +1,7 @@
 export default {
     name: "Quel est le nom de l'action ?",
     started_at: "Date de début",
-    ended_at: "Date de fin",
+    ended_at: "Date de fin effective",
     topics: "Quels sont les champs d'intervention de l'action ?",
     goals: "Quels sont les objectifs de l'action ?",
     location_type: "Où se déroule l'action ?",

--- a/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.vue
@@ -2,7 +2,7 @@
     <ArrangementLeftMenu :tabs="tabs" autonav>
         <template v-slot:menuTitle>Rubriques</template>
 
-        <FormDeclarationActionCaracteristiques class="mt-6" />
+        <FormDeclarationActionCaracteristiques class="mt-6" :mode="mode" />
         <FormDeclarationActionLocalisation class="mt-6" />
         <FormDeclarationActionContacts class="mt-6" />
         <FormDeclarationActionIndicateurs class="mt-6" />

--- a/packages/frontend/webapp/src/components/FormDeclarationAction/inputs/FormDeclarationActionInputDates.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/inputs/FormDeclarationActionInputDates.vue
@@ -8,10 +8,10 @@
             showMandatoryStar
         />
         <DatepickerInput
+            v-if="mode === 'edit'"
             name="ended_at"
             id="ended_at"
             :label="labels.ended_at"
-            info="(effective)"
             inlineInfo
             :minDate="values.started_at"
         />
@@ -22,6 +22,15 @@
 import { useFormValues } from "vee-validate";
 import { DatepickerInput } from "@resorptionbidonvilles/ui";
 import labels from "../FormDeclarationAction.labels";
+import { defineProps, toRefs } from "vue";
 
+const props = defineProps({
+    mode: {
+        type: String,
+        required: true,
+        default: "create",
+    },
+});
+const { mode } = toRefs(props);
 const values = useFormValues();
 </script>

--- a/packages/frontend/webapp/src/components/FormDeclarationAction/inputs/FormDeclarationActionInputDates.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/inputs/FormDeclarationActionInputDates.vue
@@ -12,6 +12,7 @@
             name="ended_at"
             id="ended_at"
             :label="labels.ended_at"
+            info="(optionnel)"
             inlineInfo
             :minDate="values.started_at"
         />

--- a/packages/frontend/webapp/src/components/FormDeclarationAction/inputs/FormDeclarationActionInputDates.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/inputs/FormDeclarationActionInputDates.vue
@@ -11,7 +11,7 @@
             name="ended_at"
             id="ended_at"
             :label="labels.ended_at"
-            info="(optionnel)"
+            info="(effective)"
             inlineInfo
             :minDate="values.started_at"
         />

--- a/packages/frontend/webapp/src/components/FormDeclarationAction/inputs/FormDeclarationActionInputDates.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/inputs/FormDeclarationActionInputDates.vue
@@ -28,7 +28,6 @@ const props = defineProps({
     mode: {
         type: String,
         required: true,
-        default: "create",
     },
 });
 const { mode } = toRefs(props);

--- a/packages/frontend/webapp/src/components/FormDeclarationAction/sections/FormDeclarationActionCaracteristiques.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/sections/FormDeclarationActionCaracteristiques.vue
@@ -9,7 +9,7 @@
         <FormParagraph
             title="Quelles sont les dates et les objectifs de l'action ?"
         >
-            <InputDates />
+            <InputDates :mode="mode" />
             <InputTopics />
             <InputGoals />
         </FormParagraph>
@@ -25,4 +25,14 @@ import InputName from "../inputs/FormDeclarationActionInputName.vue";
 import InputDates from "../inputs/FormDeclarationActionInputDates.vue";
 import InputTopics from "../inputs/FormDeclarationActionInputTopics.vue";
 import InputGoals from "../inputs/FormDeclarationActionInputGoals.vue";
+import { defineProps, toRefs } from "vue";
+
+const props = defineProps({
+    mode: {
+        type: String,
+        required: true,
+        default: "create",
+    },
+});
+const { mode } = toRefs(props);
 </script>

--- a/packages/frontend/webapp/src/components/FormDeclarationAction/sections/FormDeclarationActionCaracteristiques.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/sections/FormDeclarationActionCaracteristiques.vue
@@ -31,7 +31,6 @@ const props = defineProps({
     mode: {
         type: String,
         required: true,
-        default: "create",
     },
 });
 const { mode } = toRefs(props);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/SVMFGvge/XXX

## 🛠 Description de la PR
Changement de wording: **Date de fin (optionnel)** devient **Date de fin (effective)**
Le changement ne concerne que la propriété `info` du composant `FormDeclarationActionInputDate` ; de cette façon, on conserve le terme "Date de fin " dans les exports et les messages d'erreurs lors des contrôles de saisie mais de rendre le label clair sur l'information attendue lors de la mise à jour d'une action.

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/226582447-18fd7c38-3359-4b5d-97b7-4537be967be2.png)

## 🚨 Notes pour la mise en production
- ràs