### PR TITLE
#patch (1913) Bug — Le clic sur "X messages" de la carte site du TB ne redirige pas toujours vers le journal

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSite/CarteSite.vue
+++ b/packages/frontend/webapp/src/components/CarteSite/CarteSite.vue
@@ -77,7 +77,7 @@
 
             <!-- journal du site -->
             <p v-if="numberOfComments > 0" class="mt-6">
-                <Link :to="`/site/${shantytown.id}#journal_du_site`"
+                <Link @click.stop="routeToJournalDuSite"
                     >{{ numberOfComments }} message{{
                         numberOfComments !== 1 ? "s" : ""
                     }}
@@ -86,7 +86,7 @@
         </main>
 
         <footer class="mt-auto">
-            <Link :to="`/site/${shantytown.id}`" @click="routeToDetailsPage"
+            <Link @click="routeToDetailsPage"
                 >Voir la fiche du site <Icon icon="arrow-right"
             /></Link>
         </footer>
@@ -125,5 +125,9 @@ const numberOfComments = computed(
 
 function routeToDetailsPage() {
     router.push(`/site/${shantytown.value.id}`);
+}
+
+function routeToJournalDuSite() {
+    router.push(`/site/${shantytown.value.id}#journal_du_site`);
 }
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kXq1OQvH/1913-bug-le-clic-sur-x-messages-de-la-carte-site-du-tb-ne-redirige-pas-toujours-vers-le-journal

## 🛠 Description de la PR
lorsque l'on clique sur "X messages", il semble les deux redirections sont faites en même temps (vers le site, et vers le journal) 

en remplaçant :to = "..." par @click.stop = "..." on peut stopper la propagation