### PR TITLE
#patch (2149) La création d'utilisateur ne marche pas pour le cas "association"

### DIFF
--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.schema.js
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.schema.js
@@ -156,7 +156,7 @@ export default (variant, allowNewOrganization, language) => {
                 ),
         })
         .label(labels.territorial_collectivity);
-    schema.association = string()
+    schema.association = object()
         .when("organization_category", {
             is: "association",
             then: (schema) =>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JtcCJDEq/2149

## 🛠 Description de la PR
Le champ 'association' était validé comme étant une string alors que depuis le passage en Autocomplete, ce champ produit un objet et non une string.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS