### PR TITLE
#patch (2095) Erreur de rendu des gradients

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/generateDataset.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/generateDataset.js
@@ -11,7 +11,10 @@ function setBackgroundColor(context, bgColor, start = 1) {
     const gradientBg = ctx.createLinearGradient(0, top, 0, bottom);
     if (start < 1) {
         gradientBg.addColorStop(1, "rgba(255, 255, 255, 0)");
-        gradientBg.addColorStop(1 - start, "rgba(255, 255, 255, 0)");
+        gradientBg.addColorStop(
+            Math.max(0, 1 - start - 0.01),
+            "rgba(255, 255, 255, 0)"
+        );
     }
     gradientBg.addColorStop(1 - start, bgColor);
     gradientBg.addColorStop(

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/generateDataset.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/generateDataset.js
@@ -11,7 +11,7 @@ function setBackgroundColor(context, bgColor, start = 1) {
     const gradientBg = ctx.createLinearGradient(0, top, 0, bottom);
     if (start < 1) {
         gradientBg.addColorStop(1, "rgba(255, 255, 255, 0)");
-        gradientBg.addColorStop(1 - start - 0.01, "rgba(255, 255, 255, 0)");
+        gradientBg.addColorStop(1 - start, "rgba(255, 255, 255, 0)");
     }
     gradientBg.addColorStop(1 - start, bgColor);
     gradientBg.addColorStop(


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ULY4HQ1B/2095

## 🛠 Description de la PR
Erreur de rendu du graphe sur l'onglet Synthèse - Loire Atlantique - Période: 014/01/2019 au 22/01/2024
Correction du calcul de gradient sur l'arrière plan.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/50863659/7bc98268-41b5-47a0-a5ef-b5bd3e08dec7)

## 🚨 Notes pour la mise en production
- ràs