### PR TITLE
#minor (2014) Permettre la modification du territoire d'intervention d'un utilisateur

### DIFF
--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.route.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.route.ts
@@ -1,0 +1,10 @@
+import { type ApplicationWithCustomRoutes } from '#server/loaders/customRouteMethodsLoader';
+import validator from './user.setInterventionAreas.validator';
+import controller from './user.setInterventionAreas';
+
+export default (app: ApplicationWithCustomRoutes): void => {
+    app.customRoutes.put('/users/:id/intervention-areas', controller, validator, {
+        authenticate: true,
+        multipart: false,
+    });
+};

--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
@@ -1,0 +1,33 @@
+
+import {
+    type Request, type Response, type NextFunction,
+} from 'express';
+import setInterventionAreas from '#server/services/user/setInterventionAreas';
+import { User } from '#root/types/resources/User.d';
+import { InputInterventionArea } from '#root/types/inputs/InterventionArea.d';
+
+interface UserSetInterventionAreasRequest extends Request {
+    user: User,
+    userToUpdate: User,
+    body: {
+        organization_areas: InputInterventionArea[],
+        user_areas: InputInterventionArea[],
+    }
+}
+
+export default async (req: UserSetInterventionAreasRequest, res: Response, next: NextFunction) => {
+    try {
+        const user = await setInterventionAreas(
+            req.user,
+            req.userToUpdate,
+            req.body.organization_areas,
+            req.body.user_areas,
+        );
+        res.status(200).send(user);
+    } catch (error) {
+        res.status(500).send({
+            user_message: 'Une erreur inconnue est survenue',
+        });
+        next(error);
+    }
+};

--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.validator.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.validator.ts
@@ -11,7 +11,7 @@ export default [
         .isInt().bail().withMessage('L\'identifiant de l\'utilisateur à modifier est invalide')
         .custom(async (value, { req }) => {
             if (req.user.id === value) {
-                throw new Error('Vous ne pouvez pas modifier vos propre territoires d\'intervention');
+                throw new Error('Vous ne pouvez pas modifier vos propres territoires d\'intervention');
             }
 
             let user: User;

--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.validator.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.validator.ts
@@ -1,0 +1,86 @@
+/* eslint-disable newline-per-chained-call */
+import { body, param } from 'express-validator';
+import getLocation from '#server/models/geoModel/getLocation';
+import findOneUser from '#server/models/userModel/findOne';
+import { Location } from '#server/models/geoModel/Location.d';
+import { User } from '#root/types/resources/User.d';
+
+export default [
+    param('id')
+        .toInt()
+        .isInt().bail().withMessage('L\'identifiant de l\'utilisateur à modifier est invalide')
+        .custom(async (value, { req }) => {
+            let user: User;
+            try {
+                user = await findOneUser(value, undefined, req.user, 'activate');
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la recherche de l\'utilisateur en base de données');
+            }
+
+            if (user === null) {
+                throw new Error('L\'utilisateur à mettre à jour est introuvable en base de données');
+            }
+
+            req.userToUpdate = user;
+            return true;
+        }),
+
+    body('organization_areas')
+        .isArray({ min: 1 }).withMessage('Vous devez préciser un ou plusieurs territoires d\'intervention pour la structure')
+        .custom(async (value, { req }) => {
+            let locations: Location[];
+            try {
+                locations = await Promise.all(
+                    value.map(({ code, type }) => getLocation(type, code)),
+                );
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification des territoires d\'intervention de la structure');
+            }
+
+            const errors = locations.reduce((acc, v, index) => {
+                if (v !== null) {
+                    return acc;
+                }
+
+                acc.push(v[index]?.name || 'nom inconnu');
+                return acc;
+            }, []);
+            if (errors.length > 0) {
+                throw new Error(`Les territoires d'intervention suivants n'ont pas été retrouvés en base de données : ${errors.join(', ')}`);
+            }
+
+            req.organizationAreas = locations;
+            return true;
+        }),
+
+    body('user_areas')
+        .optional({ nullable: true })
+        .isArray().withMessage('La liste des territoires d\'intervention de l\'utilisateur doit être un tableau')
+        .custom(async (value, { req }) => {
+            let locations: Location[];
+            try {
+                locations = await Promise.all(
+                    value.map(({ code, type }) => getLocation(type, code)),
+                );
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification des territoires d\'intervention de la structure');
+            }
+
+            const errors = locations.reduce((acc, v, index) => {
+                if (v !== null) {
+                    return acc;
+                }
+
+                acc.push(v[index]?.name || 'nom inconnu');
+                return acc;
+            }, []);
+            if (errors.length > 0) {
+                throw new Error(`Les territoires d'intervention suivants n'ont pas été retrouvés en base de données : ${errors.join(', ')}`);
+            }
+
+            req.userAreas = locations;
+            return true;
+        }),
+    body('user_areas')
+        .customSanitizer(value => value || []),
+];

