### PR TITLE
#patch (1986) inverser la logique de sélection du label

### DIFF
--- a/packages/frontend/ui/src/components/LanguagePicker.vue
+++ b/packages/frontend/ui/src/components/LanguagePicker.vue
@@ -1,7 +1,7 @@
 <template>
   <select @change="pickLang($event.target.value)"
     class="focus:ring-2 ring-offset-2 ring-info bg-white text-lg border-2 border-primary text-primary focus:outline-none p-2"
-    name="language" :label="language === 'fr' ? 'Change language' : 'Changer la langue'" :disabled="disabled">
+    name="language" :label="language === 'fr' ? 'Changer la langue' : 'Change language'" :disabled="disabled">
     <option class="hover:bg-primary" v-for="lang in languages" :key="lang.key" :alt="lang.alt" :value="lang.key"
       :lang="lang.key" @change="pickLang(lang.key)">
       {{ lang.flag }} {{ lang.label }}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kFnjua60/1986

## 🛠 Description de la PR
Actuellement, si le français est sélectionné dans le composant "LanguagePicker", c’est un label en anglais qui indique “Change language” et pour toutes les autres langues choisies, le label est en français. Il faut inverser la langue et afficher le label en anglais pour toutes les langues sauf le français.