### PR TITLE
#patch (2059) Ne plus distinguer les actions en cours des actions terminées sur la fiche d'un site fermé

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActions.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActions.vue
@@ -1,32 +1,52 @@
 <template>
     <FicheRubrique title="Actions">
-        <section>
-            <template v-if="actions.onGoing.length > 0">
-                <p>Actions en cours</p>
-                <div class="grid grid-cols-2 gap-4">
+        <template v-if="town.closedAt === null">
+            <section>
+                <template v-if="actions.onGoing.length > 0">
+                    <p>Actions en cours</p>
+                    <div class="grid grid-cols-2 gap-4">
+                        <CarteActionDeSite
+                            v-for="action in actions.onGoing"
+                            :key="action.id"
+                            :action="action"
+                        />
+                    </div>
+                </template>
+                <p v-else>Il n'y a aucune action en cours sur ce site.</p>
+            </section>
+
+            <section v-if="actions.ended.length > 0" class="mt-6">
+                <Button @click="toggleEndedActions"
+                    >{{ showEndedActions ? "Masquer" : "Voir" }}
+                    {{ actionEndedWording }}</Button
+                >
+                <div
+                    class="grid grid-cols-2 gap-4 mt-4"
+                    v-if="showEndedActions"
+                >
                     <CarteActionDeSite
-                        v-for="action in actions.onGoing"
+                        v-for="action in actions.ended"
                         :key="action.id"
                         :action="action"
                     />
                 </div>
-            </template>
-            <p v-else>Il n'y a aucune action en cours sur ce site.</p>
-        </section>
+            </section>
+        </template>
 
-        <section v-if="actions.ended.length > 0" class="mt-6">
-            <Button @click="toggleEndedActions"
-                >{{ showEndedActions ? "Masquer" : "Voir" }}
-                {{ actionEndedWording }}</Button
-            >
-            <div class="grid grid-cols-2 gap-4 mt-4" v-if="showEndedActions">
-                <CarteActionDeSite
-                    v-for="action in actions.ended"
-                    :key="action.id"
-                    :action="action"
-                />
-            </div>
-        </section>
+        <template v-else>
+            <section>
+                <template v-if="town.actions.length > 0">
+                    <div class="grid grid-cols-2 gap-4">
+                        <CarteActionDeSite
+                            v-for="action in town.actions"
+                            :key="action.id"
+                            :action="action"
+                        />
+                    </div>
+                </template>
+                <p v-else>Ce site n'est lié à aucune action.</p>
+            </section>
+        </template>
     </FicheRubrique>
 </template>
 

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActions.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActions.vue
@@ -1,90 +1,18 @@
 <template>
     <FicheRubrique title="Actions">
-        <template v-if="town.closedAt === null">
-            <section>
-                <template v-if="actions.onGoing.length > 0">
-                    <p>Actions en cours</p>
-                    <div class="grid grid-cols-2 gap-4">
-                        <CarteActionDeSite
-                            v-for="action in actions.onGoing"
-                            :key="action.id"
-                            :action="action"
-                        />
-                    </div>
-                </template>
-                <p v-else>Il n'y a aucune action en cours sur ce site.</p>
-            </section>
-
-            <section v-if="actions.ended.length > 0" class="mt-6">
-                <Button @click="toggleEndedActions"
-                    >{{ showEndedActions ? "Masquer" : "Voir" }}
-                    {{ actionEndedWording }}</Button
-                >
-                <div
-                    class="grid grid-cols-2 gap-4 mt-4"
-                    v-if="showEndedActions"
-                >
-                    <CarteActionDeSite
-                        v-for="action in actions.ended"
-                        :key="action.id"
-                        :action="action"
-                    />
-                </div>
-            </section>
-        </template>
-
-        <template v-else>
-            <section>
-                <template v-if="town.actions.length > 0">
-                    <div class="grid grid-cols-2 gap-4">
-                        <CarteActionDeSite
-                            v-for="action in town.actions"
-                            :key="action.id"
-                            :action="action"
-                        />
-                    </div>
-                </template>
-                <p v-else>Ce site n'est lié à aucune action.</p>
-            </section>
-        </template>
+        <FicheSiteOuvertActions :town="town" v-if="town.closedAt === null" />
+        <FicheSiteFermeActions :town="town" v-else />
     </FicheRubrique>
 </template>
 
 <script setup>
-import { computed, ref, toRefs } from "vue";
-import { Button } from "@resorptionbidonvilles/ui";
+import { toRefs } from "vue";
 import FicheRubrique from "@/components/FicheRubrique/FicheRubrique.vue";
-import CarteActionDeSite from "@/components/CarteActionDeSite/CarteActionDeSite.vue";
+import FicheSiteOuvertActions from "./FicheSiteOuvertActions.vue";
+import FicheSiteFermeActions from "./FicheSiteFermeActions.vue";
 
 const props = defineProps({
     town: Object,
 });
 const { town } = toRefs(props);