--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.validator.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.validator.ts
@@ -10,6 +10,10 @@ export default [
         .toInt()
         .isInt().bail().withMessage('L\'identifiant de l\'utilisateur à modifier est invalide')
         .custom(async (value, { req }) => {
+            if (req.user.id === value) {
+                throw new Error('Vous ne pouvez pas modifier vos propre territoires d\'intervention');
+            }
+
             let user: User;
             try {
                 user = await findOneUser(value, undefined, req.user, 'activate');

--- a/packages/api/server/models/organizationModel/create.ts
+++ b/packages/api/server/models/organizationModel/create.ts
@@ -1,12 +1,12 @@
 import { sequelize } from '#db/sequelize';
-import { LocationType } from '#server/models/geoModel/LocationType.d';
 import { type Transaction } from 'sequelize';
+import { InputInterventionArea } from '#root/types/inputs/InterventionArea.d';
 
 type OrganizationCreateData = {
     type: number,
     name: string,
     abbreviation: string,
-    intervention_areas: { type: LocationType, code: string | null }[],
+    intervention_areas: InputInterventionArea[],
 };
 
 export default async (createdBy: number, data: OrganizationCreateData, argTransaction?: Transaction): Promise<number> => {

--- a/packages/api/server/models/organizationModel/setInterventionAreas.ts
+++ b/packages/api/server/models/organizationModel/setInterventionAreas.ts
@@ -1,0 +1,50 @@
+import { type Transaction } from 'sequelize';
+import { sequelize } from '#db/sequelize';
+import { InputInterventionArea } from '#root/types/inputs/InterventionArea.d';
+
+export default async (organizationId: number, interventionAreas: InputInterventionArea[], argTransaction?: Transaction): Promise<void> => {
+    const isLocalTransaction = argTransaction === undefined;
+    let transaction = argTransaction;
+    if (isLocalTransaction) {
+        transaction = await sequelize.transaction();
+    }
+
+    try {
+        await sequelize.query(
+            'DELETE FROM intervention_areas WHERE fk_organization = :organizationId AND is_main_area IS TRUE',
+            {
+                replacements: {
+                    organizationId,
+                },
+                transaction,
+            },
+        );
+        if (interventionAreas.length === 0) {
+            throw new Error('Cannot set an empty list of areas for an organization');
+        }
+
+        await sequelize.getQueryInterface().bulkInsert(
+            'intervention_areas',
+            interventionAreas.map(({ type, code }) => ({
+                fk_organization: organizationId,
+                is_main_area: true,
+                type,
+                fk_region: type === 'region' ? code : null,
+                fk_departement: type === 'departement' ? code : null,
+                fk_epci: type === 'epci' ? code : null,
+                fk_city: type === 'city' ? code : null,
+            })),
+            { transaction },
+        );
+
+        if (isLocalTransaction) {
+            await transaction.commit();
+        }
+    } catch (error) {
+        if (isLocalTransaction) {
+            await transaction.rollback();
+        }
+
+        throw error;
+    }
+};

--- a/packages/api/server/models/userModel/setInterventionAreas.ts
+++ b/packages/api/server/models/userModel/setInterventionAreas.ts
@@ -1,0 +1,48 @@
+import { type Transaction } from 'sequelize';
+import { sequelize } from '#db/sequelize';
+import { InputInterventionArea } from '#root/types/inputs/InterventionArea.d';
+
+export default async (userId: number, interventionAreas: InputInterventionArea[], argTransaction?: Transaction): Promise<void> => {
+    const isLocalTransaction = argTransaction === undefined;
+    let transaction = argTransaction;
+    if (isLocalTransaction) {
+        transaction = await sequelize.transaction();
+    }
+
+    try {
+        await sequelize.query(
+            'DELETE FROM intervention_areas WHERE fk_user = :userId AND is_main_area IS TRUE',
+            {
+                replacements: {
+                    userId,
+                },
+                transaction,
+            },
+        );
+        if (interventionAreas.length > 0) {
+            await sequelize.getQueryInterface().bulkInsert(
+                'intervention_areas',
+                interventionAreas.map(({ type, code }) => ({
+                    fk_user: userId,
+                    is_main_area: true,
+                    type,
+                    fk_region: type === 'region' ? code : null,
+                    fk_departement: type === 'departement' ? code : null,
+                    fk_epci: type === 'epci' ? code : null,
+                    fk_city: type === 'city' ? code : null,
+                })),
+                { transaction },
+            );
+        }
+
+        if (isLocalTransaction) {
+            await transaction.commit();
+        }
+    } catch (error) {
+        if (isLocalTransaction) {
+            await transaction.rollback();
+        }
+
+        throw error;
+    }
+};

--- a/packages/api/server/services/organization/create.ts
+++ b/packages/api/server/services/organization/create.ts
@@ -4,13 +4,13 @@ import createOrganizationType from '#server/models/organizationTypeModel/create'
 import createOrganization from '#server/models/organizationModel/create';
 import findOrganizationById from '#server/models/organizationModel/findOneById';
 import ServiceError from '#server/errors/ServiceError';
-import { LocationType } from '#server/models/geoModel/LocationType.d';
 import { Organization } from '#root/types/resources/Organization.d';
+import { InputInterventionArea } from '#root/types/inputs/InterventionArea.d';
 
 export type OrganizationCreateInput = {
     name: string,
     abbreviation: string | null,
-    intervention_areas: { type: LocationType, code: string | null }[],
+    intervention_areas: InputInterventionArea[],
 } & ({
     type: number,
     new_type_category: null,

--- a/packages/api/server/services/user/setInterventionAreas.spec.ts
+++ b/packages/api/server/services/user/setInterventionAreas.spec.ts
@@ -1,0 +1,125 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { rewiremock } from '#test/rewiremock';
+import ServiceError from '#server/errors/ServiceError';
+import { serialized as fakeUser } from '#test/utils/user';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+// mock all dependencies
+const sandbox = sinon.createSandbox();
+const sequelize = {
+    transaction: sandbox.stub(),
+};
+const transaction = {
+    commit: sandbox.stub(),
+    rollback: sandbox.stub(),
+};
+const findOneUser = sandbox.stub();
+const setOrganizationInterventionAreas = sandbox.stub();
+const setUserInterventionAreas = sandbox.stub();
+
+rewiremock('#db/sequelize').with({ sequelize });
+rewiremock('#server/models/userModel/findOne').withDefault(findOneUser);
+rewiremock('#server/models/organizationModel/setInterventionAreas').withDefault(setOrganizationInterventionAreas);
+rewiremock('#server/models/userModel/setInterventionAreas').withDefault(setUserInterventionAreas);
+
+rewiremock.enable();
+// eslint-disable-next-line import/first, import/newline-after-import
+import setInterventionAreas from './setInterventionAreas';
+rewiremock.disable();
+
+describe('services/user/setInterventionAreas', () => {
+    beforeEach(() => {
+        sequelize.transaction.resolves(transaction);
+    });
+    afterEach(() => {
+        sandbox.reset();
+    });
+
+    it('change le territoire d\'intervention de la structure et de l\'utilisateur', async () => {
+        await setInterventionAreas(
+            fakeUser({ id: 1 }),
+            fakeUser({ id: 42 }),
+            [{ type: 'departement', code: '78' }],
+            [{ type: 'city', code: '78000' }],
+        );
+        expect(setOrganizationInterventionAreas).to.have.been.calledOnce;
+        expect(setUserInterventionAreas).to.have.been.calledOnce;
+        expect(setOrganizationInterventionAreas).to.have.been.calledOnceWith(
+            2, [{ type: 'departement', code: '78' }], transaction,
+        );
+        expect(setUserInterventionAreas).to.have.been.calledOnceWith(
+            42, [{ type: 'city', code: '78000' }], transaction,
+        );
+    });
+
+    it('retourne l\'utilisateur mis à jour', async () => {
+        const user = fakeUser({ id: 1 });
+        const userToUpdate = fakeUser({ id: 42 });
+        const userUpdated = fakeUser({ id: 42000 });
+
+        findOneUser.withArgs(42, { extended: true }, user, undefined, transaction).resolves(userUpdated);
+
+        const response = await setInterventionAreas(
+            user,
+            userToUpdate,
+            [{ type: 'nation', code: null }],
+            [],
+        );
+
+        expect(response).to.be.eql(response);
+    });
+
+    it('exécute l\'ensemble des requêtes dans une transaction', async () => {
+        await setInterventionAreas(
+            fakeUser({ id: 1 }),
+            fakeUser({ id: 42 }),
+            [{ type: 'nation', code: null }],
+            [],
+        );
+
+        expect(transaction.commit).to.have.been.calledOnce;
+        expect(transaction.commit).to.have.been.calledAfter(findOneUser);
+    });
+
+    it('en cas d\'erreur, rollback la transaction', async () => {
+        setOrganizationInterventionAreas.rejects(new Error('Test'));
+
+        try {
+            await setInterventionAreas(
+                fakeUser({ id: 1 }),
+                fakeUser({ id: 42 }),
+                [{ type: 'nation', code: null }],
+                [],
+            );
+        } catch (error) {
+            // ignore
+        }
+
+        expect(transaction.rollback).to.have.been.calledOnce;
+    });
+
+    it('en cas d\'erreur, lance un ServiceError', async () => {
+        const originalError = new Error('test');
+        setOrganizationInterventionAreas.rejects(originalError);
+
+        let caughtError;
+        try {
+            await setInterventionAreas(
+                fakeUser({ id: 1 }),
+                fakeUser({ id: 42 }),
+                [{ type: 'nation', code: null }],
+                [],
+            );
+        } catch (error) {
+            caughtError = error;
+        }
+
+        expect(caughtError).to.be.instanceOf(ServiceError);
+        expect(caughtError.code).to.be.eql('database_error');
+        expect(caughtError.nativeError).to.be.eql(originalError);
+    });
+});

--- a/packages/api/server/services/user/setInterventionAreas.ts
+++ b/packages/api/server/services/user/setInterventionAreas.ts
@@ -1,0 +1,27 @@
+import { sequelize } from '#db/sequelize';
+import ServiceError from '#server/errors/ServiceError';
+import findOneUser from '#server/models/userModel/findOne';
+import setOrganizationInterventionAreas from '#server/models/organizationModel/setInterventionAreas';
+import setUserInterventionAreas from '#server/models/userModel/setInterventionAreas';
+import { InputInterventionArea } from '#root/types/inputs/InterventionArea.d';
+import { User } from '#root/types/resources/User.d';
+
+export default async (updatedBy: User, user: User, organizationAreas: InputInterventionArea[], userAreas: InputInterventionArea[]): Promise<User> => {
+    const transaction = await sequelize.transaction();
+
+    let updatedUser: User;
+    try {
+        await Promise.all([
+            setOrganizationInterventionAreas(user.organization.id, organizationAreas, transaction),
+            setUserInterventionAreas(user.id, userAreas, transaction),
+        ]);
+
+        updatedUser = await findOneUser(user.id, { extended: true }, updatedBy, undefined, transaction);
+        await transaction.commit();
+    } catch (error) {
+        await transaction.rollback();
+        throw new ServiceError('database_error', error);
+    }
+
+    return updatedUser;
+};

--- a/packages/api/types/inputs/InterventionArea.d.ts
+++ b/packages/api/types/inputs/InterventionArea.d.ts
@@ -1,0 +1,3 @@
+import { LocationType } from '#server/models/geoModel/LocationType.d';
+
+export type InputInterventionArea = { type: LocationType, code: string | null };

--- a/packages/frontend/webapp/src/api/organizations.api.js
+++ b/packages/frontend/webapp/src/api/organizations.api.js
@@ -31,12 +31,12 @@ export function autocompleteTerritorialCollectivity(str) {
     );
 }
 
-export function get(id) {
-    return axios.get(`/organizations/${encodeURI(id)}`);
-}
-
 export function create(data) {
     return axios.post("/organizations", data);
+}
+
+export function get(id) {
+    return axios.get(`/organizations/${encodeURI(id)}`);
 }
 
 export function list() {

--- a/packages/frontend/webapp/src/api/users.api.js
+++ b/packages/frontend/webapp/src/api/users.api.js
@@ -92,6 +92,10 @@ export function setExpertiseTopics(
     });
 }
 
+export function setInterventionAreas(userId, data) {
+    return axios.put(`users/${encodeURI(userId)}/intervention-areas`, data);
+}
+
 export function setLocalAdmin(userId, admin = true) {
     return axios.put(`/users/${encodeURI(userId)}/role-admin`, { admin });
 }

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnUserDetails.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnUserDetails.vue
@@ -46,7 +46,7 @@
     <Button
         class="mt-2"
         size="sm"
-        icon="user-pen"
+        icon="building-user"
         iconPosition="left"
         :href="`/utilisateur/${user.id}/territoires`"
         >Modifier le(s) territoire(s) d'intervention</Button

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnUserDetails.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnUserDetails.vue
@@ -44,6 +44,7 @@
         >Modifier ces informations</Button
     >
     <Button
+        v-if="userStore.user?.id !== user.id"
         class="mt-2"
         size="sm"
         icon="building-user"

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnUserDetails.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnUserDetails.vue
@@ -43,6 +43,14 @@
         :href="`/utilisateur/${user.id}`"
         >Modifier ces informations</Button
     >
+    <Button
+        class="mt-2"
+        size="sm"
+        icon="user-pen"
+        iconPosition="left"
+        :href="`/utilisateur/${user.id}/territoires`"
+        >Modifier le(s) territoire(s) d'intervention</Button
+    >
 </template>
 
 <script setup>

--- a/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.labels.js
+++ b/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.labels.js
@@ -1,0 +1,4 @@
+export default {
+    organization_areas: "Territoire(s) d'intervention de la structure",
+    user_areas: "Territoire(s) d'intervention de l'utilisateur",
+};

--- a/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.schema.js
+++ b/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.schema.js
@@ -1,0 +1,12 @@
+import { object, array } from "yup";
+import labels from "./FormMiseAjourTerritoires.labels";
+
+export default object({
+    organization_areas: array()
+        .required(`Le champ ${labels.organization_areas} est obligatoire`)
+        .min(1, `Le champ ${labels.organization_areas} est obligatoire`)
+        .label(labels.organization_areas),
+    user_areas: array()
+        .required(`Le champ ${labels.user_areas} est obligatoire`)
+        .label(labels.user_areas),
+});

--- a/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.vue
+++ b/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.vue
@@ -1,0 +1,107 @@
+<template>
+    <form>
+        <FormParagraph :title="labels.organization_areas" showMandatoryStar>
+            <p class="text-info mb-2">
+                <Icon icon="info-circle" />
+                Le territoire d'intervention de la structure est partagé par
+                tous les utilisateurs qui y sont rattachés. Attention donc, si
+                vous modifiez ce territoire, vous le modifiez pour
+                <span class="font-bold"
+                    >tous les utilisateurs de cette structure</span
+                >.
+            </p>
+            <FormMiseAjourTerritoiresInputOrganizationAreas
+        /></FormParagraph>
+
+        <FormParagraph
+            class="mt-12"
+            :title="labels.user_areas"
+            info="(optionnel)"
+        >
+            <p class="text-info mb-2">
+                <Icon icon="info-circle" />
+                Le territoire d'intervention de l'utilisateur lui est spécifique
+                et ne concerne que lui. Il
+                <span class="font-bold"
+                    >s'ajoute au territoire de sa structure (ci-dessus)</span
+                >.
+            </p>
+            <FormMiseAjourTerritoiresInputUserAreas
+        /></FormParagraph>
+
+        <ErrorSummary
+            id="erreurs"
+            class="mt-12"
+            v-if="error || Object.keys(errors).length > 0"
+            :message="error"
+            :summary="errors"
+        />
+    </form>
+</template>
+
+<script setup>
+import { ref, defineExpose, toRefs } from "vue";
+import { useForm } from "vee-validate";
+import schema from "./FormMiseAjourTerritoires.schema";
+import labels from "./FormMiseAjourTerritoires.labels";
+import { useNotificationStore } from "@/stores/notification.store";
+import router from "@/helpers/router";
+
+import { ErrorSummary, FormParagraph, Icon } from "@resorptionbidonvilles/ui";
+import FormMiseAjourTerritoiresInputOrganizationAreas from "./inputs/FormMiseAjourTerritoiresInputOrganizationAreas.vue";
+import FormMiseAjourTerritoiresInputUserAreas from "./inputs/FormMiseAjourTerritoiresInputUserAreas.vue";
+
+const props = defineProps({
+    user: {
+        type: Object,
+        required: true,
+    },
+});
+const { user } = toRefs(props);
+
+const { handleSubmit, setErrors, errors, isSubmitting } = useForm({
+    validationSchema: schema,
+    initialValues: user.value.intervention_areas.areas
+        .filter(({ is_main_area }) => is_main_area === true)
+        .reduce(
+            (acc, area) => {
+                acc[`${area.area_of}_areas`].push({
+                    type: area.type,
+                    code: area[area.type]?.code || null,
+                    name: area[area.type]?.name || "France entière",
+                });
+                return acc;
+            },
+            {
+                organization_areas: [],
+                user_areas: [],
+            }
+        ),
+});
+
+const error = ref(null);
+
+defineExpose({
+    submit: handleSubmit(async (sentValues) => {
+        error.value = null;
+
+        try {
+            console.log(sentValues);
+            await new Promise((res, rej) => setTimeout(rej, 1000));
+
+            const notificationStore = useNotificationStore();
+            notificationStore.success(
+                "Territoires modifiés",
+                "Le territoire d'intervention a bien été mis à jour, l'effet est immédiat"
+            );
+            router.replace("/acces");
+        } catch (e) {
+            error.value = e?.user_message || "Une erreur inconnue est survenue";
+            if (e?.fields) {
+                setErrors(e.fields);
+            }
+        }
+    }),
+    isSubmitting,
+});
+</script>

--- a/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.vue
+++ b/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.vue
@@ -45,7 +45,9 @@ import { useForm } from "vee-validate";
 import schema from "./FormMiseAjourTerritoires.schema";
 import labels from "./FormMiseAjourTerritoires.labels";
 import { useNotificationStore } from "@/stores/notification.store";
+import { useAccesStore } from "@/stores/acces.store";
 import router from "@/helpers/router";
+import { setInterventionAreas } from "@/api/users.api";
 
 import { ErrorSummary, FormParagraph, Icon } from "@resorptionbidonvilles/ui";
 import FormMiseAjourTerritoiresInputOrganizationAreas from "./inputs/FormMiseAjourTerritoiresInputOrganizationAreas.vue";
@@ -86,8 +88,25 @@ defineExpose({
         error.value = null;
 
         try {
-            console.log(sentValues);
-            await new Promise((res, rej) => setTimeout(rej, 1000));
+            const accesStore = useAccesStore();
+            const updatedUser = await setInterventionAreas(user.value.id, {
+                organization_areas: sentValues.organization_areas.map(
+                    ({ type, code, name }) => ({
+                        type,
+                        code,
+                        name,
+                    })
+                ),
+                user_areas: sentValues.user_areas.map(
+                    ({ type, code, name }) => ({
+                        type,
+                        code,
+                        name,
+                    })
+                ),
+            });
+
+            accesStore.updateUser(user.value.id, updatedUser);
 
             const notificationStore = useNotificationStore();
             notificationStore.success(

--- a/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/inputs/FormMiseAjourTerritoiresInputOrganizationAreas.vue
+++ b/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/inputs/FormMiseAjourTerritoiresInputOrganizationAreas.vue
@@ -1,0 +1,7 @@
+<template>
+    <InputZoneIntervention name="organization_areas" />
+</template>
+
+<script setup>
+import InputZoneIntervention from "@/components/InputZoneIntervention/InputZoneIntervention.vue";
+</script>

--- a/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/inputs/FormMiseAjourTerritoiresInputUserAreas.vue
+++ b/packages/frontend/webapp/src/components/FormMiseAjourTerritoires/inputs/FormMiseAjourTerritoiresInputUserAreas.vue
@@ -1,0 +1,7 @@
+<template>
+    <InputZoneIntervention name="user_areas" />
+</template>
+
+<script setup>
+import InputZoneIntervention from "@/components/InputZoneIntervention/InputZoneIntervention.vue";
+</script>

--- a/packages/frontend/webapp/src/helpers/router.js
+++ b/packages/frontend/webapp/src/helpers/router.js
@@ -371,6 +371,15 @@ const router = createRouter({
             },
         },
         {
+            path: "/utilisateur/:id/territoires",
+            component: () => import("@/views/MiseAjourTerritoiresView.vue"),
+            meta: {
+                title: "Modifier les territoires d'intervention d'un utilisateur",
+                navTab: "administration",
+                displayOrderOnSiteMap: 0,
+            },
+        },
+        {
             path: "/utilisateurs/permissions",
             component: () => import("@/views/ExceptionsDePermissionView.vue"),
             meta: {

--- a/packages/frontend/webapp/src/utils/formatUserName.js
+++ b/packages/frontend/webapp/src/utils/formatUserName.js
@@ -1,7 +1,7 @@
 export default function (user, includeOrganization = true) {
     const name = `${user.first_name} ${user.last_name.toUpperCase()}`;
     if (user.organization && includeOrganization === true) {
-        return `${name}- ${
+        return `${name} - ${
             user.organization.abbreviation || user.organization.name
         }`;
     }

--- a/packages/frontend/webapp/src/views/MiseAjourTerritoiresView.vue
+++ b/packages/frontend/webapp/src/views/MiseAjourTerritoiresView.vue
@@ -47,6 +47,7 @@
 <script setup>
 import { onMounted, ref, computed } from "vue";
 import { useAccesStore } from "@/stores/acces.store.js";
+import { useUserStore } from "@/stores/user.store";
 import router, { setDocumentTitle } from "@/helpers/router";
 import backOrReplace from "@/utils/backOrReplace";
 import formatUserName from "@/utils/formatUserName";
@@ -59,6 +60,7 @@ import FormMiseAjourTerritoires from "@/components/FormMiseAjourTerritoires/Form
 import ButtonContact from "@/components/ButtonContact/ButtonContact.vue";
 
 const accesStore = useAccesStore();
+const userStore = useUserStore();
 const isLoading = ref(null);
 const error = ref(null);
 const form = ref(null);
@@ -78,6 +80,12 @@ async function load() {
     isLoading.value = true;
     error.value = null;
     try {
+        if (userId.value === userStore.user?.id) {
+            throw {
+                code: "Vous ne pouvez pas modifier vos propres territoires d'intervention",
+            };
+        }
+
         userRef = await accesStore.fetchUser(userId.value, true);
         setDocumentTitle(
             `${router.currentRoute.value.meta.title} — ${formatUserName(

--- a/packages/frontend/webapp/src/views/MiseAjourTerritoiresView.vue
+++ b/packages/frontend/webapp/src/views/MiseAjourTerritoiresView.vue
@@ -1,0 +1,106 @@
+<template>
+    <LayoutLoading v-if="isLoading !== false" />
+
+    <LayoutError v-else-if="error !== null">
+        <template v-slot:title>Formulaire inaccessible</template>
+        <template v-slot:code>{{ error }}</template>
+        <template v-slot:content
+            >Vous souhaitiez modifier le territoire d'intervention d'un
+            utilisateur, mais nous ne parvenons pas à collecter les informations
+            nécessaires. Vous pouvez réessayer un peu plus tard ou nous
+            contacter en cas d'urgence.</template
+        >
+        <template v-slot:actions>
+            <Button
+                icon="rotate-right"
+                iconPosition="left"
+                type="button"
+                @click="load"
+                >Réessayer</Button
+            >
+            <ButtonContact />
+        </template>
+    </LayoutError>
+
+    <LayoutForm v-else size="large">
+        <template v-slot:title
+            >Mise à jour des territoires d'intervention</template
+        >
+        <template v-slot:subtitle>
+            {{ formatUserName(userRef) }}
+        </template>
+        <template v-slot:buttons>
+            <Button variant="primaryOutline" type="button" @click="back"
+                >Annuler</Button
+            >
+            <Button @click="submit" :loading="form?.isSubmitting"
+                >Mettre à jour les territoires</Button
+            >
+        </template>
+
+        <ContentWrapper size="large">
+            <FormMiseAjourTerritoires ref="form" :user="userRef" />
+        </ContentWrapper>
+    </LayoutForm>
+</template>
+
+<script setup>
+import { onMounted, ref, computed } from "vue";
+import { useAccesStore } from "@/stores/acces.store.js";
+import router, { setDocumentTitle } from "@/helpers/router";
+import backOrReplace from "@/utils/backOrReplace";
+import formatUserName from "@/utils/formatUserName";
+
+import { Button, ContentWrapper } from "@resorptionbidonvilles/ui";
+import LayoutError from "@/components/LayoutError/LayoutError.vue";
+import LayoutLoading from "@/components/LayoutLoading/LayoutLoading.vue";
+import LayoutForm from "@/components/LayoutForm/LayoutForm.vue";
+import FormMiseAjourTerritoires from "@/components/FormMiseAjourTerritoires/FormMiseAjourTerritoires.vue";
+import ButtonContact from "@/components/ButtonContact/ButtonContact.vue";
+
+const accesStore = useAccesStore();
+const isLoading = ref(null);
+const error = ref(null);
+const form = ref(null);
+
+onMounted(load);
+
+let userRef = null;
+const userId = computed(() => {
+    return parseInt(router.currentRoute.value.params.id, 10);
+});
+
+async function load() {
+    if (isLoading.value === true) {
+        return;
+    }
+
+    isLoading.value = true;
+    error.value = null;
+    try {
+        userRef = await accesStore.fetchUser(userId.value, true);
+        setDocumentTitle(
+            `${router.currentRoute.value.meta.title} — ${formatUserName(
+                userRef.value,
+                false
+            )}`
+        );
+    } catch (e) {
+        error.value = e?.code || "Erreur inconnue";
+    }
+
+    isLoading.value = false;
+}
+
+function submit(...args) {
+    return form.value.submit(...args);
+}
+
+function back() {
+    if (userId.value) {
+        backOrReplace(`/acces/${userId.value}`);
+    } else {
+        router.back();
+    }
+}
+</script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Jd5EjYe7/2014

## 🛠 Description de la PR
Ce ticket se base sur le ticket "Permettre de créer une structure", [dont la PR est ici](https://github.com/MTES-MCT/resorption-bidonvilles/pull/926).

- Création d'une route `PUT /users/:id/intervention-areas` avec validateurs, contrôleurs, services, et modèles associés
- Création d'une page, côté webapp, `/utilisateur/:id/territoires` qui donne accès à un formulaire listant les territoires de l'utilisateur ET de sa structure
- Ajout d'un bouton dans la fiche d'accès, permettant d'accéder au dit formulaire
- Interdiction pour un utilisateur de modifier son propre territoire d'intervention

Interrogations :
- nécessiter d'historiser les modifications pour garder une trace de qui a fait quoi ?
- rajouter la possibilité d'imposer le territoire d'un utilisateur en court-circuitant celui de sa structure ? (possibilité déjà existante en base et API)

## 📸 Captures d'écran
Le bouton
<img width="454" alt="Capture d’écran 2024-02-07 à 14 50 23" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/aee22927-66e0-4b49-a7f8-37a249a8ccd7">

Le formulaire
<img width="1282" alt="Capture d’écran 2024-02-07 à 14 50 30" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/1a5cdcbe-43b3-4289-9453-746bb50805b6">

## 🚨 Notes pour la mise en production
- penser à merger APRÉS le ticket 2055