### PR TITLE
#minor (1909) étendre les droits d'export des sites à une date passée

### DIFF
--- a/packages/api/db/migrations/30000062-01-extend-shantytown_history-export-permissions.js
+++ b/packages/api/db/migrations/30000062-01-extend-shantytown_history-export-permissions.js
@@ -1,0 +1,87 @@
+const shantytownExportPermissionsRequest = `
+    SELECT
+        rp.fk_role_regular as "role_regular",
+        rp.fk_role_admin as "role_admin",
+        rp.fk_feature as "feature",
+        rp.fk_entity as "entity",
+        rp.allowed as "allowed",
+        rp.allow_all as "allow_all"
+    FROM
+        role_permissions rp
+    LEFT JOIN
+        role_permissions rp2 
+    ON
+        rp.fk_role_regular = rp2.fk_role_regular
+    AND 
+        rp2.fk_feature = 'export'
+    AND 
+        rp2.fk_entity = 'shantytown_history'
+    LEFT JOIN role_permissions rp3
+    ON
+        rp.fk_role_admin = rp3.fk_role_admin
+    AND 
+        rp3.fk_feature = 'export'
+    AND 
+        rp3.fk_entity = 'shantytown_history'
+    WHERE 
+        rp.fk_feature = 'export'
+    AND
+        rp.fk_entity = 'shantytown'
+    AND
+        rp2.role_permission_id IS NULL
+    AND
+        rp3.role_permission_id IS NULL`;
+
+function isEmpty(str) {
+    return (!str || str.length === 0);
+}
+
+
+module.exports = {
+    async up(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+        const shantytownExportPermissions = await queryInterface.sequelize.query(
+            shantytownExportPermissionsRequest,
+            {
+                type: queryInterface.sequelize.QueryTypes.SELECT,
+                transaction,
+            },
+        );
+
+        await Promise.all(shantytownExportPermissions.reduce((acc, permission) => {
+            if (!isEmpty(permission.role_regular)) {
+                acc.push(queryInterface.sequelize.query(`
+                    INSERT INTO role_permissions (fk_role_regular, fk_role_admin, fk_feature, fk_entity, allowed, allow_all)
+                    VALUES (:fkRoleRegular, NULL, :fkFeature, 'shantytown_history', :allowed, :allowAll)`, {
+                    transaction,
+                    replacements: {
+                        fkRoleRegular: permission.role_regular,
+                        fkFeature: permission.feature,
+                        fkEntity: permission.entity,
+                        allowed: permission.allowed,
+                        allowAll: permission.allow_all,
+                    },
+                }));
+            } else if (!isEmpty(permission.role_admin)) {
+                acc.push(queryInterface.sequelize.query(`
+                    INSERT INTO role_permissions (fk_role_regular, fk_role_admin, fk_feature, fk_entity, allowed, allow_all)
+                    VALUES (NULL, :fkRoleAdmin, :fkFeature, 'shantytown_history', :allowed, :allowAll)`, {
+                    transaction,
+                    replacements: {
+                        fkRoleAdmin: permission.role_admin,
+                        fkFeature: permission.feature,
+                        fkEntity: permission.entity,
+                        allowed: permission.allowed,
+                        allowAll: permission.allow_all,
+                    },
+                }));
+            }
+            return acc;
+        }, []));
+        return transaction.commit();
+    },
+
+    down: queryInterface => queryInterface.sequelize.query(
+        "DELETE FROM role_permissions WHERE fk_entity = 'shantytown_history' AND fk_feature = 'export' AND (fk_role_admin NOT IN ('national_admin') OR fk_role_admin IS NULL)",
+    ),
+};

--- a/packages/api/server/controllers/townController/export.ts
+++ b/packages/api/server/controllers/townController/export.ts
@@ -4,7 +4,7 @@ const { exportTown } = shantytownService;
 
 const ERROR_RESPONSES = {
     fetch_failed: { code: 400, message: 'Une lecture en base de données a échoué' },
-    access_denied: { code: 403, message: 'Accès refusé' },
+    permission_denied: { code: 403, message: 'Accès refusé' },
     write_failed: { code: 500, message: 'Une écriture en base de données a échoué' },
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };

