### PR TITLE
#patch (2074) L'icône "poubelle" est manquante dans le lien de suppression d'un message

### DIFF
--- a/packages/frontend/webapp/src/components/CarteCommentaire/CarteCommentaire.vue
+++ b/packages/frontend/webapp/src/components/CarteCommentaire/CarteCommentaire.vue
@@ -13,7 +13,7 @@
                 v-if="showActionIcons && (isOwner || (canModerate && isHover))"
                 @click="deleteMessage"
                 >Supprimer {{ isOwner ? "mon" : "le" }} message
-                <Icon icon="fa-trash-alt" alt="Supprimer le message"
+                <Icon icon="trash-alt" alt="Supprimer le message"
             /></span>
         </div>
         <div class="text-G600 text-sm mb-1" v-if="comment.covid?.date">


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/LsbOYDFo/2074

## 🛠 Description de la PR
Juste une mauvaise référence de l'id de l'icône à utiliser...

## 📸 Captures d'écran
Avant :
<img width="1094" alt="Capture d’écran 2024-01-18 à 09 16 07" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/deecb3c2-91ab-40f7-aac5-80070fcfbefc">

Après :
<img width="1093" alt="Capture d’écran 2024-01-18 à 09 16 30" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/82997d36-0b64-4200-99a5-f631299af5d5">

## 🚨 Notes pour la mise en production
RàS