### PR TITLE
#patch: (2056) Désactivation du mail J+90 tant que le sondage n'est pas à jour

### DIFF
--- a/packages/api/server/services/accessRequest/scheduler.ts
+++ b/packages/api/server/services/accessRequest/scheduler.ts
@@ -41,9 +41,10 @@ export default {
             await agenda.schedule('in 60 days', 'user_share', {
                 user,
             });
-            await agenda.schedule('in 90 days', 'user_review', {
-                user,
-            });
+            // Désactivation temporaire liée au [#2060](https://trello.com/c/agkYaQcx/2086-le-sondage-post-3-mois-nexiste-plus)
+            // await agenda.schedule('in 90 days', 'user_review', {
+            //     user,
+            // });
         },
     },
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/agkYaQcx/2086-le-sondage-post-3-mois-nexiste-plus

## 🛠 Description de la PR
Désactivation temporaire du mail automatique J+90 envoyant un sondage "périmé" à l'utilisateur.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS