### PR TITLE
#patch (2116) Ajout d'une astérisque sur les champs obligatoires du formulaire de création d'un utilisateur

### DIFF
--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputAssociation.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputAssociation.vue
@@ -7,6 +7,7 @@
         v-model="association"
         showCategory
         ref="autocompleteInput"
+        showMandatoryStar
     />
 </template>
 

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationAdministration.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationAdministration.vue
@@ -5,6 +5,7 @@
         :label="label"
         :options="options"
         :loader="contactStore.fetchAdministrations"
+        showMandatoryStar
     />
 </template>
 

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationPublic.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationPublic.vue
@@ -6,6 +6,7 @@
         :options="options"
         :loader="refreshOptions"
         ref="select"
+        showMandatoryStar
     />
 </template>
 

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationType.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationType.vue
@@ -5,6 +5,7 @@
         :label="label"
         :options="options"
         :loader="contactStore.fetchPublicEstablishmentTypes"
+        showMandatoryStar
     />
 </template>
 

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputPosition.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputPosition.vue
@@ -1,5 +1,5 @@
 <template>
-    <TextInput id="position" :label="label" />
+    <TextInput id="position" :label="label" showMandatoryStar />
 </template>
 
 <script setup>

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputTerritorialCollectivity.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputTerritorialCollectivity.vue
@@ -6,6 +6,7 @@
         :fn="autocompleteFn"
         v-model="organization"
         showCategory
+        showMandatoryStar
     />
 </template>
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/eWBkRyyX/2116

## 🛠 Description de la PR
Certains champs (notamment `Fonction` et la plupart des champs de sélection de sa structure) n'avaient pas l'astérisque.

## 📸 Captures d'écran
Exemple d'un cas problématique avec `Fonction` et `Territoire de la collectivité` :
<img width="668" alt="Capture d’écran 2024-02-08 à 13 42 22" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/5174f6fd-db37-417f-a684-d9178e1aa76e">

## 🚨 Notes pour la mise en production
RàS