### PR TITLE
#patch (2067) Le tableau de sélection d'utilisateurs disparaît après plusieurs clics (journal du site)

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournalFormNouveauMessage/FicheSiteJournalFormNouveauMessage.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournalFormNouveauMessage/FicheSiteJournalFormNouveauMessage.vue
@@ -11,7 +11,7 @@
                 <FormNouveauMessageInputTags />
                 <FormNouveauMessageInputMode @click="onModeChange" />
                 <FormNouveauMessageInputTarget
-                    v-if="values.mode === 'custom'"
+                    v-show="values.mode === 'custom'"
                     :departement="town.departement.code"
                 />
                 <p class="text-sm mb-4">


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ZdhtT4LL/2067

## 🛠 Description de la PR
Le problème était lié à vee-validate : lorsque le champ apparaissait, un appel à `useField` était fait, avec le `name` du champ.
La première fois cela fonctionne normalement, mais si l'on fait disparaître puis réapparaître le champ, un nouvel appel à `useField` est fait et vee-validate refuse la demande car le champ existe théoriquement déjà pour lui.
La solution était donc simplement d'utiliser `v-show` pour éviter que le champ ne soit instancié plusieurs fois.

## 📸 Captures d'écran
Ce à quoi cela doit ressemble à chaque sélection de "Une liste d'utilisateurs personnalisés" :
<img width="1111" alt="Capture d’écran 2024-01-18 à 09 09 09" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/3649ca6c-b543-44cb-ac50-16c263606880">

Mais après deux clics, on reste bloqués sur :
<img width="1053" alt="Capture d’écran 2024-01-18 à 09 09 05" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/5edb6269-2c4d-4db5-87ea-81898de28ba8">

## 🚨 Notes pour la mise en production
RàS