### PR TITLE
#patch: (2151) Correction d'une faille majeure de sécurité

### DIFF
--- a/packages/api/server/controllers/user/update/user.update.ts
+++ b/packages/api/server/controllers/user/update/user.update.ts
@@ -4,6 +4,12 @@ import authUtils from '#server/utils/auth';
 const { hashPassword } = authUtils;
 
 export default async (req, res, next) => {
+    if (req.user.role_id !== 'national_admin' && req.params?.id !== req.user.id) {
+        return res.status(403).send({
+            user_message: 'Vous n\'avez pas les droits suffisants pour modifier cet utilisateur',
+        });
+    }
+
     const { id: paramId } = req.params;
     const { id: connectedUserId } = req.user;
 

--- a/packages/api/server/controllers/user/update/user.update.validator.ts
+++ b/packages/api/server/controllers/user/update/user.update.validator.ts
@@ -1,9 +1,13 @@
 /* eslint-disable newline-per-chained-call */
-import { body } from 'express-validator';
+import { body, param } from 'express-validator';
 import checkPassword from '#server/utils/checkPassword';
 import EMAIL_SUBSCRIPTIONS from '#server/config/email_subscriptions';
 
 export default [
+    param('id')
+        .isInt().withMessage('L\'identifiant de l\'utilisateur est invalide')
+        .toInt(),
+
     body('last_name')
         .optional()
         .isString()


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/FbvYJuy9/2151-secu-faille-permettant-de-modifier-le-mot-de-passe-de-nimporte-quel-utilisateur

## 🛠 Description de la PR
Correction d'une faille majeure de sécurité permettant à n'importe quel utilisateur connecté de modifier le mot de passe de n'importe quel autre utilisateur, incluant les administrateurs.
Pour se faire, il faut être en mesure de récupérer son propre JWT et émettre des requêtes vers l'API.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS