### PR TITLE
#patch (1843) ajouter les admins nationaux en copie-cachée des notifs de suppression de commentaire

### DIFF
--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -33,7 +33,12 @@ type MailOptions = {
         email: string,
         first_name: string,
         last_name: string
-    }
+    },
+    bcc?: {
+        email: string,
+        first_name: string,
+        last_name: string
+    }[]
 };
 
 export default {
@@ -528,7 +533,7 @@ export default {
      * @param {Object} options
      */
     sendUserCommentDeletion: (recipient, options: MailOptions = {}) => {
-        const { variables, preserveRecipient } = options;
+        const { variables, preserveRecipient, bcc } = options;
 
         return mailService.send('user_comment_deletion', {
             recipient,
@@ -540,6 +545,7 @@ export default {
                 blogUrl,
             },
             preserveRecipient,
+            bcc,
         });
     },
 

--- a/packages/api/server/services/mailService.ts
+++ b/packages/api/server/services/mailService.ts
@@ -20,7 +20,7 @@ export default {
      */
     send(templateName, options) {
         const {
-            recipient, preserveRecipient = true, variables, replyTo = null,
+            recipient, preserveRecipient = true, variables, replyTo = null, bcc = [],
         } = options;
 
         let finalRecipient = recipient;
@@ -30,6 +30,7 @@ export default {
                 first_name: 'Service',
                 last_name: 'Qualité',
             };
+            bcc.splice(0, bcc.length);
         }
 
         const htmlContent = fs.readFileSync(path.join(__dirname, '../mails/dist', `${templateName}.html`));
@@ -52,6 +53,7 @@ export default {
                 },
             },
             replyTo,
+            bcc,
         );
     },
 };

--- a/packages/api/server/services/shantytown/deleteComment.ts
+++ b/packages/api/server/services/shantytown/deleteComment.ts
@@ -58,6 +58,7 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
 
     try {
         if (!isOwner) {
+            const nationalAdmins = await userModel.getNationalAdmins();
             await mails.sendUserCommentDeletion(author, {
                 variables: {
                     town: {
@@ -72,6 +73,7 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
                     },
                     message,
                 },
+                bcc: nationalAdmins,
             });
         }
     } catch (error) {

--- a/packages/api/server/utils/mail.ts
+++ b/packages/api/server/utils/mail.ts
@@ -21,7 +21,7 @@ export default {
         };
     },
 
-    send(user, mailContent, replyTo = null) {
+    send(user, mailContent, replyTo = null, bcc = []) {
         if (mailjet === null) {
             return Promise.resolve(true);
         }
@@ -47,6 +47,10 @@ export default {
                                     : undefined,
                             },
                         ],
+                        Bcc: bcc?.length > 0 ? bcc.map(r => ({
+                            Email: r.email,
+                            Name: `${r.last_name.toUpperCase()} ${r.first_name}`,
+                        })) : undefined,
                     }, mailContent),
                 ],
             });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/HL18tRcd/1843

## 🛠 Description de la PR
Ajout d'une option"Bcc" aux utilitaires de mail.