### PR TITLE
#patch (2070) Erreurs de calcul dans le fichier arc-en-ciel

### DIFF
--- a/packages/api/server/services/dataReport/_utils/getReportIndex.ts
+++ b/packages/api/server/services/dataReport/_utils/getReportIndex.ts
@@ -28,7 +28,7 @@ export default (argFrom: Date, argTo: Date, argDate: Date): number => {
     }
 
     // si la date donnée correspond au même mois que la date de fin, il s'agit forcément du dernier "rapport"
-    if (date.month() === to.month() && date.year() === to.year()) {
+    if ((date.month() === to.month() && date.year() === to.year()) || date.unix() > to.unix()) {
         return from.month() === to.month() && from.year() === to.year()
             ? 1
             : getMonthDiff(argFrom, argTo);

--- a/packages/api/server/services/dataReport/getTownsReport.ts
+++ b/packages/api/server/services/dataReport/getTownsReport.ts
@@ -64,14 +64,19 @@ export default async (argFrom: Date, argTo: Date): Promise<TownReport[]> => {
             ? getReportIndex(argFrom, argTo, row.closed_at)
             : reports.length;
         if (isNew) {
-            for (let i = reportIndex; i < maxReportIndex; i += 1) {
+            const minReportIndex = Math.max(
+                0,
+                getReportIndex(argFrom, argTo, row.known_since),
+            );
+            for (let i = minReportIndex; i < maxReportIndex; i += 1) {
                 reports[i].all_sizes[territoryKey].number_of_towns.total += 1;
                 reports[i].big_towns_only[territoryKey].number_of_towns.total += row.population_total >= BIG_TOWN_SIZE ? 1 : 0;
             }
         }
 
         // on ignore les saisies intermédiaires entre deux dates
-        // (par exemple si la date est "15/01/2023" mais qu'on a déjà traité "16/01/2023", on peut l'ignorer)
+        // (par exemple si la date est "15/01/2023" mais qu'on a déjà traité "16/01/2023", on peut l'ignorer
+        // car il s'agit du même rapport)
         if (previousIndex === reportIndex) {
             return;
         }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/HC7wKmal/2070

## 🛠 Description de la PR
Deux erreurs ont été corrigées :
1. les sites n'étaient pas bien comptés dans les totaux (ils étaient comptés à partir de leur dernière date de modification plutôt qu'à partir de leur date d'existence)
2. une saisie faite après la date de fin du rapport pouvait provoquer une erreur de génération (car la saisie provoquait la modification d'une colonne inexistante dans le rapport ; ex. : modifier la colonne 3 dans un rapport qui doit compter 2 colonnes).

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS