### PR TITLE
#patch (1815) Préciser "inconnu" pour "Présence de nuisibles"

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVie.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVie.vue
@@ -66,9 +66,20 @@
 
         <div v-if="town.livingConditions.version === 2">
             <FicheSiteConditionsDeVieRubrique
+                v-if="
+                    ['good', 'bad'].includes(
+                        town.livingConditions.pest_animals.status.status
+                    )
+                "
                 :title="pestAnimalsWording"
                 :status="town.livingConditions.pest_animals.status"
                 :showStatus="false"
+                :answers="answers.pest_animals"
+            />
+            <FicheSiteConditionsDeVieRubrique
+                v-else
+                :title="pestAnimalsWording"
+                :status="town.livingConditions.pest_animals.status"
                 :answers="answers.pest_animals"
             />
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/0IJU7yDT

## 🛠 Description de la PR
Ajoute la mention "inconnu" si le statut de la présence de nuisible est inconnu sur la fiche site.

## 📸 Captures d'écran
![image](https://user-images.githubusercontent.com/50863659/226968342-c25c2004-5e4a-4940-abb9-7840f5f88bee.png)

## 🚨 Notes pour la mise en production
- ràs