### PR TITLE
#patch (2090) La vue d'ensemble ne charge pas sur les territoires où aucun utilisateur ne s'est connecté sur la semaine

### DIFF
--- a/packages/api/server/models/statsModel/_common/decomposeForDiagramm.ts
+++ b/packages/api/server/models/statsModel/_common/decomposeForDiagramm.ts
@@ -97,7 +97,13 @@ export default (towns, connectedUsers, listOfDates) => {
     minors.evolution = Math.round(parseFloat((((minors.data.slice(-1)[0].figure - minors.data[0].figure) * 100) / minors.data[0].figure).toFixed(2)));
     closedShantytowns.evolution = Math.round(parseFloat((((closedShantytowns.data.slice(-1)[0].figure - closedShantytowns.data[0].figure) * 100) / closedShantytowns.data[0].figure).toFixed(2)));
     resorbedShantytowns.evolution = Math.round(parseFloat((((resorbedShantytowns.data.slice(-1)[0].figure - resorbedShantytowns.data[0].figure) * 100) / resorbedShantytowns.data[0].figure).toFixed(2)));
-    connectedUserStats.evolution = Math.round(parseFloat((((connectedUserStats.data.slice(-1)[0].figure - connectedUserStats.data[0].figure) * 100) / connectedUserStats.data[0].figure).toFixed(2)));
+    connectedUserStats.evolution = connectedUserStats.data.length > 0 ? Math.round(
+        parseFloat(
+            (
+                ((connectedUserStats.data.slice(-1)[0].figure - connectedUserStats.data[0].figure) * 100) / connectedUserStats.data[0].figure
+            ).toFixed(2),
+        ),
+    ) : 0;
 
     return {
         population, minors, closedShantytowns, resorbedShantytowns, connectedUserStats, openShantytowns, minorsInSchool,

--- a/packages/api/server/models/statsModel/getStats.ts
+++ b/packages/api/server/models/statsModel/getStats.ts
@@ -145,7 +145,7 @@ export default async (user: User, location: Location) => {
     if (shantytownStats.length === 0) {
         return null;
     }
-    const listOfDates = getArrayOfDates(otherDate, date);
 
+    const listOfDates = getArrayOfDates(otherDate, date);
     return decomposeForDiagramm(shantytownStats, connectedUsers, listOfDates);
 };

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
@@ -14,7 +14,10 @@
             <div>
                 <div class="font-bold text-primary text-xl -mb-1">
                     <span>
-                        {{ formatStat(cardStats.data.slice(-1)[0].figure) }}
+                        <template v-if="cardStats.data.length > 0">{{
+                            formatStat(cardStats.data.slice(-1)[0].figure)
+                        }}</template>
+                        <template v-else>0</template>
                     </span>
                 </div>
                 <p class="leading-tight">
@@ -111,7 +114,9 @@ const props = defineProps({
 });
 const { icon, cardStats } = toRefs(props);
 
-const isEvolutionPositive = computed(() => cardStats.value.evolution >= 0);
+const isEvolutionPositive = computed(
+    () => cardStats.value.data.length > 0 && cardStats.value.evolution >= 0
+);
 const columns = ref([]);
 const evolutionColor = computed(() => {
     return cardStats.value.color === "red"
@@ -138,7 +143,7 @@ function onMouseLeave() {
 }
 
 function setColumns() {
-    if (maxNumber.value === 0) {
+    if (maxNumber.value === 0 || cardStats.value.data.length === 0) {
         return;
     }
 

--- a/packages/frontend/webapp/src/utils/formatGlobalStats.js
+++ b/packages/frontend/webapp/src/utils/formatGlobalStats.js
@@ -60,10 +60,15 @@ export default function (stats) {
             id: "connectedUsers",
             icon: "user",
             label:
+                stats.connectedUserStats.data.length > 0 &&
                 stats.connectedUserStats.data.slice(-1)[0].figure > 1
                     ? "utilisateurs connectés ces 7 derniers jours"
                     : "utilisateur connecté ces 7 derniers jours",
-            color: stats.connectedUserStats.evolution >= 0 ? "green" : "red",
+            color:
+                stats.connectedUserStats.data.length > 0 &&
+                stats.connectedUserStats.evolution >= 0
+                    ? "green"
+                    : "red",
         },
     ];
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/CcxmTu74/2090

## 🛠 Description de la PR
La vue d'ensemble ne prenait pas en compte ce cas où le tableau "connectedUsers" pouvait être vide. C'est un VIEUX bug.

## 📸 Captures d'écran
Voilà à quoi ressemble l'erreur :
<img width="1552" alt="Capture d’écran 2024-01-18 à 18 17 37" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/c409fe0d-dc41-455c-b219-c8ce2fe6602e">

## 🚨 Notes pour la mise en production
RàS