### PR TITLE
#patch (1966) Corriger le formulaire de contact et le LanguagePicker

### DIFF
--- a/packages/frontend/ui/src/components/LanguagePicker.vue
+++ b/packages/frontend/ui/src/components/LanguagePicker.vue
@@ -1,48 +1,16 @@
 <template>
-  <Dropdown>
-    <template v-slot:button>
-      <Button variant="primaryOutline" icon="chevron-down">
-        <img v-if="language === 'fr'" width="24" height="24" src="./assets/img/languages/FR.svg"
-          class="inline-block h-6" alt="Version Française" />
-        <img v-if="language === 'en'" width="24" height="24" src="./assets/img/languages/UK.svg"
-          class="inline-block h-6" alt="English version" />
-        <img v-if="language === 'ro'" width="24" height="24" src="./assets/img/languages/RO.svg"
-          class="inline-block h-6" alt="Versiunea Romaneasca" />
-        <img v-if="language === 'bg'" width="24" height="24" src="./assets/img/languages/BG.svg"
-          class="inline-block h-6" alt="Versiunea Bulgară" />
-        {{ " " }}
-        <span class="uppercase">{{ language }}</span>
-      </Button>
-    </template>
-    <template v-slot:menu="{ closeMenu }">
-      <Menu @click="closeMenu">
-        <MenuItem @click="pickLang('fr')">
-        <img src="./assets/img/languages/FR.svg" class="inline-block h-6" width="24" height="24"
-          alt="Version Française" /> FR
-        </MenuItem>
-        <MenuItem @click="pickLang('en')">
-        <img src="./assets/img/languages/UK.svg" class="inline-block h-6" width="24" height="24"
-          alt="English version" /> EN
-        </MenuItem>
-        <MenuItem @click="pickLang('ro')">
-        <img src="./assets/img/languages/RO.svg" class="inline-block h-6" width="24" height="24"
-          alt="Versiunea Romaneasca" /> RO
-        </MenuItem>
-        <MenuItem @click="pickLang('bg')">
-        <img src="./assets/img/languages/BG.svg" class="inline-block h-6" width="24" height="24"
-          alt="Versiunea Bulgară" /> BG
-        </MenuItem>
-      </Menu>
-    </template>
-  </Dropdown>
+  <select @change="pickLang($event.target.value)"
+    class="focus:ring-2 ring-offset-2 ring-info bg-white text-lg border-2 border-primary text-primary focus:outline-none p-2"
+    name="language" label="Langue" :disabled="disabled">
+    <option class="hover:bg-primary" v-for="lang in languages" :key="lang.key" :alt="lang.alt" :value="lang.key"
+      @change="pickLang(lang.key)">
+      {{ lang.flag }} {{ lang.label }}
+    </option>
+  </select>
 </template>
 
 <script setup>
