### PR TITLE
#patch: (2144) Correction du lien des statistiques sur la page Tableau de bord

### DIFF
--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordVueEnsemble.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordVueEnsemble.vue
@@ -41,10 +41,10 @@
             </div>
             <p class="text-center mt-6">
                 <Link
-                    to="/statistiques"
+                    to="/visualisation-donnees"
                     v-if="userStore.hasPermission('stats.read')"
                 >
-                    Voir plus de statistiques
+                    Visualiser toutes les données
                 </Link>
             </p>
         </section>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kt9WW340/2144-bug-le-lien-sur-la-page-statistiques-priv%C3%A9es-est-cass%C3%A9

## 🛠 Description de la PR
Le lien de visualisation des statistiques sur le tableau de bord n'aboutissait plus. Il renvoi maintenant sur la visualisation de données.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RAS