### PR TITLE
#patch (2058) Changement de wording pour mieux gérer le singulier/pluriel sur actions terminées d'un site

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActions.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActions.vue
@@ -16,8 +16,8 @@
 
         <section v-if="actions.ended.length > 0" class="mt-6">
             <Button @click="toggleEndedActions"
-                >{{ showEndedActions ? "Masquer" : "Voir" }} les
-                {{ actions.ended.length }} actions terminées sur ce site</Button
+                >{{ showEndedActions ? "Masquer" : "Voir" }}
+                {{ actionEndedWording }}</Button
             >
             <div class="grid grid-cols-2 gap-4 mt-4" v-if="showEndedActions">
                 <CarteActionDeSite
@@ -55,6 +55,13 @@ const actions = computed(() => {
         },
         { onGoing: [], ended: [] }
     );
+});
+
+const actionEndedWording = computed(() => {
+    const total = actions.value.ended.length;
+    return total === 1
+        ? "la seule action terminée"
+        : `les ${total} actions terminées`;
 });
 
 function toggleEndedActions() {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/dmD6gHXj/2058

## 🛠 Description de la PR
Rien de particulier, soit `Voir la seule action terminée`, soit `Voir les X actions terminées`.

## 📸 Captures d'écran
Avant : 
<img width="1170" alt="Capture d’écran 2024-01-18 à 09 13 15" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/2d6b8603-2b0e-4e70-8e27-f5dd6c588987">

Après :
<img width="1169" alt="Capture d’écran 2024-01-18 à 09 13 53" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/3823689b-85a9-4b74-8a25-4639a4ccdc68">

Et bien sûr le cas du pluriel qui n'a pas changé :
<img width="1161" alt="Capture d’écran 2024-01-18 à 09 13 31" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/efa109dd-1b3a-4307-b174-96bc5ad5a8ef">

## 🚨 Notes pour la mise en production
RàS