### PR TITLE
#patch (2083) Ajout d'un filtre par compétences dans la fiche d'une structure

### DIFF
--- a/packages/frontend/ui/src/components/Callout.vue
+++ b/packages/frontend/ui/src/components/Callout.vue
@@ -1,0 +1,13 @@
+<template>
+    <div class="flex gap-4 bg-G200 border-l-4 border-blue400 px-4 py-6">
+        <Icon icon="circle-info" />
+        <div class="pt-6">
+            <h3 class="font-bold text-xl"><slot name="title" /></h3>
+            <slot />
+        </div>
+    </div>
+</template>
+
+<script setup>
+import Icon from './Icon.vue';
+</script>

--- a/packages/frontend/ui/src/index.mjs
+++ b/packages/frontend/ui/src/index.mjs
@@ -4,6 +4,7 @@ export { default as AsyncSelect } from './components/Input/AsyncSelect.vue';
 export { default as Autocomplete } from './components/Input/Autocomplete.vue';
 export { default as BottomPagination } from './components/BottomPagination.vue';
 export { default as Button } from './components/Button.vue';
+export { default as Callout } from './components/Callout.vue';
 export { default as CheckableGroup } from './components/Input/CheckableGroup.vue';
 export { default as Checkbox } from './components/Input/Checkbox.vue';
 export { default as CheckboxUi } from './components/Input/CheckboxUi.vue';

--- a/packages/frontend/webapp/src/components/CarteUtilisateur/CarteUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/CarteUtilisateur/CarteUtilisateur.vue
@@ -83,7 +83,6 @@ import { Icon, Link } from "@resorptionbidonvilles/ui";
 import CarteUtilisateurWrapper from "./CarteUtilisateurWrapper.vue";
 import CarteUtilisateurDetailsIcon from "./CarteUtilisateurDetailsIcon.vue";
 import IconeAdministrateur from "@/components/IconeAdministrateur/IconeAdministrateur.vue";
