### PR TITLE
#patch (2094) Éviter qu'un utilisateur fraîchement réactivé ne soit identifié comme inactif

### DIFF
--- a/packages/api/server/models/userModel/reactivate.ts
+++ b/packages/api/server/models/userModel/reactivate.ts
@@ -10,7 +10,16 @@ export default async (id: number, transaction: Transaction = undefined): Promise
                 WHEN users.password IS NULL THEN 'new'
                 ELSE 'active'
             END,
-            updated_at = NOW()
+            updated_at = NOW(),
+
+            -- les deux lignes suivantes sont nécessaires pour éviter
+            -- que l'utilisateur ne soit identifié comme utilisateur inactif
+            -- depuis trop longtemps et qu'il se retrouve automatiquement désactivé
+            last_access = CASE
+                WHEN users.password IS NULL THEN NULL
+                ELSE NOW()
+            END,
+            inactivity_alert_sent_at = NULL
         WHERE
             user_id = :id
         `,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/RQDLKQJW/2094

## 🛠 Description de la PR
Lorsqu'on réactive un utilisateur il ne faut pas se contenter de changer son status pour éviter qu'il ne soit automatiquement identifié comme utilisateur inactif et qu'il soit alerté de son inactivité ou, pire, qu'il soit automatiquement désactivé.