### PR TITLE
#patch (2052) Eviter d'appliquer les filtres des sites fermés sur sites ouverts

### DIFF
--- a/packages/frontend/webapp/src/stores/towns.store.js
+++ b/packages/frontend/webapp/src/stores/towns.store.js
@@ -117,21 +117,22 @@ export const useTownsStore = defineStore("towns", () => {
         const userStore = useUserStore();
         const { search: searchFilter, data: locationFilter } =
             getDefaultLocationFilter(userStore.user);
-
+        // Filtres communs sites ouverts/sites fermés
         filters.search.value = searchFilter;
         filters.location.value = locationFilter;
         filters.status.value = "open";
-
         filters.properties.value.population = [];
         filters.properties.value.fieldType = [];
         filters.properties.value.justice = [];
         filters.properties.value.origin = [];
+        filters.properties.value.target = [];
+        // Filtres spécifiques aux sites ouverts
         filters.properties.value.conditions = [];
+        filters.properties.value.actors = [];
+        filters.properties.value.heatwave = [];
+        // Filtres spécifiques aux sites fermés
         filters.properties.value.closingReason = [];
         filters.properties.value.solvedOrClosed = [];
-        filters.properties.value.actors = [];
-        filters.properties.value.target = [];
-        filters.properties.value.heatwave = [];
     }
 
     function reset() {

--- a/packages/frontend/webapp/src/utils/filterShantytowns.js
+++ b/packages/frontend/webapp/src/utils/filterShantytowns.js
@@ -24,15 +24,15 @@ export default function (shantytowns, filters) {
         }
 
         if (
-            filters.fieldType.length > 0 &&
-            !checkFieldType(shantytown, filters.fieldType)
+            filters.population.length > 0 &&
+            !checkPopulation(shantytown, filters.population)
         ) {
             return false;
         }
 
         if (
-            filters.population.length > 0 &&
-            !checkPopulation(shantytown, filters.population)
+            filters.fieldType.length > 0 &&
+            !checkFieldType(shantytown, filters.fieldType)
         ) {
             return false;
         }
@@ -52,6 +52,15 @@ export default function (shantytowns, filters) {
         }
 
         if (
+            filters.target.length > 0 &&
+            !checkTarget(shantytown, filters.target)
+        ) {
+            return false;
+        }
+
+        // Filtres spécifiques aux sites ouverts
+        if (
+            filters.status === "open" &&
             filters.conditions.length > 0 &&
             !checkConditions(shantytown, filters.conditions)
         ) {
@@ -59,20 +68,7 @@ export default function (shantytowns, filters) {
         }
 
         if (
-            filters.closingReason.length > 0 &&
-            !checkClosingReason(shantytown, filters.closingReason)
-        ) {
-            return false;
-        }
-
-        if (
-            filters.solvedOrClosed.length > 0 &&
-            !checkSolvedOrClosed(shantytown, filters.solvedOrClosed)
-        ) {
-            return false;
-        }
-
-        if (
+            filters.status === "open" &&
             filters.actors.length > 0 &&
             !checkActors(shantytown, filters.actors)
         ) {
@@ -80,19 +76,29 @@ export default function (shantytowns, filters) {
         }
 
         if (
-            filters.target.length > 0 &&
-            !checkTarget(shantytown, filters.target)
-        ) {
-            return false;
-        }
-
-        if (
+            filters.status === "open" &&
             filters.heatwave.length > 0 &&
             !checkHeatwave(shantytown, filters.heatwave)
         ) {
             return false;
         }
 
+        // Filtres spécifiques aux sites fermés
+        if (
+            filters.status === "close" &&
+            filters.closingReason.length > 0 &&
+            !checkClosingReason(shantytown, filters.closingReason)
+        ) {
+            return false;
+        }
+
+        if (
+            filters.status === "close" &&
+            filters.solvedOrClosed.length > 0 &&
+            !checkSolvedOrClosed(shantytown, filters.solvedOrClosed)
+        ) {
+            return false;
+        }
         return true;
     });
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QHJxfzxF/2052

## 🛠 Description de la PR
- N'appliquer les filtres correspondant aux sites ouverts que sur les sites ouverts et les filtres pour sites fermés que sur les sites fermés.
- Corriger le bug affectant le filtre sur les procédures judiciaires.