### PR TITLE
#patch (1839) changement de la stat publique "Nombre d'utilisateurs"

### DIFF
--- a/packages/api/server/models/statsModel/numberOfActiveUsers.ts
+++ b/packages/api/server/models/statsModel/numberOfActiveUsers.ts
@@ -8,11 +8,9 @@ export default async () => {
         FROM users
         LEFT JOIN localized_organizations AS organizations ON users.fk_organization = organizations.organization_id
         WHERE
-            users.fk_status='active'
+            users.last_access IS NOT NULL
             AND
             to_be_tracked = TRUE
-            AND
-            organizations.active = TRUE
         `,
         {
             type: QueryTypes.SELECT,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/bSHIR7DL/1839

## 🛠 Description de la PR
Ne sont plus comptés les utilisateurs avec un compte "actuellement actif", mais le nombre d'utilisateur s'étant connectés à la plateforme au moins une fois.