### PR TITLE
#patch (2078) Les pilotes/opérateurs des fiches action ne s'affichent plus

### DIFF
--- a/packages/frontend/webapp/src/components/CarteStructure/CarteStructure.vue
+++ b/packages/frontend/webapp/src/components/CarteStructure/CarteStructure.vue
@@ -191,7 +191,7 @@ const plural = computed(() => {
 });
 
 function getUserFilteredExpertiseTopics(user, topicLevel) {
-    return user.expertise_topics.filter((topic) => {
+    return (user.expertise_topics || []).filter((topic) => {
         return (
             directoryStore.filters.expertiseTopics.includes(topic.id) &&
             topic.type == topicLevel

--- a/packages/frontend/webapp/src/components/CarteUtilisateur/CarteUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/CarteUtilisateur/CarteUtilisateur.vue
@@ -34,7 +34,7 @@
             }}</CarteUtilisateurDetailsIcon>
         </div>
         <div
-            v-if="user.expertise_topics.length > 0"
+            v-if="user.expertise_topics?.length > 0"
             class="col-span-2 grid grid-cols-2 gap-4"
         >
             <div v-if="getTopicsByLevel('expertise').length > 0" class="flex">
@@ -105,7 +105,7 @@ function trackEmail(event) {
 }
 
 function getTopicsByLevel(level) {
-    return user.value.expertise_topics.filter((topic) => {
+    return (user.value.expertise_topics || []).filter((topic) => {
         return (
             directoryStore.filters.expertiseTopics.includes(topic.id) &&
             topic.type == level


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/w9YNrMhO/2078

## 🛠 Description de la PR
Dans le cas d'une fiche action, les opérateurs et pilotes sont fournis par l'API sans expertise_topics, ce qui cause une erreur au sein de CarteUtilisateur.

## 🚨 Notes pour la mise en production
RàS