### PR TITLE
#patch (1817) Demande d'accès - Impossible de renseigner un numéro de téléphone hors métropole

### DIFF
--- a/packages/api/server/middlewares/validators/common/newUser.ts
+++ b/packages/api/server/middlewares/validators/common/newUser.ts
@@ -62,7 +62,7 @@ export default (
                 return true;
             }
 
-            const frenchPhoneRegex = /^(?:(?:\+|00)33|0)\s*[1-9](?:[\s.-]*\d{2}){4}$/gmi;
+            const frenchPhoneRegex = /^(?:(?:\+|00)(?:33|262|590|594|596)|0)\s*[1-9](?:[\s.-]*\d{2}){4}$/gmi;
             const match = value.match(frenchPhoneRegex);
 
             if (!match) {

--- a/packages/api/server/middlewares/validators/editUser.ts
+++ b/packages/api/server/middlewares/validators/editUser.ts
@@ -49,7 +49,7 @@ export default [
                 return true;
             }
 
-            const frenchPhoneRegex = /^(?:(?:\+|00)33|0)\s*[1-9](?:[\s.-]*\d{2}){4}$/gmi;
+            const frenchPhoneRegex = /^(?:(?:\+|00)(?:33|262|590|594|596)|0)\s*[1-9](?:[\s.-]*\d{2}){4}$/gmi;
             const match = value.match(frenchPhoneRegex);
 
             if (!match) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/TRrdWoie

## 🛠 Description de la PR
Ajout des indicatifs suivants dans la règle de validation des numéros de téléphones:
262 pour la Réunion
590 pour la Guadeloupe
594 pour la Guyane
596 pour la Martinique

## 🚨 Notes pour la mise en production
- ràs