### PR TITLE
#patch (1990) Améliorer l'accessibilité du formulaire de connexion

### DIFF
--- a/packages/frontend/ui/src/components/Input/PasswordInput.vue
+++ b/packages/frontend/ui/src/components/Input/PasswordInput.vue
@@ -1,16 +1,10 @@
 <template>
     <div class="relative">
-        <TextInput
-            :type="this.hidden ? 'password' : 'text'"
-            v-bind="$attrs"
-            @input="$emit('input', $event)"
-        >
+        <TextInput :type="this.hidden ? 'password' : 'text'" v-bind="$attrs" @input="$emit('input', $event)">
             <template v-slot:suffix>
-                <Icon
-                    class="absolute right-8 cursor-pointer"
-                    :icon="hidden ? 'fa-eye-slash fa-regular' : 'fa-eye fa-regular'"
-                    @click="toggleHidden"
-                />
+                <Icon class="absolute right-8 cursor-pointer"
+                    :icon="hidden ? 'fa-eye-slash fa-regular' : 'fa-eye fa-regular'" tabindex="0" :aria-label="hidden ? 'Valider pour afficher le mot de passe'
+                        : 'Valider pour masquer le mot de passe'" @click="toggleHidden" @keyup.enter="toggleHidden" />
             </template>
         </TextInput>
     </div>

--- a/packages/frontend/ui/src/components/Input/utils/InputError.vue
+++ b/packages/frontend/ui/src/components/Input/utils/InputError.vue
@@ -1,3 +1,5 @@
 <template>
-    <div class="text-error mt-2"><slot /></div>
+    <div class="text-error mt-2" aria-live="assertive">
+        <slot />
+    </div>
 </template>

--- a/packages/frontend/webapp/src/components/FormConnexion/FormConnexion.vue
+++ b/packages/frontend/webapp/src/components/FormConnexion/FormConnexion.vue
@@ -11,18 +11,26 @@
         size="small"
         :showErrorSummary="false"
     >
-        <template v-slot:title
-            >Connectez-vous à<br />Résorption-bidonvilles</template
-        >
+        <template v-slot:title>
+            Connectez-vous à<br />Résorption-bidonvilles
+        </template>
 
         <template v-slot:body>
-            <FormConnexionInputEmail />
-            <FormConnexionInputPassword />
+            <FormConnexionInputEmail
+                aria-label="Veuillez saisir l'adresse de messagerie correspondant à votre identifiant sur la plateforme"
+            />
+            <FormConnexionInputPassword
+                aria-label="Veuillez saisir votre mot de passe"
+            />
         </template>
 
         <template v-slot:button>
             <p class="text-center">
-                <Button type="submit">Me connecter</Button>
+                <Button
+                    type="submit"
+                    aria-label="Valider les informations saisies,"
+                    >Me connecter</Button
+                >
             </p>
         </template>
 

--- a/packages/frontend/webapp/src/components/FormConnexion/inputs/FormConnexionInputEmail.vue
+++ b/packages/frontend/webapp/src/components/FormConnexion/inputs/FormConnexionInputEmail.vue
@@ -3,6 +3,7 @@
         id="email"
         :label="label"
         placeholder="marcel.dupont@exemple.fr"
+        autocomplete="username"
     />
 </template>
 

--- a/packages/frontend/webapp/src/components/FormConnexion/inputs/FormConnexionInputPassword.vue
+++ b/packages/frontend/webapp/src/components/FormConnexion/inputs/FormConnexionInputPassword.vue
@@ -1,5 +1,5 @@
 <template>
-    <PasswordInput id="password" :label="label" />
+    <PasswordInput id="password" :label="label" autocomplete="password" />
 </template>
 
 <script setup>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/VAiGaJxl/1990

## 🛠 Description de la PR
- Rendre les messages d'erreurs de saisie accessibles en ajoutant la possibilité aux mal-voyants de les entendre
- Rendre accessible le bouton afficher/masquer le mot de passe en permettant d'y accéder via la touche tabulation et d'entendre le label Aria associé indiquant qu'on peut afficher le mot de passe s'il est masqué et inversement
- améliorer l'accessibilité des éléments du formulaire en ajoutant un label Aria sur les zones de saisie et un message plus détaillé sur le bouton "Me connecter"
- Ajouter un attribut `autocomplete` aux éléments `username` et `PasswordI`