-
-const showEndedActions = ref(false);
-const actions = computed(() => {
-    return town.value.actions.reduce(
-        (acc, action) => {
-            if (action.is_ended) {
-                acc.ended.push(action);
-            } else {
-                acc.onGoing.push(action);
-            }
-
-            return acc;
-        },
-        { onGoing: [], ended: [] }
-    );
-});
-
-const actionEndedWording = computed(() => {
-    const total = actions.value.ended.length;
-    return total === 1
-        ? "la seule action terminée"
-        : `les ${total} actions terminées`;
-});
-
-function toggleEndedActions() {
-    showEndedActions.value = !showEndedActions.value;
-}
 </script>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActionsGrille.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActionsGrille.vue
@@ -1,0 +1,22 @@
+<template>
+    <div class="grid grid-cols-2 gap-4">
+        <CarteActionDeSite
+            v-for="action in actions"
+            :key="action.id"
+            :action="action"
+        />
+    </div>
+</template>
+
+<script setup>
+import { toRefs } from "vue";
+import CarteActionDeSite from "@/components/CarteActionDeSite/CarteActionDeSite.vue";
+
+const props = defineProps({
+    actions: {
+        type: Array,
+        required: true,
+    },
+});
+const { actions } = toRefs(props);
+</script>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActionsSection.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteActionsSection.vue
@@ -1,0 +1,24 @@
+<template>
+    <section>
+        <template v-if="actions.length > 0">
+            <p v-if="$slots.title" class="text-primary text-lg">
+                <slot name="title" />
+            </p>
+            <FicheSiteActionsGrille :actions="actions" />
+        </template>
+        <p v-else><slot name="empty" /></p>
+    </section>
+</template>
+
+<script setup>
+import { toRefs } from "vue";
+import FicheSiteActionsGrille from "./FicheSiteActionsGrille.vue";
+
+const props = defineProps({
+    actions: {
+        type: Array,
+        required: true,
+    },
+});
+const { actions } = toRefs(props);
+</script>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteFermeActions.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteFermeActions.vue
@@ -1,0 +1,15 @@
+<template>
+    <FicheSiteActionsSection :actions="town.actions">
+        <template v-slot:empty>Ce site n'est lié à aucune action.</template>
+    </FicheSiteActionsSection>
+</template>
+
+<script setup>
+import { toRefs } from "vue";
+import FicheSiteActionsSection from "./FicheSiteActionsSection.vue";
+
+const props = defineProps({
+    town: Object,
+});
+const { town } = toRefs(props);
+</script>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteOuvertActions.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteActions/FicheSiteOuvertActions.vue
@@ -1,0 +1,65 @@
+<template>
+    <!-- actions en cours -->
+    <FicheSiteActionsSection :actions="actions.onGoing">
+        <template v-slot:title>Actions en cours</template>
+        <template v-slot:empty
+            >Il n'y a aucune action en cours sur ce site.</template
+        >
+    </FicheSiteActionsSection>
+
+    <!-- actions terminées-->
+    <template v-if="actions.ended.length > 0">
+        <RbButton class="mt-4" @click="toggleEndedActions">{{
+            endedActionsWording
+        }}</RbButton>
+        <FicheSiteActionsSection
+            v-if="showEndedActions"
+            :actions="actions.ended"
+            class="mt-6"
+        >
+            <template v-slot:title>Actions terminées</template>
+        </FicheSiteActionsSection>
+    </template>
+</template>
+
+<script setup>
+import { computed, ref, toRefs } from "vue";
+import { Button as RbButton } from "@resorptionbidonvilles/ui";
+import FicheSiteActionsSection from "./FicheSiteActionsSection.vue";
+
+const props = defineProps({
+    town: Object,
+});
+const { town } = toRefs(props);
+
+const actions = computed(() => {
+    return town.value.actions.reduce(
+        (acc, action) => {
+            if (action.is_ended) {
+                acc.ended.push(action);
+            } else {
+                acc.onGoing.push(action);
+            }
+
+            return acc;
+        },
+        { onGoing: [], ended: [] }
+    );
+});
+
+const showEndedActions = ref(false);
+const endedActionsWording = computed(() => {
+    const total = actions.value.ended.length;
+
+    return [
+        showEndedActions.value === true ? "Masquer" : "Voir",
+        total === 1
+            ? "la seule action terminée"
+            : `les ${total} actions terminées`,
+    ].join(" ");
+});
+
+function toggleEndedActions() {
+    showEndedActions.value = !showEndedActions.value;
+}
+</script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/KQlwnjfL/2059

## 🛠 Description de la PR
Rien de particulier à dire, on ne crée plus deux catégories d'actions pour les sites fermés.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS