### PR TITLE
#patch (2001) Désactivation des boutons submit pendant le chargement des formulaires

### DIFF
--- a/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.vue
@@ -67,7 +67,7 @@ const mode = computed(() => {
     return action.value === null ? "create" : "edit";
 });
 const validationSchema = schemaFn(mode.value);
-const { handleSubmit, values, errors, setErrors } = useForm({
+const { handleSubmit, values, errors, setErrors, isSubmitting } = useForm({
     validationSchema,
     initialValues: formatFormAction(
         action.value || {
@@ -237,5 +237,6 @@ defineExpose({
             }
         }
     }),
+    isSubmitting,
 });
 </script>

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -121,7 +121,7 @@ const minUpdatedAt = computed(() => {
     return updatedAt;
 });
 const validationSchema = schemaFn(mode.value);
-const { handleSubmit, values, errors, setErrors } = useForm({
+const { handleSubmit, values, errors, setErrors, isSubmitting } = useForm({
     validationSchema,
     initialValues,
 });
@@ -322,5 +322,6 @@ defineExpose({
             }
         }
     }),
+    isSubmitting,
 });
 </script>

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
@@ -98,7 +98,7 @@ const peopleWithSolutions = computed(() => {
     return ((total / town.value.populationTotal) * 100).toFixed(0);
 });
 
-const { handleSubmit, setErrors } = useForm({
+const { handleSubmit, setErrors, isSubmitting } = useForm({
     validationSchema: schema,
     initialValues: {
         closed_at: town.value.closedAt
@@ -194,5 +194,6 @@ defineExpose({
             }
         }
     }),
+    isSubmitting,
 });
 </script>

--- a/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
+++ b/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
@@ -42,7 +42,7 @@ import FormNouvelleQuestionInputDetails from "./inputs/FormNouvelleQuestionInput
 import FormNouvelleQuestionInputTags from "./inputs/FormNouvelleQuestionInputTags.vue";
 import FormNouvelleQuestionInputOtherTag from "./inputs/FormNouvelleQuestionInputOtherTag.vue";
 
-const { handleSubmit, setErrors, errors } = useForm({
+const { handleSubmit, setErrors, errors, isSubmitting } = useForm({
     validationSchema: schema,
     initialValues: {
         question: router.currentRoute.value.query?.resume || "",
@@ -87,5 +87,6 @@ defineExpose({
             }
         }
     }),
+    isSubmitting,
 });
 </script>

--- a/packages/frontend/webapp/src/views/DeclarationActionView.vue
+++ b/packages/frontend/webapp/src/views/DeclarationActionView.vue
@@ -5,7 +5,9 @@
             <Button variant="primaryOutline" type="button" @click="back"
                 >Annuler</Button
             >
-            <Button @click="submit">Déclarer l'action</Button>
+            <Button @click="submit" :loading="form?.isSubmitting"
+                >Déclarer l'action</Button
+            >
         </template>
 
         <ContentWrapper size="large">

--- a/packages/frontend/webapp/src/views/DeclarationDeSiteView.vue
+++ b/packages/frontend/webapp/src/views/DeclarationDeSiteView.vue
@@ -5,7 +5,9 @@
             <Button variant="primaryOutline" type="button" @click="back"
                 >Annuler</Button
             >
-            <Button @click="submit">Déclarer le site</Button>
+            <Button @click="submit" :loading="form?.isSubmitting"
+                >Déclarer le site</Button
+            >
         </template>
 
         <ContentWrapper size="large">

--- a/packages/frontend/webapp/src/views/FermetureDeSiteView.vue
+++ b/packages/frontend/webapp/src/views/FermetureDeSiteView.vue
@@ -32,7 +32,9 @@
             <Button variant="primaryOutline" type="button" @click="back"
                 >Annuler</Button
             >
-            <Button @click="submit">{{ submitWording }}</Button>
+            <Button @click="submit" :loading="form?.isSubmitting">{{
+                submitWording
+            }}</Button>
         </template>
 
         <ContentWrapper size="intermediate">

--- a/packages/frontend/webapp/src/views/MiseAJourActionView.vue
+++ b/packages/frontend/webapp/src/views/MiseAJourActionView.vue
@@ -31,7 +31,9 @@
             <Button variant="primaryOutline" type="button" @click="back"
                 >Annuler</Button
             >
-            <Button @click="submit">Mettre à jour l'action</Button>
+            <Button @click="submit" :loading="form?.isSubmitting"
+                >Mettre à jour l'action</Button
+            >
         </template>
 
         <ContentWrapper size="large">

--- a/packages/frontend/webapp/src/views/MiseAJourDeSiteView.vue
+++ b/packages/frontend/webapp/src/views/MiseAJourDeSiteView.vue
@@ -32,7 +32,9 @@
             <Button variant="primaryOutline" type="button" @click="back"
                 >Annuler</Button
             >
-            <Button @click="submit">Mettre à jour le site</Button>
+            <Button @click="submit" :loading="form?.isSubmitting"
+                >Mettre à jour le site</Button
+            >
         </template>
 
         <ContentWrapper size="large">

--- a/packages/frontend/webapp/src/views/NouvelleQuestionCommunauteView.vue
+++ b/packages/frontend/webapp/src/views/NouvelleQuestionCommunauteView.vue
@@ -6,7 +6,9 @@
             <Button variant="primaryOutline" type="button" @click="back"
                 >Annuler</Button
             >
-            <Button @click="submit">Publier</Button>
+            <Button @click="submit" :loading="form?.isSubmitting"
+                >Publier</Button
+            >
         </template>
 
         <ContentWrapper size="large">

--- a/packages/frontend/webapp/src/views/SignalementDeSiteView.vue
+++ b/packages/frontend/webapp/src/views/SignalementDeSiteView.vue
@@ -5,7 +5,7 @@
             <Button variant="primaryOutline" type="button" @click="back"
                 >Annuler</Button
             >
-            <Button @click="submit"
+            <Button @click="submit" :loading="form?.isSubmitting"
                 >Envoyer l'information aux administrateurs</Button
             >
         </template>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/erMMTiPO/2001

## 🛠 Description de la PR
Le helper `useIsSubmitting()` utilisé par le composant `Button` ne fonctionne pas dans le cadre d'un `FormLayout` car le bouton se trouve en dehors de la définition du formulaire vee-validate.

La solution identifiée comme la plus simple est de récupérer l'état `isSubmitting` au niveau de chaque formulaire, de l'exposer à la view qui l'utilise et enfin de le faire parvenir au button concerné.