### PR TITLE
(patch) Corrige la requête retournant les users inactifs

### DIFF
--- a/packages/api/server/models/userModel/findInactiveUsers.ts
+++ b/packages/api/server/models/userModel/findInactiveUsers.ts
@@ -11,6 +11,12 @@ export default () => query(
                 operator: '>',
                 value: delayBeforeAlert,
             },
+            last_access_is_null: {
+                // la précédence des opérateurs en SQL fait que le AND s'applique avant le OR
+                query: 'users.last_access IS NULL AND (NOW() - users.created_at)',
+                operator: '>',
+                value: delayBeforeAlert,
+            },
         },
         {
             inactivity_alert_sent_at: { value: null },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/D7kiDZjh

## 🛠 Description de la PR
Il faut enrichir la clause `where` existante:
```
WHERE (NOW() - users.last_access > ('6 month'))
AND (users.inactivity_alert_sent_at IS NULL) 
AND (users.fk_status IN ('active')
```
avec la condition supplémentaire suivante:
```
WHERE (
	NOW() - users.last_access > ('6 month')
	OR
	(users.last_access IS NULL AND (NOW() - users.created_at) > ('6 month')))
AND
	(users.inactivity_alert_sent_at IS NULL) 
AND (users.fk_status IN ('active'))
```
En utilisant les filtres SQL implémentés dans `userModel`, on doit se priver de certaines parenthèses mais comme indiqué en commentaire dans le code, la règle de précédence des opérateurs (AND avant OR) nous permet de nous en dispenser.

## 🚨 Notes pour la mise en production
- ràs