### PR TITLE
#patch (2102) L'export des sites ne marche plus

### DIFF
--- a/packages/api/server/loaders/routesLoader.ts
+++ b/packages/api/server/loaders/routesLoader.ts
@@ -514,6 +514,7 @@ export default (app) => {
     app.get(
         '/towns/export',
         middlewares.auth.authenticate,
+        bodyParser.json(),
         (...args: [express.Request, express.Response, Function]) => middlewares.auth.checkPermissions(['shantytown.export'], ...args),
         middlewares.charte.check,
         validators.exportTowns,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/eKI0ehbs/2102

## 🛠 Description de la PR
Suite à la mep des pièces-jointes, toutes les requêtes n'ont pas de `req.body` par défaut, notamment les requêtes `GET`, ce qui pose un problème à l'export des sites car le validateur de ce dernier essaie d'écrire dans `req.body` alors qu'il n'existe pas.

Un simple ajout d'un `bodyParser.json()` suffit à résoudre le problème.
J'ai contrôlé l'ensemble des routes dans le cadre de cette PR, c'était le seul cas de ce genre.