### PR TITLE
#patch (2079) Amélioration de la visualisation des données pour n'afficher que les lignes contenant des données

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiques/DonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/DonneesStatistiques.vue
@@ -30,7 +30,7 @@
                 <Grille
                     class="mt-6"
                     :metrics="metricsStore.filteredMetrics"
-                    :collapseByDefault="metricsStore.metrics.length <= 1"
+                    :collapseByDefault="metricsStore.metrics.length > 1"
                 />
             </template>
         </main>

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/DonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/DonneesStatistiques.vue
@@ -27,7 +27,11 @@
             />
             <template v-else>
                 <Onglets :tabs="tabs" :activeTab="activeTab" />
-                <Grille class="mt-6" :metrics="metricsStore.filteredMetrics" />
+                <Grille
+                    class="mt-6"
+                    :metrics="metricsStore.filteredMetrics"
+                    :collapseByDefault="metricsStore.metrics.length <= 1"
+                />
             </template>
         </main>
     </ContentWrapper>

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/Grille.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/Grille.vue
@@ -16,6 +16,7 @@
             variant="primary"
             :class="index === 0 ? 'mt-4' : 'mt-2'"
             :metrics="m"
+            :collapseByDefault="collapseByDefault"
         />
     </section>
 </template>
@@ -38,6 +39,11 @@ const props = defineProps({
         type: Object,
         required: true,
     },
+    collapseByDefault: {
+        type: Boolean,
+        required: false,
+        default: true,
+    },
 });
-const { metrics } = toRefs(props);
+const { metrics, collapseByDefault } = toRefs(props);
 </script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/GrilleLigne.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/GrilleLigne.vue
@@ -90,6 +90,7 @@
                 class="mt-2"
                 :metrics="m"
                 :variant="variant === 'primary' ? 'secondary' : 'tertiary'"
+                :collapseByDefault="collapseByDefault"
             />
         </div>
     </section>
@@ -116,13 +117,21 @@ const props = defineProps({
         type: String,
         default: "primary",
     },
+    collapseByDefault: {
+        type: Boolean,
+        required: false,
+        default: true,
+    },
 });
-const { metrics, variant } = toRefs(props);
+const { metrics, variant, collapseByDefault } = toRefs(props);
 
 const metricsStore = useMetricsStore();
 const collapsed = computed(() => {
     const { uid, level } = metrics.value;
-    return metricsStore.collapsedStatuses[`${level}-${uid}`] ?? false;
+    return (
+        metricsStore.collapsedStatuses[`${level}-${uid}`] ??
+        collapseByDefault.value
+    );
 });
 
 const linkTo = computed(() => {

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/GrilleLigne.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/GrilleLigne.vue
@@ -30,7 +30,7 @@
                 >
                     <span class="mr-4" v-if="variant !== 'tertiary'"
                         ><Icon
-                            :icon="collapsed ? 'chevron-down' : 'chevron-right'"
+                            :icon="collapsed ? 'chevron-right' : 'chevron-down'"
                             class="cursor-pointer"
                             :class="
                                 metrics.children?.length > 0 ? '' : 'invisible'
@@ -82,7 +82,7 @@
         <div
             class="bg-G100"
             :class="variant === 'primary' ? 'py-3' : ''"
-            v-if="metrics.children?.length > 0 && collapsed"
+            v-if="metrics.children?.length > 0 && !collapsed"
         >
             <GrilleLigne
                 v-for="m in metrics.children"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/O1vD6N1v/2079

## 🛠 Description de la PR
- si l'utilisateur n'a pas accès à des données en métropole, ne pas afficher la ligne métropole
- idem pour l'outremer
- pour les deux cas de figure ci-dessus, ne pas afficher la ligne "Métropole" ou "Outremer" mais son contenu directement
- la ligne "France entière" n'est désormais affichée *que* si l'utilisateur a accès à la fois aux données sur la métropole et l'outremer
- si l'utilisateur n'a accès qu'à une seule ligne, alors la déplier automatiquement

## 📸 Captures d'écran
Exemple d'un utilisateur n'ayant accès qu'à une seule région en métropole :
<img width="1539" alt="Capture d’écran 2024-02-08 à 14 33 33" src="https://github.com/MTES-MCT/resorption-bidonvilles/assets/1801091/6328467f-bc3b-4e8d-a53a-95a2425cff55">

## 🚨 Notes pour la mise en production
RàS