--- a/packages/api/server/services/shantytown/exportTown.spec.ts
+++ b/packages/api/server/services/shantytown/exportTown.spec.ts
@@ -106,10 +106,20 @@ describe('services/shantytown', () => {
                 } catch (error) {
                     // ignore
                 }
-                expect(stubs.can).to.have.been.calledOnceWith(user);
-                expect(stubs.do).to.have.been.calledOnceWith('export', 'shantytown');
-                expect(stubs.on).to.have.been.calledOnceWith(location);
+                expect(stubs.can).to.have.been.calledWith(user);
+                expect(stubs.do).to.have.been.calledWith('export', 'shantytown');
+                expect(stubs.on).to.have.been.calledWith(location);
             });
+            it('vérifie que l\'utilisateur a le droit d\'exporter les sites à une date passée', async () => {
+                try {
+                    await exportTownService(user, data);
+                } catch (error) {
+                    // ignore
+                }
+                expect(stubs.can).to.have.been.calledWith(user);
+                expect(stubs.do).to.have.been.calledWith('export', 'shantytown_history');
+            });
+
             it('renvoie une exception ServiceError \'permission_denied\' si l\'utilisateur n\'a pas la permission', async () => {
                 stubs.on.returns(false);
                 let responseError;

--- a/packages/api/server/services/shantytown/exportTown.spec.ts
+++ b/packages/api/server/services/shantytown/exportTown.spec.ts
@@ -125,10 +125,7 @@ describe('services/shantytown', () => {
                 const pastDate = moment().subtract(1, 'days').format('YYYY-MM-DD'); // Date d'hier
                 const dataWithPastDate = { ...data, date: pastDate };
 
-                // 1. On simuler le succès du premier test de permission (retourne true dès le premier appel à can())
-                stubs.can.returns({ do: sinon.stub().returns({ on: sinon.stub().returns(true) }) });
-
-                // 2. On simule l'échec du deuxième test de permission en retournant false dès le deuxième appel à can()
+                // On simule l'échec du deuxième test de permission en retournant false dès le deuxième appel à can()
                 const doStub = sinon.stub();
                 doStub.onFirstCall().returns({ on: sinon.stub().returns(true) });
                 doStub.onSecondCall().returns({ on: sinon.stub().returns(false) });

--- a/packages/api/server/services/shantytown/exportTown.ts
+++ b/packages/api/server/services/shantytown/exportTown.ts
@@ -32,9 +32,6 @@ export default async (user, data) => {
 
     const today = new Date();
 
-    if (user.is_superuser === false && moment(data.date).format('YYYY-MM-DD') !== moment(today).format('YYYY-MM-DD')) {
-        throw new ServiceError('permission_denied', new Error('Vous n\'êtes pas autorisé(e) à exporter des données passées'));
-    }
     const closedTowns = parseInt(data.closedTowns, 10) === 1;
     const filters = [
         {

--- a/packages/api/server/services/shantytown/exportTown.ts
+++ b/packages/api/server/services/shantytown/exportTown.ts
@@ -32,6 +32,10 @@ export default async (user, data) => {
 
     const today = new Date();
 
+    if (!permissionUtils.can(user).do('export', 'shantytown_history') && moment(data.date).format('YYYY-MM-DD') !== moment(today).format('YYYY-MM-DD')) {
+        throw new ServiceError('permission_denied', new Error('Vous n\'êtes pas autorisé(e) à exporter des données passées'));
+    }
+
     const closedTowns = parseInt(data.closedTowns, 10) === 1;
     const filters = [
         {

--- a/packages/api/server/services/shantytown/exportTown.ts
+++ b/packages/api/server/services/shantytown/exportTown.ts
@@ -32,7 +32,7 @@ export default async (user, data) => {
 
     const today = new Date();
 
-    if (!permissionUtils.can(user).do('export', 'shantytown_history') && moment(data.date).format('YYYY-MM-DD') !== moment(today).format('YYYY-MM-DD')) {
+    if (!permissionUtils.can(user).do('export', 'shantytown_history').on(location) && moment(data.date).format('YYYY-MM-DD') !== moment(today).format('YYYY-MM-DD')) {
         throw new ServiceError('permission_denied', new Error('Vous n\'êtes pas autorisé(e) à exporter des données passées'));
     }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/u58JdhF1

## 🛠 Description de la PR
- Ajout d'une migration qui étend le droit d'exporter la liste des sites à une date passée aux rôles ayant le droit d'export des sites.
- La migration `down` supprime le droit d'export à une date passée à tous les rôles sauf  'national_admin' qui était le seul à disposer de ce droit avant l'exécution de la migration `up`

## 🚨 Notes pour la mise en production
- Exécuter la migration `30000062-01-extend-shantytown_history-export-permissions.js`