-import { useDirectoryStore } from "@/stores/directory.store";
 
 const props = defineProps({
     user: {
@@ -97,7 +96,6 @@ const props = defineProps({
     },
 });
 const { user, linkToUser } = toRefs(props);
-const directoryStore = useDirectoryStore();
 
 function trackEmail(event) {
     event.stopPropagation();
@@ -105,11 +103,8 @@ function trackEmail(event) {
 }
 
 function getTopicsByLevel(level) {
-    return (user.value.expertise_topics || []).filter((topic) => {
-        return (
-            directoryStore.filters.expertiseTopics.includes(topic.uid) &&
-            topic.type == level
-        );
-    });
+    return (user.value.expertise_topics || []).filter(
+        (topic) => topic.type === level
+    );
 }
 </script>

--- a/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
+++ b/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
@@ -13,45 +13,17 @@
 
         <FicheStructureInfos :organization="organization" />
         <FicheStructureFiltres v-model="expertiseTopicsFilter" class="mb-6" />
-        <div
+        <FicheStructureWarningFiltreActif
             v-if="
                 expertiseTopicsFilter.length > 0 &&
                 organization.users.length !== filteredUsers.length
             "
-            class="flex gap-4 bg-G200 border-l-4 border-blue400 px-4 py-6 mb-6"
-        >
-            <Icon icon="circle-info" />
-            <div class="pt-6">
-                <h3 class="font-bold text-xl">Filtre actif</h3>
-                <p>
-                    Attention, la liste des membres de cette structure est
-                    actuellement filtrée par sujets d'expertise.<br />
-                    <template
-                        v-if="
-                            organization.users.length - filteredUsers.length > 1
-                        "
-                    >
-                        <span class="font-bold"
-                            >{{
-                                organization.users.length - filteredUsers.length
-                            }}
-                            utilisateurs</span
-                        >
-                        sont actuellement masqués.
-                    </template>
-                    <template v-else>
-                        <span class="font-bold">1 utilisateur</span> est
-                        actuellement masqué.
-                    </template>
-                </p>
-                <RbButton
-                    size="sm"
-                    @click="expertiseTopicsFilter = []"
-                    class="mt-4"
-                    >Cliquez ici pour retirer ce filtre</RbButton
-                >
-            </div>
-        </div>
+            :numberOfHiddenUsers="
+                organization.users.length - filteredUsers.length
+            "
+            class="mb-6"
+            @resetFilters="() => (expertiseTopicsFilter = [])"
+        />
 
         <div
             class="grid grid-cols-1 lg:grid-cols-2 gap-4 auto-rows-fr"
@@ -81,15 +53,12 @@
 <script setup>
 import { computed, ref, toRefs } from "vue";
 import { useDirectoryStore } from "@/stores/directory.store";
-import {
-    ContentWrapper,
-    Icon,
-    Button as RbButton,
-} from "@resorptionbidonvilles/ui";
+import { ContentWrapper } from "@resorptionbidonvilles/ui";
 import ViewHeader from "@/components/ViewHeader/ViewHeader.vue";
 import CarteUtilisateur from "@/components/CarteUtilisateur/CarteUtilisateur.vue";
 import FicheStructureFiltres from "./FicheStructureFiltres.vue";
 import FicheStructureInfos from "./FicheStructureInfos.vue";
+import FicheStructureWarningFiltreActif from "./FicheStructureWarningFiltreActif.vue";
 import ViewError from "@/components/ViewError/ViewError.vue";
 
 const props = defineProps({

--- a/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
+++ b/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
@@ -12,23 +12,85 @@
         </ViewHeader>
 
         <FicheStructureInfos :organization="organization" />
+        <FicheStructureFiltres v-model="expertiseTopicsFilter" class="mb-6" />
+        <div
+            v-if="
+                expertiseTopicsFilter.length > 0 &&
+                organization.users.length !== filteredUsers.length
+            "
+            class="flex gap-4 bg-G200 border-l-4 border-blue400 px-4 py-6 mb-6"
+        >
+            <Icon icon="circle-info" />
+            <div class="pt-6">
+                <h3 class="font-bold text-xl">Filtre actif</h3>
+                <p>
+                    Attention, la liste des membres de cette structure est
+                    actuellement filtrée par sujets d'expertise.<br />
+                    <template
+                        v-if="
+                            organization.users.length - filteredUsers.length > 1
+                        "
+                    >
+                        <span class="font-bold"
+                            >{{
+                                organization.users.length - filteredUsers.length
+                            }}
+                            utilisateurs</span
+                        >
+                        sont actuellement masqués.
+                    </template>
+                    <template v-else>
+                        <span class="font-bold">1 utilisateur</span> est
+                        actuellement masqué.
+                    </template>
+                </p>
+                <RbButton
+                    size="sm"
+                    @click="expertiseTopicsFilter = []"
+                    class="mt-4"
+                    >Cliquez ici pour retirer ce filtre</RbButton
+                >
+            </div>
+        </div>
 
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 auto-rows-fr">
+        <div
+            class="grid grid-cols-1 lg:grid-cols-2 gap-4 auto-rows-fr"
+            v-if="filteredUsers.length > 0"
+        >
             <CarteUtilisateur
-                v-for="user in organization.users"
+                v-for="user in filteredUsers"
                 :key="user.id"
                 :user="user"
+                :topics="expertiseTopicsFilter"
             />
         </div>
+        <ViewError v-else variant="vide">
+            <template v-slot:title
+                >Aucun résultat pour cette recherche</template
+            >
+            <template v-slot:code>Filtres actifs</template>
+            <template v-slot:content
+                >Il semblerait qu'il n'existe aucun membre de cette structure
+                répondant à vos critères.</template
+            >
+            <template v-slot:actions>&nbsp;</template>
+        </ViewError>
     </ContentWrapper>
 </template>
 
 <script setup>
-import { defineProps, toRefs } from "vue";
-import { ContentWrapper } from "@resorptionbidonvilles/ui";
+import { computed, ref, toRefs } from "vue";
+import { useDirectoryStore } from "@/stores/directory.store";
+import {
+    ContentWrapper,
+    Icon,
+    Button as RbButton,
+} from "@resorptionbidonvilles/ui";
 import ViewHeader from "@/components/ViewHeader/ViewHeader.vue";
 import CarteUtilisateur from "@/components/CarteUtilisateur/CarteUtilisateur.vue";
+import FicheStructureFiltres from "./FicheStructureFiltres.vue";
 import FicheStructureInfos from "./FicheStructureInfos.vue";
+import ViewError from "@/components/ViewError/ViewError.vue";
 
 const props = defineProps({
     organization: {
@@ -37,4 +99,18 @@ const props = defineProps({
     },
 });
 const { organization } = toRefs(props);
+const directoryStore = useDirectoryStore();
+const expertiseTopicsFilter = ref(directoryStore.filters.expertiseTopics || []);
+
+const filteredUsers = computed(() => {
+    if (expertiseTopicsFilter.value.length === 0) {
+        return organization.value.users;
+    }
+
+    return organization.value.users.filter((user) => {
+        return (user?.expertise_topics || []).some(({ uid }) =>
+            expertiseTopicsFilter.value.includes(uid)
+        );
+    });
+});
 </script>

--- a/packages/frontend/webapp/src/components/FicheStructure/FicheStructureFiltres.vue
+++ b/packages/frontend/webapp/src/components/FicheStructure/FicheStructureFiltres.vue
@@ -1,0 +1,45 @@
+<template>
+    <section>
+        <p>Filtrer par</p>
+        <RbFilter
+            v-model="expertiseTopicsFilter"
+            v-if="expertiseTopicsItems.length > 0"
+            title="Expertises ou sujets d'intérêts"
+            :options="expertiseTopicsItems"
+        />
+    </section>
+</template>
+
+<script setup>
+import { computed, toRefs } from "vue";
+import { useConfigStore } from "@/stores/config.store";
+import { Filter as RbFilter } from "@resorptionbidonvilles/ui";
+
+const props = defineProps({
+    modelValue: {
+        type: Array,
+        required: false,
+        default() {
+            return [];
+        },
+    },
+});
+const { modelValue } = toRefs(props);
+const emit = defineEmits(["update:modelValue"]);
+
+const configStore = useConfigStore();
+const expertiseTopicsItems = computed(() => {
+    return (configStore.config?.expertise_topics || []).map((item) => ({
+        value: item.uid,
+        label: item.label,
+    }));
+});
+const expertiseTopicsFilter = computed({
+    get() {
+        return modelValue.value;
+    },
+    set(newValue) {
+        emit("update:modelValue", newValue);
+    },
+});
+</script>

--- a/packages/frontend/webapp/src/components/FicheStructure/FicheStructureWarningFiltreActif.vue
+++ b/packages/frontend/webapp/src/components/FicheStructure/FicheStructureWarningFiltreActif.vue
@@ -1,0 +1,43 @@
+<template>
+    <Callout>
+        <template v-slot:title>Filtre actif</template>
+
+        <p>
+            Attention, la liste des membres de cette structure est actuellement
+            filtrée par sujets d'expertise.<br />
+            <span class="font-bold">{{ wording.numberOfUsers }}</span>
+            {{ wording.currentlyHidden }}.
+        </p>
+        <RbButton size="sm" @click="emit('resetFilters')" class="mt-4"
+            >Cliquez ici pour retirer ce filtre</RbButton
+        >
+    </Callout>
+</template>
+
+<script setup>
+import { toRefs, computed } from "vue";
+import { Button as RbButton, Callout } from "@resorptionbidonvilles/ui";
+
+const props = defineProps({
+    numberOfHiddenUsers: {
+        type: Number,
+        required: true,
+    },
+});
+const { numberOfHiddenUsers } = toRefs(props);
+const emit = defineEmits(["resetFilters"]);
+
+const wording = computed(() => {
+    if (numberOfHiddenUsers.value === 1) {
+        return {
+            numberOfUsers: "1 utilisateur",
+            currentlyHidden: "est actuellement masqué",
+        };
+    }
+
+    return {
+        numberOfUsers: `${numberOfHiddenUsers.value} utilisateurs`,
+        currentlyHidden: "sont actuellement masqués",
+    };
+});
+</script>

--- a/packages/frontend/webapp/src/views/FicheStructureView.vue
+++ b/packages/frontend/webapp/src/views/FicheStructureView.vue
@@ -65,6 +65,7 @@ const ariane = computed(() => [
     { label: "Annuaire", to: "/annuaire" },
     { label: organization.value?.name || "..." },
 ]);
+
 watch(organization, () => {
     if (organization.value !== null) {
         registerView();


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/XiwrRs07/2083

## 🛠 Description de la PR
- création d'un composant Callout
- ajout d'un filtre par compétences sur l'annuaire
- correction de la fiche d'une structure pour qu'elle affiche toujours les compétences des utilisateurs
- correction du filtrage de l'annuaire pour qu'il n'impacte pas les fiches structure (en dupliquant les objets `organization` avant de modifier leur liste d'utilisateurs selon les filtres appliqués)

## 📸 Captures d'écran
<img width="1543" alt="Capture d’écran 2024-02-08 à 13 39 11" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/5f52c146-99b5-4679-986c-6e3017ae0b14">

## 🚨 Notes pour la mise en production
RàS