### PR TITLE
#patch (1899) restaurer l'alerte canicule

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -63,10 +63,18 @@ const isOpen = computed(() => {
 });
 
 async function toggleHeatwave() {
-    await townsStore.setHeatwaveStatus(
-        shantytown.value.id,
-        !heatwaveStatus.value
-    );
+    try {
+        await townsStore.setHeatwaveStatus(
+            shantytown.value.id,
+            !heatwaveStatus.value
+        );
+    } catch (e) {
+        notificationStore.error(
+            "Risque canicule",
+            "Une erreur inconnue est survenue"
+        );
+        return;
+    }
 
     if (heatwaveRequestStatus.value?.error !== null) {
         notificationStore.error(

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -8,7 +8,7 @@
             type="button"
             size="sm"
             :loading="heatwaveRequestStatus?.loading === true"
-            @click="toggleHeatwave"
+            @click.prevent="toggleHeatwave"
         >
             <template v-if="heatwaveStatus === false">Alerte Canicule</template>
             <template v-else>Supprimer l'alerte Canicule</template>
@@ -62,8 +62,7 @@ const isOpen = computed(() => {
     return shantytown.value.status === "open";
 });
 
-async function toggleHeatwave(event) {
-    event.preventDefault(); // éviter que le clic ne redirige vers la fiche site
+async function toggleHeatwave() {
     await townsStore.setHeatwaveStatus(
         shantytown.value.id,
         !heatwaveStatus.value


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/jPYBz75b/1899-liste-des-sites-remettre-le-bouton-alerte-canicule

## 🛠 Description de la PR
 Restauration basée sur le commit e1baefb07c68d0aad59b00b14a77119e428e4b34


