### PR TITLE
#patch (1985) Ajoute des liens d'évitement de la carto

### DIFF
--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -4,7 +4,8 @@
             href="#"
             v-if="displaySkipMapLinks"
             class="sr-only"
-            @click.prevent="skipMap(skipFocusNext)"
+            @click.prevent="skipMap(skipFocusNext, skipPreviousLink)"
+            ref="skipNextLink"
             >&Eacute;viter la carte</a
         >
         <div id="map" class="h-full border">
@@ -37,7 +38,8 @@
             href="#"
             v-if="displaySkipMapLinks"
             class="sr-only"
-            @click.prevent="skipMap(skipFocusPrevious)"
+            @click.prevent="skipMap(skipFocusPrevious, skipNextLink)"
+            ref="skipPreviousLink"
             >&Eacute;viter la carte</a
         >
     </section>
@@ -167,6 +169,8 @@ const {
 } = toRefs(props);
 
 const map = ref(null);
+const skipNextLink = ref(null);
+const skipPreviousLink = ref(null);
 const printer = ref(null);
 const currentMarkerGroup = ref(null);
 
@@ -380,9 +384,8 @@ function createLocationMarker(level, location) {
     marker.addTo(markersGroup[level].value);
 }
 
-function skipMap(skipMapFunc) {
-    const map = document.getElementById("map");
-    if (map && skipMapFunc(map)) {
+function skipMap(skipMapFunc, el) {
+    if (el && skipMapFunc(el)) {
         window.scrollTo(0, getAbsoluteOffsetTop(document.activeElement));
     }
 }

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -1,4 +1,11 @@
 <template>
+    <a
+        href="#"
+        v-if="displaySkipMapLinks"
+        class="sr-only"
+        @click.prevent="skipMap(skipFocusNext, mapRef)"
+        >&Eacute;viter la carte</a
+    >
     <section class="h-full relative">
         <div id="map" class="h-full border">
             <div
@@ -27,6 +34,13 @@
             <slot />
         </div>
     </section>
+    <a
+        href="#"
+        v-if="displaySkipMapLinks"
+        class="sr-only"
+        @click="skipMap(skipFocusPrevious, mapRef)"
+        >&Eacute;viter la carte</a
+    >
 </template>
 
 <style>
@@ -40,7 +54,7 @@ export default {
 </script>
 
 <script setup>
-import { ref, toRefs, onMounted, onBeforeUnmount, watch } from "vue";
+import { ref, toRefs, onMounted, onBeforeUnmount, watch, computed } from "vue";
 import L from "leaflet";
 import domtoimage from "dom-to-image-more";
 import "leaflet.markercluster/dist/MarkerCluster.css";
@@ -55,6 +69,14 @@ import formatDate from "@common/utils/formatDate";
 
 import { Icon, Spinner } from "@resorptionbidonvilles/ui";
 import { trackEvent } from "@/helpers/matomo";
+
+import getAbsoluteOffsetTop from "@/utils/getAbsoluteOffsetTop";
+import skipFocusNext from "@/utils/skipFocusNext";
+import skipFocusPrevious from "@/utils/skipFocusPrevious";
+
+const mapRef = computed(() => {
+    return document.getElementById("map");
+});
 
 const props = defineProps({
     isLoading: {
@@ -127,6 +149,11 @@ const props = defineProps({
         default: (...args) => {
             return marqueurLocationDefault(...args);
         },
+    },
+    displaySkipMapLinks: {
+        type: Boolean,
+        required: false,
+        default: false,
     },
 });
 const {
@@ -354,6 +381,12 @@ function createLocationMarker(level, location) {
         });
 
     marker.addTo(markersGroup[level].value);
+}
+
+function skipMap(skipMapFunc, eltRef) {
+    if (skipMapFunc(eltRef)) {
+        window.scrollTo(0, getAbsoluteOffsetTop(document.activeElement));
+    }
 }
 
 watch(towns, syncTownMarkers);

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -163,6 +163,7 @@ const {
     townClusteringOptions,
     townMarkerFn,
     locationMarkerFn,
+    displaySkipMapLinks,
 } = toRefs(props);
 
 const map = ref(null);

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -1,12 +1,12 @@
 <template>
-    <a
-        href="#"
-        v-if="displaySkipMapLinks"
-        class="sr-only"
-        @click.prevent="skipMap(skipFocusNext)"
-        >&Eacute;viter la carte</a
-    >
     <section class="h-full relative">
+        <a
+            href="#"
+            v-if="displaySkipMapLinks"
+            class="sr-only"
+            @click.prevent="skipMap(skipFocusNext)"
+            >&Eacute;viter la carte</a
+        >
         <div id="map" class="h-full border">
             <div
                 class="absolute w-full h-full top-0 left-0 z-[1001]"
@@ -33,14 +33,14 @@
 
             <slot />
         </div>
+        <a
+            href="#"
+            v-if="displaySkipMapLinks"
+            class="sr-only"
+            @click="skipMap(skipFocusPrevious)"
+            >&Eacute;viter la carte</a
+        >
     </section>
-    <a
-        href="#"
-        v-if="displaySkipMapLinks"
-        class="sr-only"
-        @click="skipMap(skipFocusPrevious)"
-        >&Eacute;viter la carte</a
-    >
 </template>
 
 <style>

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -3,7 +3,7 @@
         href="#"
         v-if="displaySkipMapLinks"
         class="sr-only"
-        @click.prevent="skipMap(skipFocusNext, mapRef)"
+        @click.prevent="skipMap(skipFocusNext)"
         >&Eacute;viter la carte</a
     >
     <section class="h-full relative">
@@ -38,7 +38,7 @@
         href="#"
         v-if="displaySkipMapLinks"
         class="sr-only"
-        @click="skipMap(skipFocusPrevious, mapRef)"
+        @click="skipMap(skipFocusPrevious)"
         >&Eacute;viter la carte</a
     >
 </template>
@@ -54,7 +54,7 @@ export default {
 </script>
 
 <script setup>
-import { ref, toRefs, onMounted, onBeforeUnmount, watch, computed } from "vue";
+import { ref, toRefs, onMounted, onBeforeUnmount, watch } from "vue";
 import L from "leaflet";
 import domtoimage from "dom-to-image-more";
 import "leaflet.markercluster/dist/MarkerCluster.css";
@@ -73,10 +73,6 @@ import { trackEvent } from "@/helpers/matomo";
 import getAbsoluteOffsetTop from "@/utils/getAbsoluteOffsetTop";
 import skipFocusNext from "@/utils/skipFocusNext";
 import skipFocusPrevious from "@/utils/skipFocusPrevious";
-
-const mapRef = computed(() => {
-    return document.getElementById("map");
-});
 
 const props = defineProps({
     isLoading: {
@@ -383,8 +379,9 @@ function createLocationMarker(level, location) {
     marker.addTo(markersGroup[level].value);
 }
 
-function skipMap(skipMapFunc, eltRef) {
-    if (skipMapFunc(eltRef)) {
+function skipMap(skipMapFunc) {
+    const map = document.getElementById("map");
+    if (map && skipMapFunc(map)) {
         window.scrollTo(0, getAbsoluteOffsetTop(document.activeElement));
     }
 }

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -37,7 +37,7 @@
             href="#"
             v-if="displaySkipMapLinks"
             class="sr-only"
-            @click="skipMap(skipFocusPrevious)"
+            @click.prevent="skipMap(skipFocusPrevious)"
             >&Eacute;viter la carte</a
         >
     </section>

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -10,6 +10,7 @@
         :locationMarkerFn="marqueurLocationStats"
         :townClusteringOptions="{ maxClusterRadius: 0 }"
         :defaultView="departementMetricsStore.lastMapView || undefined"
+        displaySkipMapLinks="true"
     >
         <div
             ref="legendeConditionsDeVie"

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -10,7 +10,7 @@
         :locationMarkerFn="marqueurLocationStats"
         :townClusteringOptions="{ maxClusterRadius: 0 }"
         :defaultView="departementMetricsStore.lastMapView || undefined"
-        displaySkipMapLinks="true"
+        displaySkipMapLinks
     >
         <div
             ref="legendeConditionsDeVie"

--- a/packages/frontend/webapp/src/components/CartoFicheAction/CartoFicheAction.vue
+++ b/packages/frontend/webapp/src/components/CartoFicheAction/CartoFicheAction.vue
@@ -3,7 +3,7 @@
         ref="carto"
         :layers="['Dessin', 'Satellite']"
         defaultLayer="Satellite"
-        displaySkipMapLinks="true"
+        displaySkipMapLinks
     />
 </template>
 

--- a/packages/frontend/webapp/src/components/CartoFicheAction/CartoFicheAction.vue
+++ b/packages/frontend/webapp/src/components/CartoFicheAction/CartoFicheAction.vue
@@ -3,6 +3,7 @@
         ref="carto"
         :layers="['Dessin', 'Satellite']"
         defaultLayer="Satellite"
+        displaySkipMapLinks="true"
     />
 </template>
 

--- a/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
+++ b/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
@@ -1,25 +1,23 @@
 <template>
-    <SkipMap>
-        <Carto
-            ref="carto"
-            :layers="['Dessin', 'Satellite']"
-            defaultLayer="Satellite"
-            :defaultView="defaultView"
-            :townMarkerFn="marqueurSiteEau"
-            displaySkipMapLinks="true"
+    <Carto
+        ref="carto"
+        :layers="['Dessin', 'Satellite']"
+        defaultLayer="Satellite"
+        :defaultView="defaultView"
+        :townMarkerFn="marqueurSiteEau"
+        displaySkipMapLinks="true"
+    >
+        <div
+            ref="cadastreToggler"
+            class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden"
+            v-show="cadastre"
         >
-            <div
-                ref="cadastreToggler"
-                class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden"
-                v-show="cadastre"
-            >
-                <label class="flex items-center space-x-2">
-                    <input type="checkbox" v-model="showCadastre" />
-                    <span>Voir le cadastre</span>
-                </label>
-            </div>
-        </Carto>
-    </SkipMap>
+            <label class="flex items-center space-x-2">
+                <input type="checkbox" v-model="showCadastre" />
+                <span>Voir le cadastre</span>
+            </label>
+        </div>
+    </Carto>
 </template>
 
 <script setup>
@@ -28,7 +26,6 @@ import L from "leaflet";
 import { useNotificationStore } from "@/stores/notification.store";
 import copyToClipboard from "@/utils/copyToClipboard";
 import Carto from "@/components/Carto/Carto.vue";
-import SkipMap from "@/components/SkipMap/SkipMap.vue";
 import marqueurSiteEau from "@/utils/marqueurSiteEau";
 
 const props = defineProps({

--- a/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
+++ b/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
@@ -5,7 +5,7 @@
         defaultLayer="Satellite"
         :defaultView="defaultView"
         :townMarkerFn="marqueurSiteEau"
-        displaySkipMapLinks="true"
+        displaySkipMapLinks
     >
         <div
             ref="cadastreToggler"

--- a/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
+++ b/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
@@ -1,22 +1,25 @@
 <template>
-    <Carto
-        ref="carto"
-        :layers="['Dessin', 'Satellite']"
-        defaultLayer="Satellite"
-        :defaultView="defaultView"
-        :townMarkerFn="marqueurSiteEau"
-    >
-        <div
-            ref="cadastreToggler"
-            class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden"
-            v-show="cadastre"
+    <SkipMap>
+        <Carto
+            ref="carto"
+            :layers="['Dessin', 'Satellite']"
+            defaultLayer="Satellite"
+            :defaultView="defaultView"
+            :townMarkerFn="marqueurSiteEau"
+            displaySkipMapLinks="true"
         >
-            <label class="flex items-center space-x-2">
-                <input type="checkbox" v-model="showCadastre" />
-                <span>Voir le cadastre</span>
-            </label>
-        </div>
-    </Carto>
+            <div
+                ref="cadastreToggler"
+                class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden"
+                v-show="cadastre"
+            >
+                <label class="flex items-center space-x-2">
+                    <input type="checkbox" v-model="showCadastre" />
+                    <span>Voir le cadastre</span>
+                </label>
+            </div>
+        </Carto>
+    </SkipMap>
 </template>
 
 <script setup>
@@ -25,6 +28,7 @@ import L from "leaflet";
 import { useNotificationStore } from "@/stores/notification.store";
 import copyToClipboard from "@/utils/copyToClipboard";
 import Carto from "@/components/Carto/Carto.vue";
+import SkipMap from "@/components/SkipMap/SkipMap.vue";
 import marqueurSiteEau from "@/utils/marqueurSiteEau";
 
 const props = defineProps({

--- a/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
+++ b/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
@@ -7,6 +7,7 @@
             :layers="['Dessin', 'Satellite']"
             defaultLayer="Dessin"
             :isLoading="isSubmitting"
+            displaySkipMapLinks="true"
         />
     </div>
 </template>

--- a/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
+++ b/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
@@ -7,7 +7,7 @@
             :layers="['Dessin', 'Satellite']"
             defaultLayer="Dessin"
             :isLoading="isSubmitting"
-            displaySkipMapLinks="true"
+            displaySkipMapLinks
         />
     </div>
 </template>

--- a/packages/frontend/webapp/src/utils/getAbsoluteOffsetTop.js
+++ b/packages/frontend/webapp/src/utils/getAbsoluteOffsetTop.js
@@ -1,0 +1,11 @@
+// Renvoie la distance entre la bordure extérieure de l'élément passé en paramètre et le haut de la page
+export default function getAbsoluteOffsetTop(element) {
+    let distanceTotale = 0;
+
+    // Parcours des parents de l'élément jusqu'à atteindre le haut de page
+    while (element) {
+        distanceTotale += element.offsetTop; // Ajout de la distance de l'élément actuel
+        element = element.offsetParent; // Parent suivant
+    }
+    return distanceTotale;
+}

--- a/packages/frontend/webapp/src/utils/skipFocus.js
+++ b/packages/frontend/webapp/src/utils/skipFocus.js
@@ -40,8 +40,7 @@ function tryFocus(el) {
             el.tabIndex > -1) &&
         !el.disabled &&
         !el.hidden &&
-        el.focus &&
-        !el.classList.contains("sr-only")
+        el.focus
     ) {
         el.focus();
         return true;

--- a/packages/frontend/webapp/src/utils/skipFocus.js
+++ b/packages/frontend/webapp/src/utils/skipFocus.js
@@ -1,4 +1,4 @@
-export function skipFocus(el, direction, originNode, allowTop = true) {
+export default function skipFocus(el, direction, originNode, allowTop = true) {
     // soi-même
     if (tryFocus(el)) {
         return true;
@@ -40,7 +40,8 @@ function tryFocus(el) {
             el.tabIndex > -1) &&
         !el.disabled &&
         !el.hidden &&
-        el.focus
+        el.focus &&
+        !el.classList.contains("sr-only")
     ) {
         el.focus();
         return true;

--- a/packages/frontend/webapp/src/utils/skipFocus.js
+++ b/packages/frontend/webapp/src/utils/skipFocus.js
@@ -1,0 +1,50 @@
+export function skipFocus(el, direction, originNode, allowTop = true) {
+    // soi-même
+    if (tryFocus(el)) {
+        return true;
+    }
+
+    // ensuite les enfants (et leurs descendants)
+    if (originNode.parentNode !== el && el.childNodes?.length > 0) {
+        const child =
+            direction === "bottom"
+                ? el.childNodes[0]
+                : el.childNodes[el.childNodes.length - 1];
+        if (skipFocus(child, direction, el, false)) {
+            return true;
+        }
+    }
+
+    // ensuite les frères
+    const sibling =
+        direction === "bottom"
+            ? el.nextElementSibling
+            : el.previousElementSibling;
+    if (sibling) {
+        return skipFocus(sibling, direction, el, allowTop);
+    }
+
+    // et enfin le parent
+    if (allowTop && el.parentNode) {
+        return skipFocus(el.parentNode, direction, el, allowTop);
+    }
+
+    return false;
+}
+
+function tryFocus(el) {
+    if (
+        (["A", "BUTTON", "INPUT", "TEXTAREA", "SELECT", "DETAILS"].includes(
+            el.nodeName
+        ) ||
+            el.tabIndex > -1) &&
+        !el.disabled &&
+        !el.hidden &&
+        el.focus
+    ) {
+        el.focus();
+        return true;
+    }
+
+    return false;
+}

--- a/packages/frontend/webapp/src/utils/skipFocusNext.js
+++ b/packages/frontend/webapp/src/utils/skipFocusNext.js
@@ -1,0 +1,5 @@
+import skipFocus from "./skipFocus";
+
+export function skipFocusNext(el) {
+    return skipFocus(el.nextElementSibling || el.parentNode, "bottom", el);
+}

--- a/packages/frontend/webapp/src/utils/skipFocusNext.js
+++ b/packages/frontend/webapp/src/utils/skipFocusNext.js
@@ -1,5 +1,5 @@
 import skipFocus from "./skipFocus";
 
-export function skipFocusNext(el) {
+export default function skipFocusNext(el) {
     return skipFocus(el.nextElementSibling || el.parentNode, "bottom", el);
 }

--- a/packages/frontend/webapp/src/utils/skipFocusPrevious.js
+++ b/packages/frontend/webapp/src/utils/skipFocusPrevious.js
@@ -1,5 +1,5 @@
 import skipFocus from "./skipFocus";
 
-export function skipFocusPrevious(el) {
+export default function skipFocusPrevious(el) {
     return skipFocus(el.previousElementSibling || el.parentNode, "top", el);
 }

--- a/packages/frontend/webapp/src/utils/skipFocusPrevious.js
+++ b/packages/frontend/webapp/src/utils/skipFocusPrevious.js
@@ -1,0 +1,5 @@
+import skipFocus from "./skipFocus";
+
+export function skipFocusPrevious(el) {
+    return skipFocus(el.previousElementSibling || el.parentNode, "top", el);
+}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/atiklFos/1985

## 🛠 Description de la PR
- Création d'utilitaires permettant d'éviter de donner le focus à un élément HTML
- Création d'un utilitaire permettant de calculer la distance entre le bord supérieur d'un élément et le haut de la page (utilise pour le scroll vers l'élément suivant lorsqu'on évite la carte)
- Ajout d'une propriété au composant carto permettant d'afficher ou non les lien d'évitement
- Adaptation des composants `CartoDonneesStatistiques.vue, `CartoFicheSite.vue `, `InputCoordinates.vue` et `CartoFicheAction`  pour afficher les liens d'évitement de la carte

## 🚨 Notes pour la mise en production
- ràs