### PR TITLE
#patch (1917) Espace d'entraide — Le bouton "Demander" n'est pas aligné avec son champ

### DIFF
--- a/packages/frontend/webapp/src/components/Entraide/EntraideBanniere.vue
+++ b/packages/frontend/webapp/src/components/Entraide/EntraideBanniere.vue
@@ -25,9 +25,10 @@
                 @submit="redirectToNewQuestion"
             >
                 <TextInput
-                    class="mb-0 flex-1"
+                    class="flex-1"
                     placeholder="Votre question ... "
                     v-model="question"
+                    withoutMargin="true"
                 />
                 <Button size="sm">Demander</Button>
             </form>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/2oYmNCrv/1917-espace-dentraide-le-bouton-demander-nest-pas-align%C3%A9-avec-son-champ

## 🛠 Description de la PR
Le textInput n'avait pas la propriété withoutMargin = "true", ce qui introduisait une marge à l'origine du décalage