### PR TITLE
#patch (2042) Envoi automatique d'un lien d'accès lors de la réactivation d'un compte

### DIFF
--- a/packages/api/server/controllers/userController/reactivate.spec.ts
+++ b/packages/api/server/controllers/userController/reactivate.spec.ts
@@ -27,6 +27,7 @@ describe('userController.reactivate()', () => {
 
     it('demande la réactivation du compte', async () => {
         const req = mockReq({
+            user: fakeUser(),
             body: {
                 user: fakeUser({ id: 42 }),
             },
@@ -35,7 +36,7 @@ describe('userController.reactivate()', () => {
 
         await reactivateController(req, res, () => {});
         expect(userService.reactivate).to.have.been.calledOnce;
-        expect(userService.reactivate).to.have.been.calledWith(42);
+        expect(userService.reactivate).to.have.been.calledWith(req.user, 42);
     });
 
     it('répond avec un code 200 et l\'utilisateur mis à jour', async () => {
@@ -43,13 +44,14 @@ describe('userController.reactivate()', () => {
         const updatedUser = fakeUser({ id: 42, status: 'active' });
 
         const req = mockReq({
+            user: fakeUser(),
             body: {
                 user: originalUser,
             },
         });
         const res = mockRes();
 
-        userService.reactivate.withArgs(42).resolves(updatedUser);
+        userService.reactivate.withArgs(req.user, 42).resolves(updatedUser);
 
         await reactivateController(req, res, () => {});
         expect(res.status).to.have.been.calledOnceWith(200);

--- a/packages/api/server/controllers/userController/reactivate.ts
+++ b/packages/api/server/controllers/userController/reactivate.ts
@@ -15,7 +15,7 @@ interface UserReactivateRequest extends Request {
 
 export default async (req: UserReactivateRequest, res: Response, next: NextFunction): Promise<void> => {
     try {
-        const updatedUser = await userService.reactivate(req.body.user.id);
+        const updatedUser = await userService.reactivate(req.user, req.body.user.id);
         res.status(200).send(updatedUser);
     } catch (error) {
         const { code, message } = ERRORS[error?.code] || ERRORS.undefined;

--- a/packages/api/server/controllers/userController/sendActivationLink.spec.ts
+++ b/packages/api/server/controllers/userController/sendActivationLink.spec.ts
@@ -1,0 +1,82 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import rewiremock from 'rewiremock/node';
+import { mockReq, mockRes } from 'sinon-express-mock';
+import { serialized as fakeUser } from '#test/utils/user';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+const sandbox = sinon.createSandbox();
+const sendActivationLinkService = sandbox.stub();
+
+rewiremock('#server/services/user/sendActivationLink').with(sendActivationLinkService);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import sendActivationLinkController from './sendActivationLink';
+rewiremock.disable();
+
+describe('userController.sendActivationLink()', () => {
+    afterEach(() => {
+        sandbox.reset();
+    });
+
+    it('demande l\'envoi d\'un accès au compte', async () => {
+        const req = mockReq({
+            userToBeActivated: fakeUser({ id: 42 }),
+            user: fakeUser({ id: 1 }),
+            body: {
+                options: ['option1', 'option2'],
+            },
+        });
+        const res = mockRes();
+
+        await sendActivationLinkController(req, res, () => {});
+        expect(sendActivationLinkService).to.have.been.calledOnce;
+        expect(sendActivationLinkService).to.have.been.calledWith(req.user, req.userToBeActivated, ['option1', 'option2']);
+    });
+
+    it('répond avec un code 200 et l\'utilisateur mis à jour', async () => {
+        const originalUser = fakeUser({ id: 42, status: 'inactive' });
+        const updatedUser = fakeUser({ id: 42, status: 'active' });
+
+        const req = mockReq({
+            userToBeActivated: originalUser,
+            user: fakeUser({ id: 1 }),
+            body: {
+                options: [],
+            },
+        });
+        const res = mockRes();
+
+        sendActivationLinkService.resolves(updatedUser);
+
+        await sendActivationLinkController(req, res, () => {});
+        expect(res.status).to.have.been.calledOnceWith(200);
+        expect(res.send).to.have.been.calledOnceWith(updatedUser);
+    });
+
+    it('en cas d\'erreur, répond avec un code 500 et un détail de l\'erreur', async () => {
+        const req = mockReq({
+            userToBeActivated: fakeUser({ id: 42 }),
+            user: fakeUser({ id: 1 }),
+            body: {
+                options: [],
+            },
+        });
+        const res = mockRes();
+        const next = sandbox.stub();
+
+        const error = new Error();
+        sendActivationLinkService.rejects(error);
+
+        await sendActivationLinkController(req, res, next);
+        expect(res.status).to.have.been.calledWith(500);
+        expect(res.send).to.have.been.calledWith({
+            user_message: 'Une erreur inconnue est survenue',
+        });
+        expect(next).to.have.been.calledOnceWith(error);
+    });
+});

--- a/packages/api/server/controllers/userController/sendActivationLink.ts
+++ b/packages/api/server/controllers/userController/sendActivationLink.ts
@@ -1,85 +1,29 @@
-import { sequelize } from '#db/sequelize';
-import userModel from '#server/models/userModel';
-import userAccessModel from '#server/models/userAccessModel';
-import accessRequestService from '#server/services/accessRequest/accessRequestService';
-import permissionsDescription from '#server/permissions_description';
-import authUtils from '#server/utils/auth';
+import sendActivationLink from '#server/services/user/sendActivationLink';
+import { NextFunction, Request, Response } from 'express';
+import { User } from '#root/types/resources/User.d';
 
-const { getExpiracyDateForActivationTokenCreatedAt } = authUtils;
+interface UserSendActivationLinkRequest extends Request {
+    user: User,
+    userToBeActivated: User,
+    body: {
+        options: string[],
+    },
+}
 
-export default async (req, res, next) => {
-    let user;
+const ERRORS = {
+    undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
+};
+
+export default async (req: UserSendActivationLinkRequest, res: Response, next: NextFunction): Promise<void> => {
     try {
-        user = await userModel.findOne(req.params.id, { extended: true }, req.user, 'activate');
+        const updatedUser = await sendActivationLink(req.user, req.userToBeActivated, req.body.options);
+        res.status(200).send(updatedUser);
     } catch (error) {
-        res.status(500).send({
-            error: {
-                user_message: 'Une erreur est survenue lors de la lecture en base de données',
-            },
+        const { code, message } = ERRORS[error?.code] || ERRORS.undefined;
+        res.status(code).send({
+            user_message: message,
         });
-        return next(error);
+
+        next(error?.nativeError || error);
     }
-
-    if (user === null) {
-        return res.status(404).send({
-            error: {
-                user_message: 'L\'utilisateur auquel envoyer un accès n\'a pas été trouvé en base de données',
-            },
-        });
-    }
-
-    if (user.status !== 'new') {
-        return res.status(400).send({
-            error: {
-                user_message: 'L\'utilisateur concerné n\'a pas de demande d\'accès en attente',
-            },
-        });
-    }
-
-    try {
-        await sequelize.transaction(async (transaction) => {
-            const { options } = permissionsDescription[user.role_id];
-            const requestedOptions = options
-                .filter(({ id }) => req.body.options && req.body.options.includes(id))
-                .map(({ id }) => id);
-            await userModel.setPermissionOptions(user.id, requestedOptions, transaction);
-
-            // reload the user to take options into account (they might have changed above)
-            user = await userModel.findOne(
-                req.params.id,
-                { extended: true },
-                req.user,
-                'activate',
-                transaction,
-            );
-
-            const now = new Date();
-            const expiresAt = getExpiracyDateForActivationTokenCreatedAt(now);
-            const userAccessId = await userAccessModel.create({
-                fk_user: user.id,
-                sent_by: req.user.id,
-                created_at: now,
-                expires_at: expiresAt,
-            }, transaction);
-
-            await accessRequestService.resetRequestsForUser(user);
-            await accessRequestService.handleAccessRequestApproved(
-                user,
-                {
-                    id: userAccessId,
-                    expires_at: expiresAt.getTime() / 1000,
-                    sent_by: req.user,
-                },
-            );
-        });
-    } catch (error) {
-        res.status(500).send({
-            error: {
-                user_message: 'Une erreur est survenue lors de l\'envoi du lien d\'activation',
-            },
-        });
-        return next(error);
-    }
-
-    return res.status(200).send(await userModel.findOne(req.params.id));
 };

--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -186,6 +186,8 @@ export default (app) => {
         (...args: [express.Request, express.Response, Function]) => middlewares.auth.checkPermissions(['user.activate'], ...args),
         middlewares.charte.check,
         middlewares.appVersion.sync,
+        validators.user.sendActivationLink,
+        middlewares.validation,
         controllers.user.sendActivationLink,
     );
     app.get(

--- a/packages/api/server/middlewares/validators/index.ts
+++ b/packages/api/server/middlewares/validators/index.ts
@@ -26,6 +26,7 @@ import userDeactivate from './users/deactivate';
 import userReactivate from './users/reactivate';
 import userUpdatePermissionOptions from './users/updatePermissionOptions';
 import userGetLatestActivationLink from './users/getLatestActivationLink';
+import userSendActivationLink from './users/sendActivationLink';
 import userSetExpertiseTopics from './users/setExpertiseTopics';
 import userSetRoleRegular from './users/setRoleRegular';
 import mePostNavigationLogs from './me/post.navigationLogs';
@@ -90,6 +91,7 @@ export default {
         deactivate: userDeactivate,
         getLatestActivationLink: userGetLatestActivationLink,
         reactivate: userReactivate,
+        sendActivationLink: userSendActivationLink,
         setExpertiseTopics: userSetExpertiseTopics,
         setRoleRegular: userSetRoleRegular,
         updatePermissionOptions: userUpdatePermissionOptions,

--- a/packages/api/server/middlewares/validators/users/sendActivationLink.ts
+++ b/packages/api/server/middlewares/validators/users/sendActivationLink.ts
@@ -1,0 +1,51 @@
+/* eslint-disable newline-per-chained-call */
+import { Meta, body, param } from 'express-validator';
+import findOneUser from '#server/models/userModel/findOne';
+import permissionsDescription from '#server/permissions_description';
+
+export default [
+    param('id')
+        .toInt()
+        .isInt().bail().withMessage('L\'identifiant de l\'utilisateur est invalide')
+        .custom(async (value, { req }) => {
+            let user;
+            try {
+                user = await findOneUser(value, { extended: true }, req.user, 'activate');
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la lecture en base de données');
+            }
+
+            if (user === null) {
+                throw new Error('L\'utilisateur auquel envoyer un accès n\'a pas été trouvé en base de données');
+            }
+
+            if (user.status !== 'new') {
+                throw new Error('L\'utilisateur concerné n\'a pas de demande d\'accès en attente');
+            }
+
+            req.userToBeActivated = user;
+            return true;
+        }),
+
+    body('options')
+        .customSanitizer((value) => {
+            if (value === undefined || value === null) {
+                return [];
+            }
+
+            return value;
+        })
+        .isArray().bail().withMessage('Les options sont invalides')
+        .custom((value: string[], { req }: Meta) => {
+            if (req.userToBeActivated === undefined) {
+                throw new Error('Impossible de valider les options car l\'utilisateur n\'a pas été trouvé');
+            }
+
+            const availableOptions = permissionsDescription[req.user.role_id].options.map(({ id }) => id);
+            value.filter(id => !availableOptions.includes(id));
+
+            if (value.length > 0) {
+                throw new Error(`Certaines options ne sont pas disponibles pour l'utilisateur concerné : ${value.join(', ')}`);
+            }
+        }),
+];

--- a/packages/api/server/middlewares/validators/users/sendActivationLink.ts
+++ b/packages/api/server/middlewares/validators/users/sendActivationLink.ts
@@ -42,10 +42,10 @@ export default [
             }
 
             const availableOptions = permissionsDescription[req.user.role_id].options.map(({ id }) => id);
-            value.filter(id => !availableOptions.includes(id));
+            const forbiddenOptions = value.filter(id => !availableOptions.includes(id));
 
-            if (value.length > 0) {
-                throw new Error(`Certaines options ne sont pas disponibles pour l'utilisateur concerné : ${value.join(', ')}`);
+            if (forbiddenOptions.length > 0) {
+                throw new Error(`Certaines options ne sont pas disponibles pour l'utilisateur concerné : ${forbiddenOptions.join(', ')}`);
             }
         }),
 ];

--- a/packages/api/server/services/user/reactivate.spec.ts
+++ b/packages/api/server/services/user/reactivate.spec.ts
@@ -2,7 +2,7 @@ import chai from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
-import rewiremock from 'rewiremock/node';
+import { rewiremock } from '#test/rewiremock';
 import { serialized as fakeUser } from '#test/utils/user';
 import ServiceError from '#server/errors/ServiceError';
 
@@ -15,16 +15,17 @@ const sandbox = sinon.createSandbox();
 const sequelize = {
     transaction: sandbox.stub(),
 };
-const userModel = {
-    reactivate: sandbox.stub(),
-    findOne: sandbox.stub(),
-};
+const reactivate = sandbox.stub();
+const findOneUser = sandbox.stub();
+const sendActivationLink = sandbox.stub();
 const mails = {
     sendUserReactivationAlert: sandbox.stub(),
 };
 
 rewiremock('#db/sequelize').with({ sequelize });
-rewiremock('#server/models/userModel/index').with(userModel);
+rewiremock('#server/models/userModel/reactivate').with(reactivate);
+rewiremock('#server/models/userModel/findOne').with(findOneUser);
+rewiremock('#server/services/user/sendActivationLink').with(sendActivationLink);
 rewiremock('#server/mails/mails').with(mails);
 
 rewiremock.enable();
@@ -47,59 +48,105 @@ describe('userService.reactivate()', () => {
     });
 
     it('change le statut du compte à \'active\' ou \'new\' en base de données', async () => {
-        userModel.findOne.resolves(fakeUser());
-        await reactivateUser(42);
-        expect(userModel.reactivate).to.have.been.calledOnce;
-        expect(userModel.reactivate).to.have.been.calledWith(42);
+        findOneUser.resolves(fakeUser());
+        await reactivateUser(fakeUser(), 42);
+        expect(reactivate).to.have.been.calledOnce;
+        expect(reactivate).to.have.been.calledWith(42);
     });
 
     it('retourne le compte réactivé', async () => {
         const user = fakeUser({ id: 42, status: 'active' });
-        userModel.findOne.withArgs(42).resolves(user);
+        findOneUser.withArgs(42).resolves(user);
 
-        const response = await reactivateUser(42);
+        const response = await reactivateUser(fakeUser(), 42);
         expect(response).to.be.eql(user);
     });
 
     it('exécute l\'ensemble des requêtes dans une transaction', async () => {
-        userModel.findOne.resolves(fakeUser());
-        await reactivateUser(42);
-        expect(userModel.reactivate).to.have.been.calledWith(42, transaction);
-        expect(userModel.findOne).to.have.been.calledWith(42, {}, null, 'read', transaction);
+        findOneUser.resolves(fakeUser());
+        await reactivateUser(fakeUser(), 42);
+        expect(reactivate).to.have.been.calledWith(42, transaction);
+        expect(findOneUser).to.have.been.calledWith(42, { extended: true }, null, 'read', transaction);
         expect(transaction.commit).to.have.been.calledOnce;
     });
 
     it('si l\'utilisateur est passé en statut \'active\', envoie un mail spécifique', async () => {
         const user = fakeUser({ status: 'active' });
-        userModel.findOne.withArgs(42).resolves(user);
+        findOneUser.withArgs(42).resolves(user);
 
-        await reactivateUser(42);
+        await reactivateUser(fakeUser(), 42);
         expect(mails.sendUserReactivationAlert).to.have.been.calledOnce;
         expect(mails.sendUserReactivationAlert).to.have.been.calledWith(user);
+        expect(sendActivationLink).to.not.have.been.called;
     });
 
-    it('si l\'utilisateur est passé en statut \'new\', n\'envoie PAS de mail', async () => {
-        const user = fakeUser({ status: 'new' });
-        userModel.findOne.withArgs(42).resolves(user);
+    it('si l\'utilisateur est passé en statut \'new\', envoie un accès à l\'utilisateur', async () => {
+        const activator = fakeUser({ id: 1 });
+        const user = fakeUser({ status: 'new', permission_options: ['access_justice'] });
+        findOneUser.withArgs(42).resolves(user);
 
-        await reactivateUser(42);
+        await reactivateUser(activator, 42);
         expect(mails.sendUserReactivationAlert).to.not.have.been.called;
+        expect(sendActivationLink).to.have.been.calledOnceWith(
+            activator,
+            user,
+            ['access_justice'],
+            transaction,
+        );
     });
 
     it('ignore les erreurs de l\'envoi du mail d\'alerte', async () => {
         const user = fakeUser({ status: 'active' });
-        userModel.findOne.withArgs(42).resolves(user);
+        findOneUser.withArgs(42).resolves(user);
         mails.sendUserReactivationAlert.rejects(new Error('test'));
 
-        await reactivateUser(42);
+        await reactivateUser(fakeUser(), 42);
+    });
+
+    it('en cas d\'erreur de l\'envoi d\'un accès, lance une ServiceError', async () => {
+        findOneUser.resolves(fakeUser({
+            status: 'new',
+        }));
+
+        const error = new Error('test');
+        sendActivationLink.rejects(error);
+
+        try {
+            await reactivateUser(fakeUser(), 42);
+        } catch (e) {
+            expect(e).to.be.an.instanceof(ServiceError);
+            expect(e.code).to.be.equal('send_access_failure');
+            expect(e.nativeError).to.be.equal(error);
+            return;
+        }
+
+        expect.fail('should have thrown an error');
+    });
+
+    it('en cas d\'erreur de l\'envoi d\'un accès, rollback', async () => {
+        findOneUser.resolves(fakeUser({
+            status: 'new',
+        }));
+
+        const error = new Error('test');
+        sendActivationLink.rejects(error);
+
+        try {
+            await reactivateUser(fakeUser(), 42);
+        } catch (e) {
+            expect(transaction.rollback).to.have.been.called;
+            return;
+        }
+
+        expect.fail('should have thrown an error');
     });
 
     it('en cas d\'erreur de la modification de l\'utilisateur, lance une ServiceError', async () => {
         const error = new Error('test');
-        userModel.reactivate.rejects(error);
+        reactivate.rejects(error);
 
         try {
-            await reactivateUser(42);
+            await reactivateUser(fakeUser(), 42);
         } catch (e) {
             expect(e).to.be.an.instanceof(ServiceError);
             expect(e.code).to.be.equal('reactivation_failure');
@@ -112,10 +159,10 @@ describe('userService.reactivate()', () => {
 
     it('en cas d\'erreur de la modification de l\'utilisateur, rollback', async () => {
         const error = new Error('test');
-        userModel.reactivate.rejects(error);
+        reactivate.rejects(error);
 
         try {
-            await reactivateUser(42);
+            await reactivateUser(fakeUser(), 42);
         } catch (e) {
             expect(transaction.rollback).to.have.been.called;
             return;
@@ -126,10 +173,10 @@ describe('userService.reactivate()', () => {
 
     it('en cas d\'erreur de la recherche de l\'utilisateur, lance une ServiceError', async () => {
         const error = new Error('test');
-        userModel.findOne.rejects(error);
+        findOneUser.rejects(error);
 
         try {
-            await reactivateUser(42);
+            await reactivateUser(fakeUser(), 42);
         } catch (e) {
             expect(e).to.be.an.instanceof(ServiceError);
             expect(e.code).to.be.equal('refresh_failure');
@@ -142,10 +189,10 @@ describe('userService.reactivate()', () => {
 
     it('en cas d\'erreur de la recherche de l\'utilisateur, rollback la transaction', async () => {
         const error = new Error('test');
-        userModel.findOne.rejects(error);
+        findOneUser.rejects(error);
 
         try {
-            await reactivateUser(42);
+            await reactivateUser(fakeUser(), 42);
         } catch (e) {
             expect(transaction.rollback).to.have.been.called;
             return;
@@ -155,11 +202,13 @@ describe('userService.reactivate()', () => {
     });
 
     it('en cas d\'erreur dans la transaction, lance une ServiceError', async () => {
+        findOneUser.resolves(fakeUser());
+
         const error = new Error('test');
         transaction.commit.rejects(error);
 
         try {
-            await reactivateUser(42);
+            await reactivateUser(fakeUser(), 42);
         } catch (e) {
             expect(e).to.be.an.instanceof(ServiceError);
             expect(e.code).to.be.equal('transaction_failure');
@@ -171,11 +220,13 @@ describe('userService.reactivate()', () => {
     });
 
     it('en cas d\'erreur dans la transaction, rollback', async () => {
+        findOneUser.resolves(fakeUser());
+
         const error = new Error('test');
         transaction.commit.rejects(error);
 
         try {
-            await reactivateUser(42);
+            await reactivateUser(fakeUser(), 42);
         } catch (e) {
             expect(transaction.rollback).to.have.been.called;
             return;

--- a/packages/api/server/services/user/reactivate.spec.ts
+++ b/packages/api/server/services/user/reactivate.spec.ts
@@ -95,6 +95,16 @@ describe('userService.reactivate()', () => {
         );
     });
 
+    it('si l\'utilisateur est passé en statut \'new\', retourne l\'utilisateur mis à jour', async () => {
+        const activator = fakeUser({ id: 1 });
+        const user = fakeUser({ id: 42, status: 'new', permission_options: ['access_justice'] });
+        const updatedUser = fakeUser({ id: 423, status: 'new', permission_options: ['access_justice'] });
+        findOneUser.withArgs(42).onFirstCall().resolves(user);
+        findOneUser.withArgs(42).onSecondCall().resolves(updatedUser);
+
+        expect(await reactivateUser(activator, 42)).to.be.eql(updatedUser);
+    });
+
     it('ignore les erreurs de l\'envoi du mail d\'alerte', async () => {
         const user = fakeUser({ status: 'active' });
         findOneUser.withArgs(42).resolves(user);

--- a/packages/api/server/services/user/reactivate.ts
+++ b/packages/api/server/services/user/reactivate.ts
@@ -33,6 +33,7 @@ export default async (activator: User, id: number): Promise<User> => {
     } else {
         try {
             await sendActivationLink(activator, user, user.permission_options, transaction);
+            user = await findOneUser(id, { extended: true }, null, 'read', transaction);
         } catch (error) {
             await transaction.rollback();
             throw new ServiceError('send_access_failure', error);

--- a/packages/api/server/services/user/reactivate.ts
+++ b/packages/api/server/services/user/reactivate.ts
@@ -1,5 +1,6 @@
 import { sequelize } from '#db/sequelize';
-import userModel from '#server/models/userModel/index';
+import reactivate from '#server/models/userModel/reactivate';
+import findOneUser from '#server/models/userModel/findOne';
 import ServiceError from '#server/errors/ServiceError';
 import mails from '#server/mails/mails';
 import { User } from '#root/types/resources/User.d';
@@ -8,7 +9,7 @@ export default async (id: number): Promise<User> => {
     const transaction = await sequelize.transaction();
 
     try {
-        await userModel.reactivate(id, transaction);
+        await reactivate(id, transaction);
     } catch (error) {
         await transaction.rollback();
         throw new ServiceError('reactivation_failure', error);
@@ -16,7 +17,7 @@ export default async (id: number): Promise<User> => {
 
     let user: User;
     try {
-        user = await userModel.findOne(id, {}, null, 'read', transaction);
+        user = await findOneUser(id, {}, null, 'read', transaction);
     } catch (error) {
         await transaction.rollback();
         throw new ServiceError('refresh_failure', error);

--- a/packages/api/server/services/user/reactivate.ts
+++ b/packages/api/server/services/user/reactivate.ts
@@ -1,11 +1,12 @@
 import { sequelize } from '#db/sequelize';
 import reactivate from '#server/models/userModel/reactivate';
 import findOneUser from '#server/models/userModel/findOne';
+import sendActivationLink from '#server/services/user/sendActivationLink';
 import ServiceError from '#server/errors/ServiceError';
 import mails from '#server/mails/mails';
 import { User } from '#root/types/resources/User.d';
 
-export default async (id: number): Promise<User> => {
+export default async (activator: User, id: number): Promise<User> => {
     const transaction = await sequelize.transaction();
 
     try {
@@ -17,17 +18,10 @@ export default async (id: number): Promise<User> => {
 
     let user: User;
     try {
-        user = await findOneUser(id, {}, null, 'read', transaction);
+        user = await findOneUser(id, { extended: true }, null, 'read', transaction);
     } catch (error) {
         await transaction.rollback();
         throw new ServiceError('refresh_failure', error);
-    }
-
-    try {
-        await transaction.commit();
-    } catch (error) {
-        await transaction.rollback();
-        throw new ServiceError('transaction_failure', error);
     }
 
     if (user.status === 'active') {
@@ -36,6 +30,20 @@ export default async (id: number): Promise<User> => {
         } catch (error) {
             // ignore
         }
+    } else {
+        try {
+            await sendActivationLink(activator, user, user.permission_options, transaction);
+        } catch (error) {
+            await transaction.rollback();
+            throw new ServiceError('send_access_failure', error);
+        }
+    }
+
+    try {
+        await transaction.commit();
+    } catch (error) {
+        await transaction.rollback();
+        throw new ServiceError('transaction_failure', error);
     }
 
     return user;

--- a/packages/api/server/services/user/sendActivationLink.spec.ts
+++ b/packages/api/server/services/user/sendActivationLink.spec.ts
@@ -1,0 +1,170 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { rewiremock } from '#test/rewiremock';
+import { serialized as fakeUser } from '#test/utils/user';
+import ServiceError from '#server/errors/ServiceError';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+const sandbox = sinon.createSandbox();
+const sequelize = {
+    transaction: sandbox.stub(),
+};
+const setPermissionOptions = sandbox.stub();
+const findSingleUser = sandbox.stub();
+const createUserAccess = sandbox.stub();
+const accessRequestService = {
+    resetRequestsForUser: sandbox.stub(),
+    handleAccessRequestApproved: sandbox.stub(),
+};
+const authUtils = {
+    getExpiracyDateForActivationTokenCreatedAt: sandbox.stub(),
+};
+
+rewiremock('#db/config/sequelize').with(sequelize);
+rewiremock('#server/models/userModel/setPermissionOptions').with(setPermissionOptions);
+rewiremock('#server/models/userModel/findOne').with(findSingleUser);
+rewiremock('#server/models/userAccessModel/create').with(createUserAccess);
+rewiremock('#server/services/accessRequest/accessRequestService').with(accessRequestService);
+rewiremock('#server/utils/auth').with(authUtils);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import sendActivationLink from './sendActivationLink';
+rewiremock.disable();
+
+describe('userService/sendActivationLink', () => {
+    let transaction;
+    beforeEach(() => {
+        transaction = {
+            commit: sandbox.stub(),
+            rollback: sandbox.stub(),
+        };
+        sequelize.transaction.withArgs().resolves(transaction);
+    });
+
+    afterEach(() => {
+        sandbox.reset();
+    });
+
+    it('crée une transaction si aucune transaction n\'est passée en paramètre', async () => {
+        authUtils.getExpiracyDateForActivationTokenCreatedAt.returns(new Date());
+        await sendActivationLink(fakeUser({ id: 42 }), fakeUser({ id: 1 }), [], {} as any);
+        expect(sequelize.transaction).to.not.have.been.called;
+    });
+
+    it('met à jour les options de l\'utilisateur', async () => {
+        const activator = fakeUser({ id: 42 });
+        const user = fakeUser({ id: 1 });
+        authUtils.getExpiracyDateForActivationTokenCreatedAt.returns(new Date());
+
+        await sendActivationLink(activator, user, ['option1', 'option2']);
+        expect(setPermissionOptions).to.have.been.calledOnceWith(user.id, ['option1', 'option2'], transaction);
+    });
+
+    it('crée un nouvel accès pour l\'utilisateur', async () => {
+        const activator = fakeUser({ id: 42 });
+        const user = fakeUser({ id: 1 });
+        const now = new Date();
+        const expiresAt = new Date();
+        authUtils.getExpiracyDateForActivationTokenCreatedAt.withArgs(now).returns(expiresAt);
+
+        await sendActivationLink(activator, user);
+        expect(createUserAccess).to.have.been.calledOnceWith({
+            fk_user: 1,
+            sent_by: 42,
+            created_at: now,
+            expires_at: expiresAt,
+        });
+    });
+
+    it('met en place les mails de relances automatiques pour l\'utilisateur', async () => {
+        const activator = fakeUser({ id: 42 });
+        const user = fakeUser({ id: 1 });
+
+        createUserAccess.resolves(1989);
+        authUtils.getExpiracyDateForActivationTokenCreatedAt.returns(new Date(2024, 1, 1));
+
+        await sendActivationLink(activator, user);
+        expect(accessRequestService.resetRequestsForUser).to.have.been.calledOnceWith(user);
+        expect(accessRequestService.handleAccessRequestApproved).to.have.been.calledOnceWith(user, {
+            id: 1989,
+            expires_at: 1706742000,
+            sent_by: activator,
+        });
+    });
+
+    it('retourne l\'utilisateur mis à jour', async () => {
+        const refreshedUser = fakeUser({ id: 1, status: 'active' });
+
+        authUtils.getExpiracyDateForActivationTokenCreatedAt.returns(new Date());
+        findSingleUser.resolves(refreshedUser);
+        const response = await sendActivationLink(fakeUser({ id: 42 }), fakeUser({ id: 1 }));
+
+        expect(response).to.be.eql(refreshedUser);
+    });
+
+    it('exécute l\'ensemble des requêtes dans une transaction', async () => {
+        authUtils.getExpiracyDateForActivationTokenCreatedAt.returns(new Date());
+
+        await sendActivationLink(fakeUser({ id: 42 }), fakeUser({ id: 1 }));
+
+        expect(setPermissionOptions.getCall(0).args[2]).to.be.eql(transaction);
+        expect(createUserAccess.getCall(0).args[1]).to.be.eql(transaction);
+        expect(findSingleUser.getCall(0).args[4]).to.be.eql(transaction);
+        expect(transaction.commit).to.have.been.calledOnce;
+    });
+
+    it('ne commit pas la transaction s\'il s\'agit d\'une transaction passée en paramètre', async () => {
+        authUtils.getExpiracyDateForActivationTokenCreatedAt.returns(new Date());
+        await sendActivationLink(fakeUser({ id: 42 }), fakeUser({ id: 1 }), [], transaction);
+
+        expect(transaction.commit).to.not.have.been.called;
+    });
+
+    it('en cas d\'erreur, rollback la transaction', async () => {
+        const error = new Error('test');
+        setPermissionOptions.rejects(error);
+
+        try {
+            await sendActivationLink(fakeUser({ id: 42 }), fakeUser({ id: 1 }));
+        } catch (e) {
+            expect(transaction.rollback).to.have.been.called;
+            return;
+        }
+
+        expect.fail('should have thrown an error');
+    });
+
+    it('en cas d\'erreur, ne rollback pas la transaction s\'il s\'agit d\'une transaction passée en paramètre', async () => {
+        const error = new Error('test');
+        setPermissionOptions.rejects(error);
+
+        try {
+            await sendActivationLink(fakeUser({ id: 42 }), fakeUser({ id: 1 }), [], transaction);
+        } catch (e) {
+            expect(transaction.rollback).to.not.have.been.called;
+            return;
+        }
+
+        expect.fail('should have thrown an error');
+    });
+
+    it('en cas d\'erreur, lance une ServiceError', async () => {
+        const error = new Error('test');
+        setPermissionOptions.rejects(error);
+
+        try {
+            await sendActivationLink(fakeUser({ id: 42 }), fakeUser({ id: 1 }));
+        } catch (e) {
+            expect(e).to.be.an.instanceof(ServiceError);
+            expect(e.code).to.be.equal('generic_failure');
+            expect(e.nativeError).to.be.equal(error);
+            return;
+        }
+
+        expect.fail('should have thrown an error');
+    });
+});

--- a/packages/api/server/services/user/sendActivationLink.spec.ts
+++ b/packages/api/server/services/user/sendActivationLink.spec.ts
@@ -69,7 +69,7 @@ describe('userService/sendActivationLink', () => {
         const user = fakeUser({ id: 1 });
         const now = new Date();
         const expiresAt = new Date();
-        authUtils.getExpiracyDateForActivationTokenCreatedAt.withArgs(now).returns(expiresAt);
+        authUtils.getExpiracyDateForActivationTokenCreatedAt.returns(expiresAt);
 
         await sendActivationLink(activator, user);
         expect(createUserAccess).to.have.been.calledOnceWith({

--- a/packages/api/server/services/user/sendActivationLink.ts
+++ b/packages/api/server/services/user/sendActivationLink.ts
@@ -1,0 +1,58 @@
+import sequelize from '#db/config/sequelize';
+import setPermissionOptions from '#server/models/userModel/setPermissionOptions';
+import findSingleUser from '#server/models/userModel/findOne';
+import createUserAccess from '#server/models/userAccessModel/create';
+import accessRequestService from '#server/services/accessRequest/accessRequestService';
+import authUtils from '#server/utils/auth';
+import ServiceError from '#server/errors/ServiceError';
+import { Transaction } from 'sequelize';
+import { User } from '#root/types/resources/User.d';
+
+const { getExpiracyDateForActivationTokenCreatedAt } = authUtils;
+
+export default async (activator: User, user: User, options: string[] = [], argTransaction?: Transaction): Promise<User> => {
+    const transaction = argTransaction || await sequelize.transaction();
+    let refreshedUser: User;
+
+    try {
+        // on met à jour les options de l'utilisateur
+        await setPermissionOptions(user.id, options, transaction);
+
+        // on crée les accès
+        const now = new Date();
+        const expiresAt = getExpiracyDateForActivationTokenCreatedAt(now);
+        const userAccessId = await createUserAccess({
+            fk_user: user.id,
+            sent_by: activator.id,
+            created_at: now,
+            expires_at: expiresAt,
+        }, transaction);
+
+        // on remet à zéro les mails planifiés de relance pour cet utilisateur
+        await accessRequestService.resetRequestsForUser(user);
+        await accessRequestService.handleAccessRequestApproved(
+            user,
+            {
+                id: userAccessId,
+                expires_at: expiresAt.getTime() / 1000,
+                sent_by: activator,
+            },
+        );
+
+        // refresh the user
+        refreshedUser = await findSingleUser(user.id, undefined, undefined, undefined, transaction);
+
+        // on commit la transaction
+        if (argTransaction === undefined) {
+            await transaction.commit();
+        }
+    } catch (error) {
+        if (argTransaction === undefined) {
+            await transaction.rollback();
+        }
+
+        throw new ServiceError('generic_failure', error);
+    }
+
+    return refreshedUser;
+};

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/actions/reactivate.action.js
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/actions/reactivate.action.js
@@ -9,6 +9,6 @@ export default async function (user) {
     accesStore.updateUser(user.id, updatedUser);
     notificationStore.success(
         "Réactivation de l'accès",
-        "L'accès de cet utilisateur a bien été rétabli."
+        "L'accès de cet utilisateur a bien été rétabli et ce dernier a été notifié par mail."
     );
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/I8eAallV/2042

## 🛠 Description de la PR
- remise à niveau complète du contrôleur `sendActivationLink` de façon à déporter la logique métier dans un service dédié et réutilisable
- remise à niveau au passage dudit contrôleur avec les standards actuels (validateur, types, tests unitaires, etc.)
- modification du service `reactivate` pour faire un appel au service `sendActivationLink` quand nécessaire
- légère modification du wording côté front dans la notification de succès, pour préciser qu'un accès a été automatiquement envoyé

## 📸 Captures d'écran
Le changement de wording :
<img width="421" alt="Capture d’écran 2024-01-18 à 09 04 23" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/0a55a108-fb3a-4aaf-bf91-07548a6876d5">

## 🚨 Notes pour la mise en production
RàS