-import { toRefs, defineProps, defineEmits } from 'vue';
-import Dropdown from "./Dropdown.vue";
-import Menu from "./Menu/Menu.vue";
-import MenuItem from "./Menu/MenuItem.vue";
-import Button from "./Button.vue";
+import { computed, toRefs, defineProps, defineEmits, watch } from 'vue';
 
 const props = defineProps({
   language: {
@@ -50,9 +18,37 @@ const props = defineProps({
   },
 });
 const { language } = toRefs(props);
-const emit = defineEmits(['update:modelValue'])
+const languages = [
+  { key: 'fr', label: 'Français', alt: 'Version Française', flag: getFlagEmoji("fr") },
+  { key: 'en', label: 'English', alt: 'English Version', flag: getFlagEmoji("en") },
+  { key: 'ro', label: 'Românesc', alt: 'Versiunea în limba română', flag: getFlagEmoji("ro") },
+  { key: 'bg', label: 'Български', alt: 'Българска версия', flag: getFlagEmoji("bg") },
+];
+const emit = defineEmits(['update:modelValue']);
 function pickLang(lang) {
   emit('update:modelValue', lang)
-
+}
+function getFlagEmoji(countryCode) {
+  switch (countryCode) {
+    case 'fr':
+      return "🇫🇷";
+      break;
+    case 'en':
+      return "🇬🇧";
+      break;
+    case 'ro':
+      return "🇷🇴";
+      break;
+    case 'bg':
+      return "🇧🇬";
+      break;
+    default:
+      return "🇫🇷";
+  }
 }
 </script>
+<style scoped>
+select.decorated option:hover {
+  box-shadow: 0 0 10px 100px #1882A8 inset;
+}
+</style>

--- a/packages/frontend/ui/src/components/LanguagePicker.vue
+++ b/packages/frontend/ui/src/components/LanguagePicker.vue
@@ -3,14 +3,14 @@
     class="focus:ring-2 ring-offset-2 ring-info bg-white text-lg border-2 border-primary text-primary focus:outline-none p-2"
     name="language" label="Langue" :disabled="disabled">
     <option class="hover:bg-primary" v-for="lang in languages" :key="lang.key" :alt="lang.alt" :value="lang.key"
-      @change="pickLang(lang.key)">
+      :lang="lang.key" @change="pickLang(lang.key)">
       {{ lang.flag }} {{ lang.label }}
     </option>
   </select>
 </template>
 
 <script setup>
-import { computed, toRefs, defineProps, defineEmits, watch } from 'vue';
+import { toRefs, defineProps, defineEmits } from 'vue';
 
 const props = defineProps({
   language: {
@@ -32,16 +32,12 @@ function getFlagEmoji(countryCode) {
   switch (countryCode) {
     case 'fr':
       return "🇫🇷";
-      break;
     case 'en':
       return "🇬🇧";
-      break;
     case 'ro':
       return "🇷🇴";
-      break;
     case 'bg':
       return "🇧🇬";
-      break;
     default:
       return "🇫🇷";
   }

--- a/packages/frontend/ui/src/components/LanguagePicker.vue
+++ b/packages/frontend/ui/src/components/LanguagePicker.vue
@@ -1,7 +1,7 @@
 <template>
   <select @change="pickLang($event.target.value)"
     class="focus:ring-2 ring-offset-2 ring-info bg-white text-lg border-2 border-primary text-primary focus:outline-none p-2"
-    name="language" label="Langue" :disabled="disabled">
+    name="language" :label="language === 'fr' ? 'Change language' : 'Changer la langue'" :disabled="disabled">
     <option class="hover:bg-primary" v-for="lang in languages" :key="lang.key" :alt="lang.alt" :value="lang.key"
       :lang="lang.key" @change="pickLang(lang.key)">
       {{ lang.flag }} {{ lang.label }}

--- a/packages/frontend/ui/src/index.mjs
+++ b/packages/frontend/ui/src/index.mjs
@@ -14,7 +14,7 @@ export { default as ErrorSummary } from './components/ErrorSummary.vue';
 export { default as FilArianne } from './components/FilArianne.vue';
 export { default as Filter } from './components/Filter.vue';
 export { default as FooterBar } from './components/FooterBar/FooterBar.vue';
-export { default as FormParagraph} from './components/FormParagraph.vue';
+export { default as FormParagraph } from './components/FormParagraph.vue';
 export { default as Icon } from './components/Icon.vue';
 export { default as IdentiteVisuelle } from './components/IdentiteVisuelle/IdentiteVisuelle.vue';
 export { default as InputGroup } from './components/Input/InputGroup.vue';

--- a/packages/frontend/webapp/src/components/FormPublic/FormPublic.vue
+++ b/packages/frontend/webapp/src/components/FormPublic/FormPublic.vue
@@ -4,6 +4,7 @@
         @submit="formSubmit"
         ref="form"
         v-slot="{ values, errors }"
+        :lang="language"
     >
         <!-- form header (title and description) -->
         <header class="text-center mb-8">
@@ -72,11 +73,15 @@ const props = defineProps({
         type: Boolean,
         default: true,
     },
+    language: {
+        type: String,
+        default: "fr",
+    },
 });
 
 const form = ref(null);
 const error = ref(null);
-const { schema, submit, size, showErrorSummary } = toRefs(props);
+const { schema, submit, size, showErrorSummary, language } = toRefs(props);
 
 async function formSubmit(...args) {
     error.value = null;

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
@@ -1,5 +1,10 @@
 <template>
-    <FormPublic :schema="schema" :submit="intermediateSubmit" ref="form">
+    <FormPublic
+        :schema="schema"
+        :submit="intermediateSubmit"
+        :language="language"
+        ref="form"
+    >
         <template v-slot:subtitle><slot name="subtitle" /></template>
         <template v-slot:title><slot name="title" /></template>
 

--- a/packages/frontend/www/components/LandingPage/FourthSection/LandingPageFourthSection.vue
+++ b/packages/frontend/www/components/LandingPage/FourthSection/LandingPageFourthSection.vue
@@ -164,20 +164,36 @@
         </div>
 
         <div class="flex flex-row flex-wrap items-center justify-center mt-8 lg:flex-nowrap lg:justify-between">
-            <a href="https://solidarites-sante.gouv.fr/"><img width="200" height="118" class="h-auto m-2"
+            <a href="https://www.gouvernement.fr/" hreflang="fr"
+                aria-label="Lien vers le site du gouvernement de l'État Francais,">
+                <img width="200" height="118" class="h-auto m-2"
                     src="~/assets/img/LandingPage/FourthSection/logo-gouvernement.jpg"
-                    alt="Marque de l'État Francais" /></a>
-            <a href="https://ec.europa.eu/info/index_en"><img width="460" height="111" class="h-auto m-2"
+                    alt="Logo du site du gouvernement Francais" />
+            </a>
+            <a href="https://ec.europa.eu/info/index_fr" hreflang="fr"
+                aria-label="Lien vers le site de la Commission Européenne">
+                <img width="460" height="111" class="h-auto m-2"
                     src="~/assets/img/LandingPage/FourthSection/logo-commission-europenne.png"
-                    alt="Logo de la Commission Européenne" /></a>
-            <a href="https://beta.gouv.fr/communaute/#/incubators/mtes"><img width="96" height="96" class="h-auto m-2"
+                    alt="Logo de la Commission Européenne" />
+            </a>
+            <a href="https://beta.gouv.fr/communaute/#/incubators/mtes" hreflang="fr"
+                aria-label="Lien vers le site de la Fabrique Numérique">
+                <img width="96" height="96" class="h-auto m-2"
                     src="~/assets/img/LandingPage/FourthSection/logo-fabrique-numerique.png"
-                    alt="Logo de la Fabrique Numérique" /></a>
-            <a class="pl-12" href="https://beta.gouv.fr/"><img width="160" height="80" class="h-auto m-2"
-                    src="~/assets/img/LandingPage/FourthSection/logo_beta-gouv-fr.jpg" alt="Logo de beta.gouv" /></a>
-            <a class="pl-12" href="https://eig.etalab.gouv.fr/defis/resorption-bidonvilles/"><img width="330" height="72"
-                    class="h-auto m-2" src="~/assets/img/LandingPage/FourthSection/logo-entrepreneur-interet-general.png"
-                    alt="Logo des Entrepreneurs d'Intérêt Général" /></a>
+                    alt="Logo de la Fabrique Numérique" />
+            </a>
+            <a class="pl-12" href="https://beta.gouv.fr/" hreflang="fr"
+                aria-label="Lien vers le site de l'incubateur de services publiques numériques - beta.gouv">
+                <img width="160" height="80" class="h-auto m-2"
+                    src="~/assets/img/LandingPage/FourthSection/logo_beta-gouv-fr.jpg"
+                    alt="Logo de l'incubateur de services publiques numériques" />
+            </a>
+            <a class="pl-12" href="https://eig.etalab.gouv.fr/defis/resorption-bidonvilles/" hreflang="fr"
+                aria-label="Lien vers le site des Entrepreneurs d'Intérêt Général">
+                <img width="330" height="72" class="h-auto m-2"
+                    src="~/assets/img/LandingPage/FourthSection/logo-entrepreneur-interet-general.png"
+                    alt="Logo des Entrepreneurs d'Intérêt Général" />
+            </a>
         </div>
     </div>
 </template>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/IM5lnIgT
**[Accessibilité - 8.7 + 7.3]**

## 🛠 Description de la PR
- Pour les logos institutionnels au bas de la landing, modifier la valeur de l'attribut `alt` pour refléter au plus juste la destination du lien (supprimer les mentions “marque” ou “logo”) et en reprenant tout ou partie du texte présent dans l’image
- Le second lien qui pointe vers le site de la Commission européenne a été modifié pour afficher la page en langue française.
- Les options du composant permettant de choisir la langue ont été rendues navigables au clavier en transformant le composant en liste `select` et une balise `lang` a été ajoutée aux options dans chaque langue corrspondante pour améliorer le traitement par les lecteurs d'écrans et autres technologies d'assistance.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/50863659/05908ccf-7afe-4fc4-8b3a-e258c3628583)

## 🚨 Notes pour la mise en production
ràs