### PR TITLE
#patch (2053) Afficher le nombre de sites sous chaque onglet, dans la liste des sites

### DIFF
--- a/packages/frontend/ui/src/components/TabList/Tab.vue
+++ b/packages/frontend/ui/src/components/TabList/Tab.vue
@@ -6,6 +6,9 @@
             ? 'text-primary font-bold border-primary'
             : 'cursor-pointer border-transparent'
     ]">
+        <span v-if="$slots.prefix" class="mr-1 rounded text-sm px-1 border" :class="[
+            active ? 'border-transparent text-white bg-primary' : 'border-primary text-primary',
+        ]"><slot name="prefix" /></span>
         <slot />
     </button>
 </template>

--- a/packages/frontend/ui/src/components/TabList/TabList.vue
+++ b/packages/frontend/ui/src/components/TabList/TabList.vue
@@ -1,7 +1,9 @@
 <template>
     <div>
-        <Tab v-for="tab in tabs" :key="tab.id" :active="activeTab === tab.id" @click="onTabClick(tab.id)">{{ tab.label
-        }}</Tab>
+        <Tab v-for="tab in tabs" :key="tab.id" :active="activeTab === tab.id" @click="onTabClick(tab.id)">
+            <template v-slot:prefix>{{ tab.total }}</template>
+            {{ tab.label }}
+        </Tab>
     </div>
 </template>
 

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.vue
@@ -32,10 +32,24 @@ import ListeDesSitesListe from "./ListeDesSitesListe.vue";
 import ListeDesSitesVide from "./ListeDesSitesVide.vue";
 
 const townsStore = useTownsStore();
-const tabs = [
-    { id: "open", label: "Sites existants" },
-    { id: "close", label: "Sites fermés" },
-];
+const tabs = computed(() => [
+    {
+        id: "open",
+        label:
+            townsStore.prefilteredTowns.open.length <= 1
+                ? "Site existant"
+                : "Sites existants",
+        total: townsStore.prefilteredTowns.open.length,
+    },
+    {
+        id: "close",
+        label:
+            townsStore.prefilteredTowns.close.length <= 1
+                ? "Site fermé"
+                : "Sites fermés",
+        total: townsStore.prefilteredTowns.close.length,
+    },
+]);
 const currentTab = computed({
     get() {
         return townsStore.filters.status;

--- a/packages/frontend/webapp/src/stores/towns.store.js
+++ b/packages/frontend/webapp/src/stores/towns.store.js
@@ -42,13 +42,24 @@ export const useTownsStore = defineStore("towns", () => {
     const heatwaveStatuses = ref({});
     const exportOptions = ref([]);
     const sort = ref("updatedAt");
+    const prefilteredTowns = computed(() => {
+        return {
+            open: filterShantytowns(towns.value, {
+                status: "open",
+                search: filters.search.value,
+                location: filters.location.value,
+                ...filters.properties.value,
+            }),
+            close: filterShantytowns(towns.value, {
+                status: "close",
+                search: filters.search.value,
+                location: filters.location.value,
+                ...filters.properties.value,
+            }),
+        };
+    });
     const filteredTowns = computed(() => {
-        return filterShantytowns(towns.value, {
-            status: filters.status.value,
-            search: filters.search.value,
-            location: filters.location.value,
-            ...filters.properties.value,
-        }).sort(sortFn.value);
+        return prefilteredTowns.value[filters.status.value].sort(sortFn.value);
     });
     const townCategoryFilter = ref([]);
     const configStore = useConfigStore();
@@ -186,6 +197,7 @@ export const useTownsStore = defineStore("towns", () => {
 
             return Math.ceil(filteredTowns.value.length / ITEMS_PER_PAGE);
         }),
+        prefilteredTowns,
         filteredTowns,
         async fetchTowns() {
             if (isLoading.value === true) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/23F4bSEB/2053

## 🛠 Description de la PR
- modification du composant `Tab` pour permettre d'y inclure un préfixe
- modification du townsStore pour exposer une propriété `prefilteredTowns` qui permet d'obtenir à tout moment le total de sites ouverts et de sites fermés respectant les filtres en cours
- modification de la liste des sites pour afficher ce total dans chaque onglet

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/6d79380c-96de-4541-a772-b1af62ef6ff0)

## 🚨 Notes pour la mise en production
RàS