### PR TITLE
#patch (1851) modif. de site : ne pas valider la date du diagnostic social si elle n'a pas été changée

### DIFF
--- a/packages/api/server/middlewares/validators/common/writeTown.ts
+++ b/packages/api/server/middlewares/validators/common/writeTown.ts
@@ -366,6 +366,7 @@ export default mode => ([
         .exists({ checkNull: true }).bail().withMessage('Le champ "Date du diagnostic" est obligatoire')
         .isDate().bail().withMessage('Le champ "Date du diagnostic" est invalide')
         .toDate()
+        .if((value, { req }) => mode !== 'update' || !req.town || value.getTime() / 1000 !== req.town.censusConductedAt)
         .custom((value, { req }) => {
             const today = new Date();
             today.setHours(0, 0, 0, 0);

--- a/packages/api/server/models/shantytownModel/_common/serializeShantytown.ts
+++ b/packages/api/server/models/shantytownModel/_common/serializeShantytown.ts
@@ -6,7 +6,7 @@ import serializeLivingConditions from './livingConditions/serializeLivingConditi
 const { can } = permissionUtils;
 
 function fromDateToTimestamp(date) {
-    return date !== null ? (new Date(`${date}T00:00:00`).getTime() / 1000) : null;
+    return date !== null ? (new Date(`${date}T02:00:00`).getTime() / 1000) : null;
 }
 
 export default (town, user) => {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/6nC4J52X/1851

## 🛠 Description de la PR
RàS, voir la description du ticket.