### PR TITLE
#patch (2036) Correction de l'ordre des associations dans la liste, lors d'une demande d'accès

### DIFF
--- a/packages/api/server/models/organizationModel/findByCategory.ts
+++ b/packages/api/server/models/organizationModel/findByCategory.ts
@@ -23,7 +23,7 @@ export default async (categoryUid, search = null) => {
                 ${search !== null ? ' AND (UNACCENT(organizations.name) ILIKE UNACCENT(:search) OR UNACCENT(organizations.abbreviation) ILIKE UNACCENT(:search))' : ''}
             ORDER BY
                 CASE organization_types.fk_category
-                    WHEN 'association' THEN LOWER(UNACCENT(organizations.name))
+                    WHEN 'association' THEN LOWER(UNACCENT(COALESCE(organizations.abbreviation, organizations.name)))
                     ELSE '' END
                 ASC,
                 departement_code ASC, UNACCENT(region_name) ASC, UNACCENT(epci_name) ASC, UNACCENT(city_name) ASC`,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/3OoyUxBB/2036

## 🛠 Description de la PR
L'ordre des associations est désormais basé sur l'abbréviation si elle existe, sinon le nom ; ce qui correspond à ce qui est affiché dans la liste.

## 📸 Captures d'écran
Démonstration du problème résolu :
<img width="777" alt="Capture d’écran 2023-12-05 à 10 34 49" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/ce488da4-3eb7-47c8-afd1-c6ea54376ad4">

## 🚨 Notes pour la mise en production
RàS