### PR TITLE
#patch (1891) Replier la définition d'un site par défaut

### DIFF
--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteInfo.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteInfo.vue
@@ -1,15 +1,14 @@
 <template>
     <p v-if="mode === 'report'" class="bg-yellow-200 p-4 mb-6">
         <Icon icon="triangle-exclamation" class="mr-1" />
-        <span class="font-bold">Les données ne seront pas enregistrées</span
-        ><br />
+        <span class="font-bold">Les données ne seront pas enregistrées</span><br />
 
         À la validation de ce formulaire, les données renseignées ne seront pas
         enregistrées sur la plateforme mais transmises aux administrateurs de la
         plateforme pour validation.
     </p>
 
-    <PanelInfo icon="flag" defaultStatus="open">
+    <PanelInfo icon="flag">
         <template v-slot:title>Qu'est-ce qu'un site ?</template>
         <template v-slot:content>
             Un site est un bidonville ou squat occupé de manière informelle à


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Sg7DYBdl

## 🛠 Description de la PR
Supprime la propriété `defaultStatus`, par défaut à "closed", lors  la création du `PanelInfo` dans le composant `FormDeclarationDeSiteInfo.vue`

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/50863659/0a6eaf7b-f9d0-4e21-8b09-622373b3ee36)

## 🚨 Notes pour la mise en production
Ràs