### PR TITLE
#patch (2148) Correc° d'un bug de demande d'accès association

### DIFF
--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
@@ -242,6 +242,9 @@ function intermediateSubmit(values) {
         .territorial_collectivity?.data
         ? formattedValues.territorial_collectivity.data.id
         : null;
+    formattedValues.association = formattedValues.association?.data
+        ? formattedValues.association.data.id
+        : null;
     return submit.value(formattedValues);
 }
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/W8zFTYNZ/2148

## 🛠 Description de la PR
Le champ Association a été transformé récemment en champ Autocomplete, hors l'autocomplete ne ressort pas juste un id d'association mais un objet `{data : { id : number } }` qui est envoyé à l'API qui évidemment le refuse.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS