### PR TITLE
#patch: (2143) Wording pour l'accord de publication dans l'annuaire du site

### DIFF
--- a/packages/frontend/webapp/src/components/CharteEngagement/CharteEngagement.vue
+++ b/packages/frontend/webapp/src/components/CharteEngagement/CharteEngagement.vue
@@ -8,13 +8,19 @@
         >
 
         <template v-slot:body>
-            <CharteEngagementInputCharteAgreement class="mb-6" />
-            <CharteEngagementInputConfidentialityAgreement class="mb-6" />
+            <CharteEngagementInputCharteAgreement
+                class="mb-6"
+                v-on:input="updateInputValue"
+            />
+            <CharteEngagementInputConfidentialityAgreement
+                class="mb-6"
+                v-on:input="updateInputValue"
+            />
         </template>
 
         <template v-slot:button>
             <p class="text-center">
-                <Button type="submit"
+                <Button type="submit" :disabled="formValid !== 2"
                     >J'accepte et j'accède à la plateforme</Button
                 >
             </p>
@@ -23,6 +29,7 @@
 </template>
 
 <script setup>
+import { ref } from "vue";
 import router from "@/helpers/router";
 import { useConfigStore } from "@/stores/config.store";
 import { useNotificationStore } from "@/stores/notification.store";
@@ -35,8 +42,15 @@ import CharteEngagementInputCharteAgreement from "./inputs/CharteEngagementInput
 import CharteEngagementInputConfidentialityAgreement from "./inputs/CharteEngagementInputConfidentialityAgreement.vue";
 
 const configStore = useConfigStore();
+const formValid = ref(0);
 
 const { version_charte_engagement: charte } = configStore.config;
+
+const updateInputValue = (value) => {
+    formValid.value = value.target.checked
+        ? formValid.value + 1
+        : formValid.value - 1;
+};
 
 async function submit({ charte_agreement, confidentiality_agreement }) {
     const notificationStore = useNotificationStore();

--- a/packages/frontend/webapp/src/components/CharteEngagement/inputs/CharteEngagementInputCharteAgreement.vue
+++ b/packages/frontend/webapp/src/components/CharteEngagement/inputs/CharteEngagementInputCharteAgreement.vue
@@ -1,7 +1,7 @@
 <template>
     <CharteEngagementInput
         name="charte_agreement"
-        label="Je m'engage à respecter la charte d'engagement, à exploiter les informations présentes sur la plateforme exclusivement pour les besoins propres de mon organisation ; à ne pas communiquer sous aucune forme (orale, écrite, copie) à un tiers."
+        label="Je m'engage à respecter la charte d'engagement, à exploiter les informations présentes sur la plateforme exclusivement pour les besoins propres de mon organisation ; à ne pas communiquer sous aucune forme (orale, écrite, copie) à un tiers. J’accepte la publication de mes coordonnées dans l’annuaire pour faciliter la coordination entre acteurs."
     >
         <Link
             :to="configStore.config.version_charte_engagement.fichier"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/081f8sa0/2143-rgpd-wording-sur-la-page-dactivation-de-compte

## 🛠 Description de la PR
Cette PR intègre un wording pour spécifier à l'utilisateur qu'il donne son accord pour sa publication dans l'annuaire interne de la plateforme pour faciliter la coordination entre acteurs.

Elle intègre également une fonctionnalité de désactivation du bouton de validation de la charte tant que les 2 cases n'ont pas été cochées.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/34971399/42c075e4-14d6-4f76-b7c3-a7d600f7f344)

## 🚨 Notes pour la mise en production
RàS