### PR TITLE
#patch (2139) Le dépôt de messages réservés aux services de l'état ne marche plus

### DIFF
--- a/packages/api/server/models/organizationModel/findPrefAndDdets.ts
+++ b/packages/api/server/models/organizationModel/findPrefAndDdets.ts
@@ -6,8 +6,9 @@ export default shantytown => sequelize.query(
        SELECT organizations.organization_id AS id
          FROM organizations
     LEFT JOIN organization_types ON organizations.fk_type = organization_types.organization_type_id
+    LEFT JOIN intervention_areas ON intervention_areas.fk_organization = organizations.organization_id
         WHERE     organization_types.uid IN (:types)
-              AND (organizations.fk_region = :region OR organizations.fk_departement = :departement)`,
+              AND (intervention_areas.fk_region = :region OR intervention_areas.fk_departement = :departement)`,
     {
         type: QueryTypes.SELECT,
         replacements: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kmzbI3GR/2139

## 🛠 Description de la PR
Bug détecté sur Sentry, causé par une vieille requête qui n'avait pas été adaptée au passage à `intervention_areas`.

## 🚨 Notes pour la mise en production
RàS