### PR TITLE
#patch (2114) Bien vider le champ "Pièces-jointes" après publication d'une réponse à une question

### DIFF
--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionJournal/FicheActionJournalFormNouveauMessage/FicheActionJournalFormNouveauMessage.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionJournal/FicheActionJournalFormNouveauMessage/FicheActionJournalFormNouveauMessage.vue
@@ -37,6 +37,7 @@ const attachmentsInput = ref(null);
 const { handleSubmit, setErrors, resetForm } = useForm({
     validationSchema: schema,
     initialValues: {
+        comment: "",
         attachments: new DataTransfer().files,
     },
 });

--- a/packages/frontend/webapp/src/components/FicheQuestion/FicheQuestionReponses/FicheQuestionNouvelleReponse/FicheQuestionNouvelleReponse.vue
+++ b/packages/frontend/webapp/src/components/FicheQuestion/FicheQuestionReponses/FicheQuestionNouvelleReponse/FicheQuestionNouvelleReponse.vue
@@ -43,6 +43,10 @@ function onPaste(event) {
 
 const { handleSubmit, setErrors, resetForm } = useForm({
     validationSchema: schema,
+    initialValues: {
+        answer: "",
+        attachments: new DataTransfer().files,
+    },
 });
 
 const error = ref(null);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/vKoL6Si8/2114

## 🛠 Description de la PR
La cause du problème était que le champ pièces-jointes n'avait pas d'initialValue définie. C'était le cas uniquement sur ce formulaire.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS