### PR TITLE
#patch (1911) Bug — Le message d'erreur des checkbox n'est plus correct

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournalFormNouveauMessage/inputs/FormNouveauMessageInputTags.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournalFormNouveauMessage/inputs/FormNouveauMessageInputTags.vue
@@ -6,12 +6,14 @@
             :value="item.uid"
             :label="item.label"
             name="tags"
+            v-model="values.tags"
         />
     </CheckableGroup>
 </template>
 
 <script setup>
 import { computed } from "vue";
+import { useFormValues } from "vee-validate";
 import { useConfigStore } from "@/stores/config.store";
 import labels from "../FicheSiteJournalFormNouveauMessage.labels";
 
@@ -21,4 +23,6 @@ const configStore = useConfigStore();
 const items = computed(() => {
     return configStore.config.regular_comment_tags;
 });
+
+const values = useFormValues();
 </script>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteModaleMesThemes/inputs/ModaleMesThemesInputThemes.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteModaleMesThemes/inputs/ModaleMesThemesInputThemes.vue
@@ -6,12 +6,14 @@
             :value="themeId"
             :label="themes[themeId]"
             name="themes"
+            v-model="values.themes"
         />
     </CheckableGroup>
 </template>
 
 <script setup>
 import { computed } from "vue";
+import { useFormValues } from "vee-validate";
 import { useConfigStore } from "@/stores/config.store";
 import labels from "../FicheSiteModaleMesThemes.labels";
 
@@ -25,4 +27,6 @@ const themes = computed(() => {
 const themeIds = computed(() => {
     return Object.keys(themes.value).filter((id) => id !== "autre");
 });
+
+const values = useFormValues();
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/72Qkeyuw/1911-bug-le-message-derreur-des-checkbox-nest-plus-correct-voir-par-exemple-journal-du-site-et-tags

## 🛠 Description de la PR
Pour certaines checkbox reliées à un tableau de valeurs, l'absence de v-model faisait que la checkbox était initialisée avec false et non avec un tableau vide
Checkbox identifiées: tags du journal du site, themes de la modale intervenants