### PR TITLE
#patch (1864) réduire espacements items conditions de vie mobile

### DIFF
--- a/packages/frontend/mobile/src/js/pages/TownPage/LivingConditions/TownPageLivingConditionsDetails.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/LivingConditions/TownPageLivingConditionsDetails.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div class="flex text-center py-4">
+        <div class="flex text-center mb-2">
             <div
                 v-for="item in items"
                 :key="item.id"

--- a/packages/frontend/mobile/src/js/pages/TownPage/LivingConditions/TownPageLivingConditionsDetails.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/LivingConditions/TownPageLivingConditionsDetails.vue
@@ -1,12 +1,12 @@
 <template>
-    <div>
+    <Container>
         <div class="flex text-center mb-2">
             <div
                 v-for="item in items"
                 :key="item.id"
                 @click="changeFilter(item.id)"
                 :class="[
-                    'p-2 mt-2',
+                    'py-2',
                     select === item.id
                         ? 'text-primary border-b border-b-blue'
                         : '',
@@ -27,7 +27,7 @@
                 </li>
             </ul>
         </div>
-    </div>
+    </Container>
 </template>
 
 <style scoped>
@@ -37,6 +37,7 @@
 </style>
 
 <script>
+import Container from "#src/js/components/Container.vue";
 import { Icon } from "@resorptionbidonvilles/ui";
 
 export default {
@@ -60,6 +61,7 @@ export default {
     },
     components: {
         Icon,
+        Container,
     },
     mounted() {
         this.initTab();

--- a/packages/frontend/mobile/src/js/pages/TownPage/LivingConditions/TownPagePanelLivingConditionsSection.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/LivingConditions/TownPagePanelLivingConditionsSection.vue
@@ -1,30 +1,31 @@
 <template>
-    <div class="py-2">
-        <div :class="[colorClass, 'flex items-center']">
-            <Icon :class="['mr-1', 'font-bold']" :icon="icon" />
-            <div>
-                <div class="flex items-center">
-                    <div :class="[colorClass, 'font-bold', 'mr-1']">
-                        {{ title }}<span v-if="showStatus"> :</span>
-                    </div>
-                    <div v-if="showStatus">
+    <div>
+        <div :class="[colorClass, 'border-t border-b py-2']">
+            <Container class="flex items-center">
+                <Icon :class="['mr-2', 'font-bold']" :icon="icon" />
+                <p class="flex items-center">
+                    <span :class="[colorClass, 'font-bold', 'mr-1']">
+                        {{ title }}<template v-if="showStatus"> :</template>
+                    </span>
+                    <template v-if="showStatus">
                         {{ text }}
-                    </div>
-                </div>
-            </div>
+                    </template>
+                </p>
+            </Container>
         </div>
-        <div class="mt-6" v-if="answers.length">
+        <Container v-if="answers.length">
             <div v-for="answer in answers" :key="answer.label">
                 <TownPageInfo :title="answer.label">
                     <p>{{ answer.content }}</p>
                 </TownPageInfo>
             </div>
-        </div>
+        </Container>
         <TownPageLivingConditionsDetails :status="status" />
     </div>
 </template>
 
 <script>
+import Container from "#src/js/components/Container.vue";
 import { Icon } from "@resorptionbidonvilles/ui";
 import TownPageInfo from "../TownPageInfo.vue";
 import TownPageLivingConditionsDetails from "./TownPageLivingConditionsDetails.vue";
@@ -78,6 +79,7 @@ export default {
     },
     components: {
         Icon,
+        Container,
         TownPageLivingConditionsDetails,
         TownPageInfo,
     },

--- a/packages/frontend/mobile/src/js/pages/TownPage/LivingConditions/TownPagePanelLivingConditionsSection.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/LivingConditions/TownPagePanelLivingConditionsSection.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="mt-6">
+    <div class="py-2">
         <div :class="[colorClass, 'flex items-center']">
             <Icon :class="['mr-1', 'font-bold']" :icon="icon" />
             <div>

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPage.vue
@@ -50,12 +50,14 @@
                     />
 
                     <TownPagePanelPeople id="people" :town="town" />
+                </Container>
 
-                    <TownPagePanelLivingConditions
-                        id="living_conditions"
-                        :town="town"
-                    />
+                <TownPagePanelLivingConditions
+                    id="living_conditions"
+                    :town="town"
+                />
 
+                <Container>
                     <TownPagePanelJudicial
                         v-if="hasJusticePermission"
                         id="judicial"

--- a/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelLivingConditions.vue
+++ b/packages/frontend/mobile/src/js/pages/TownPage/TownPagePanelLivingConditions.vue
@@ -1,69 +1,80 @@
 <template>
     <div>
-        <TownPagePanelTitle :title="'Conditions de vie'" />
+        <Container>
+            <TownPagePanelTitle :title="'Conditions de vie'" />
+        </Container>
 
-        <div>
+        <TownPagePanelLivingConditionsSection
+            title="Accès à l’eau"
+            :status="town.livingConditions.water.status"
+            :answers="answers.water"
+        />
+        <TownPagePanelLivingConditionsSection
+            class="mt-6"
+            title="Accès aux toilettes"
+            :status="town.livingConditions.sanitary.status"
+            :answers="answers.sanitary"
+        />
+
+        <TownPagePanelLivingConditionsSection
+            class="mt-6"
+            title="Accès à l’électricité"
+            sanitary
+            :status="town.livingConditions.electricity.status"
+            :answers="answers.electricity"
+        />
+
+        <TownPagePanelLivingConditionsSection
+            class="mt-6"
+            title="Évacuation des déchets"
+            :status="town.livingConditions.trash.status"
+        />
+
+        <div v-if="town.livingConditions.version === 1">
             <TownPagePanelLivingConditionsSection
-                title="Accès à l’eau"
-                :status="town.livingConditions.water.status"
-                :answers="answers.water"
-            />
-            <TownPagePanelLivingConditionsSection
-                title="Accès aux toilettes"
-                :status="town.livingConditions.sanitary.status"
-                :answers="answers.sanitary"
-            />
-
-            <TownPagePanelLivingConditionsSection
-                title="Accès à l’électricité"
-                sanitary
-                :status="town.livingConditions.electricity.status"
-                :answers="answers.electricity"
+                class="mt-6"
+                :title="pestAnimalsWording"
+                :status="town.livingConditions.vermin.status"
+                :showStatus="
+                    town.livingConditions.vermin.status.status === 'unknown'
+                "
+                :answers="answers.pest_animals"
+                :inverted="true"
             />
 
             <TownPagePanelLivingConditionsSection
-                title="Évacuation des déchets"
-                :status="town.livingConditions.trash.status"
+                class="mt-6"
+                title="Prévention des incendies"
+                :status="town.livingConditions.firePrevention.status"
+                :answers="answers.fire_prevention"
+            />
+        </div>
+
+        <div v-if="town.livingConditions.version === 2">
+            <TownPagePanelLivingConditionsSection
+                class="mt-6"
+                :title="pestAnimalsWording"
+                :status="town.livingConditions.pest_animals.status"
+                :showStatus="false"
+                :inverted="true"
+                :answers="answers.pest_animals"
             />
 
-            <div v-if="town.livingConditions.version === 1">
-                <TownPagePanelLivingConditionsSection
-                    :title="pestAnimalsWording"
-                    :status="town.livingConditions.vermin.status"
-                    :showStatus="false"
-                    :answers="answers.pest_animals"
-                    :inverted="true"
-                />
-
-                <TownPagePanelLivingConditionsSection
-                    title="Prévention des incendies"
-                    :status="town.livingConditions.firePrevention.status"
-                    :answers="answers.fire_prevention"
-                />
-            </div>
-
-            <div v-if="town.livingConditions.version === 2">
-                <TownPagePanelLivingConditionsSection
-                    :title="pestAnimalsWording"
-                    :status="town.livingConditions.pest_animals.status"
-                    :showStatus="false"
-                    :inverted="true"
-                    :answers="answers.pest_animals"
-                />
-
-                <TownPagePanelLivingConditionsSection
-                    title="Prévention des incendies"
-                    :status="town.livingConditions.fire_prevention.status"
-                />
-            </div>
+            <TownPagePanelLivingConditionsSection
+                class="mt-6"
+                title="Prévention des incendies"
+                :status="town.livingConditions.fire_prevention.status"
+            />
         </div>
     </div>
 </template>
 
 <script>
+import Container from "#src/js/components/Container.vue";
 import serializeLivingConditions from "#frontend/common/helpers/town/living_conditions/serializeLivingConditions";
 import TownPagePanelLivingConditionsSection from "./LivingConditions/TownPagePanelLivingConditionsSection.vue";
 import TownPagePanelTitle from "./TownPagePanelTitle.vue";
+
 export default {
     props: {
         town: {
@@ -72,6 +83,7 @@ export default {
         },
     },
     components: {
+        Container,
         TownPagePanelLivingConditionsSection,
         TownPagePanelTitle,
     },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/qRfpLC3b/1864-mobile-wording-r%C3%A9duire-lespace-entre-les-items-des-conditions-de-vie

## 🛠 Description de la PR


## 📸 Captures d'écran

<img width="451" alt="Capture d’écran 2023-04-27 à 16 06 08" src="https://user-images.githubusercontent.com/94321132/234887094-9a158013-ac8d-46e8-89b6-ec95cacf6f76.png">

