### PR TITLE
#patch (2152) Améliorer l'accessibilité de la plateforme

### DIFF
--- a/packages/frontend/ui/src/components/Input/CheckboxUi.vue
+++ b/packages/frontend/ui/src/components/Input/CheckboxUi.vue
@@ -100,7 +100,7 @@ const props = defineProps({
     labelClass: {
         type: String,
         required: false,
-        default: ''        
+        default: ''
     }
 });
 

--- a/packages/frontend/ui/src/components/Modal.vue
+++ b/packages/frontend/ui/src/components/Modal.vue
@@ -7,7 +7,7 @@
         <div class="flex items-center justify-center h-full">
             <div role="dialog" ref="dialog" aria-modal="true" aria-labelledby="modal-headline"
                 class="opacity-100 z-50 shadow-xl max-h-[95vh] overflow-auto">
-                <div class="bg-white">
+                <div class="bg-white" ref="trapRef" role="dialog">
                     <slot name="header">
                         <div class="pt-10 px-10 pb-4">
                             <div class="flex justify-between items-center border-b-1 border-G400">
@@ -39,6 +39,7 @@
 </template>
 
 <script setup>
+import useFocusTrap from "../composables/useFocusTrap";
 import {
     defineProps,
     ref,
@@ -69,6 +70,7 @@ const { isOpen, closeWhenClickOutside, allowClose } = toRefs(props);
 const openedAt = ref(null);
 const dialog = ref(null);
 const emit = defineEmits(["close"]);
+const { trapRef } = useFocusTrap();
 
 watch(isOpen, () => {
     if (isOpen.value === true) {

--- a/packages/frontend/ui/src/components/Tag.vue
+++ b/packages/frontend/ui/src/components/Tag.vue
@@ -1,10 +1,10 @@
 <template>
-    <div :class="[display, variantClasses]">
+    <p :class="[display, variantClasses]">
         <slot />
         <span class="ml-2 cursor-pointer" @click="onDelete" v-if="onDelete">
             <Icon icon="times" />
         </span>
-    </div>
+    </p>
 </template>
 
 <script>

--- a/packages/frontend/ui/src/composables/useFocusTrap.js
+++ b/packages/frontend/ui/src/composables/useFocusTrap.js
@@ -1,0 +1,70 @@
+import { customRef } from "vue";
+
+const focusableElementsSelector =
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const useFocusTrap = () => {
+    let focusableElements = [];
+    let $firstFocusable;
+    let $lastFocusable;
+    const trapRef = customRef((track, trigger) => {
+        let $trapEl = null;
+        return {
+            get() {
+                track();
+                return $trapEl;
+            },
+            set(value) {
+                $trapEl = value;
+                value ? initFocusTrap() : clearFocusTrap();
+                trigger();
+            },
+        };
+    });
+
+    function keyHandler(e) {
+        const isTabPressed = e.key === "Tab";
+
+        if (!isTabPressed) {
+            return;
+        }
+
+        if (e.shiftKey) {
+            if (document.activeElement === $firstFocusable) {
+                $lastFocusable.focus();
+                e.preventDefault();
+            }
+        } else {
+            if (document.activeElement === $lastFocusable) {
+                $firstFocusable.focus();
+                e.preventDefault();
+            }
+        }
+    }
+
+    function initFocusTrap() {
+        // Bail out if there is no value
+        if (!trapRef.value) {
+            return;
+        }
+        focusableElements = trapRef.value.querySelectorAll(
+            focusableElementsSelector
+        );
+        $firstFocusable = focusableElements[0];
+        $lastFocusable = focusableElements[focusableElements.length - 1];
+        document.addEventListener("keydown", keyHandler);
+        $firstFocusable.focus();
+    }
+
+    function clearFocusTrap() {
+        document.removeEventListener("keydown", keyHandler);
+    }
+
+    return {
+        trapRef,
+        initFocusTrap,
+        clearFocusTrap,
+    };
+};
+
+export default useFocusTrap;

--- a/packages/frontend/ui/src/composables/useFocusTrap.js
+++ b/packages/frontend/ui/src/composables/useFocusTrap.js
@@ -34,11 +34,9 @@ const useFocusTrap = () => {
                 $lastFocusable.focus();
                 e.preventDefault();
             }
-        } else {
-            if (document.activeElement === $lastFocusable) {
+        } else if (document.activeElement === $lastFocusable) {
                 $firstFocusable.focus();
                 e.preventDefault();
-            }
         }
     }
 

--- a/packages/frontend/webapp/src/components/CarteSite/CarteSite.vue
+++ b/packages/frontend/webapp/src/components/CarteSite/CarteSite.vue
@@ -32,7 +32,7 @@
             </p>
         </header>
 
-        <main class="mb-4">
+        <div class="mb-4">
             <!-- population -->
             <NombreHabitants
                 v-if="
@@ -83,7 +83,7 @@
                     }}
                 </Link>
             </p>
-        </main>
+        </div>
 
         <footer class="mt-auto">
             <Link @click="routeToDetailsPage"

--- a/packages/frontend/webapp/src/components/LayoutSearch/LayoutSearch.vue
+++ b/packages/frontend/webapp/src/components/LayoutSearch/LayoutSearch.vue
@@ -10,7 +10,7 @@
                     >Saisissez une valeur dans le champ qui suit pour rechercher
                     un site, une commune, un département, puis sélectionner
                     l'item de votre choix dans la liste en vous déplaçant à
-                    l'aide les les flèches directionnelles</span
+                    l'aide des flèches directionnelles</span
                 >
                 <ContentWrapper class="mt-3" size="medium">
                     <div role="search" class="flex items-center space-x-2">

--- a/packages/frontend/webapp/src/components/LayoutSearch/LayoutSearch.vue
+++ b/packages/frontend/webapp/src/components/LayoutSearch/LayoutSearch.vue
@@ -6,6 +6,12 @@
                 :class="showReset ? 'pb-4' : 'pb-10'"
             >
                 <p class="text-lg xl:text-xl font-bold">{{ searchTitle }}</p>
+                <span class="sr-only"
+                    >Saisissez une valeur dans le champ qui suit pour rechercher
+                    un site, une commune, un département, puis sélectionner
+                    l'item de votre choix dans la liste en vous déplaçant à
+                    l'aide les les flèches directionnelles</span
+                >
                 <ContentWrapper class="mt-3" size="medium">
                     <div role="search" class="flex items-center space-x-2">
                         <InputLocation

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordSection.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordSection.vue
@@ -1,13 +1,17 @@
 <template>
     <section>
         <header class="md:flex items-start mb-5">
-            <h2 class="text-xl font-bold">
+            <h2 class="pt-2 text-xl font-bold">
                 {{ title }}
             </h2>
-            <nav class="pt-2 flex flex-1 justify-between items-start">
+            <div
+                role="tablist"
+                aria-label="Types de sites"
+                class="pt-2 flex flex-1 justify-between items-start"
+            >
                 <slot name="header_left" />
                 <slot name="header_right" />
-            </nav>
+            </div>
         </header>
 
         <slot />

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordSites/TableauDeBordSitesFiltres.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordSites/TableauDeBordSitesFiltres.vue
@@ -6,18 +6,29 @@
             class="inline-flex items-start"
             v-bind="item"
             @click="setFilter(item.id)"
-            ><span
-                >{{ item.label }} ({{
-                    dashboardStore.towns.data[item.id].length
-                }})
-                <template v-if="item.sublabel"
-                    ><br /><span
-                        class="inline-block w-full font-normal text-center"
-                        :class="item.active ? 'visible' : 'invisible'"
-                        >{{ item.sublabel }}</span
-                    ></template
-                ></span
+            @keyup.enter.exact="setFilter(item.id)"
+        >
+            <Button
+                type="button"
+                variant="text"
+                :id="`btn-${item.id}`"
+                role="tab"
+                :aria-selected="item.ariaSelected"
+                :aria-controls="`tabpanel-${item.id}`"
             >
+                <span
+                    >{{ item.label }} ({{
+                        dashboardStore.towns.data[item.id].length
+                    }})
+                    <template v-if="item.sublabel"
+                        ><br /><span
+                            class="inline-block w-full font-normal text-center"
+                            :class="item.active ? 'visible' : 'invisible'"
+                            >{{ item.sublabel }}</span
+                        ></template
+                    ></span
+                >
+            </Button>
         </TableauDeBordSiteFiltreItem>
     </ul>
 </template>
@@ -34,6 +45,7 @@ import { computed } from "vue";
 import { useDashboardStore } from "@/stores/dashboard.store";
 import TableauDeBordSiteFiltreItem from "./TableauDeBordSiteFiltre/TableauDeBordSiteFiltreItem.vue";
 import { trackEvent } from "@/helpers/matomo";
+import { Button } from "@resorptionbidonvilles/ui";
 
 const dashboardStore = useDashboardStore();
 const items = computed(() => {
@@ -71,6 +83,7 @@ const items = computed(() => {
         return {
             ...item,
             active: item.id === dashboardStore.towns.filter,
+            ariaSelected: item.id === dashboardStore.towns.filter,
         };
     });
 });

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordBarreHistogramme.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordBarreHistogramme.vue
@@ -4,6 +4,7 @@
         ref="bar"
         class="rounded-sm w-2 mr-1 cursor-pointer"
         :class="hover ? hoverColor : color"
+        :style="styleObject"
         :aria-label="ariaLabel"
         tabindex="-1"
         @mouseover="hover = true"
@@ -83,4 +84,15 @@ function getAudibleMonth(month) {
         .replace("11", "novembre")
         .replace("12", "décembre");
 }
+const styleObject = computed(() => {
+    if (color.value === "bg-red" || color.value === "bg-green500") {
+        return {
+            "background-image":
+                "linear-gradient(45deg, rgb(255, 255,255) 12.5%, transparent 12.5%, transparent 37.5%, rgb(255, 255,255) 37.5%, rgb(255, 255,255) 62.5%, transparent 62.5%, transparent 87.5%, rgb(255, 255,255) 87.5%)",
+            "background-size": "10px 10px",
+            "background-position": "0px 0px",
+        };
+    }
+    return {};
+});
 </script>

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordBarreHistogramme.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordBarreHistogramme.vue
@@ -39,8 +39,9 @@ onMounted(() => {
 });
 
 const ariaLabel = computed(() => {
+    let message = "";
     if (dateFrom.value) {
-        return `${figure.value} du ${dateFrom.value.slice(
+        message = `${figure.value} du ${dateFrom.value.slice(
             0,
             2
         )} ${getAudibleMonth(dateFrom.value.slice(-2))} au ${date.value.slice(
@@ -48,10 +49,23 @@ const ariaLabel = computed(() => {
             2
         )} ${getAudibleMonth(date.value.slice(-2))}`;
     } else {
-        return `${figure.value} au ${date.value.slice(0, 2)} ${getAudibleMonth(
-            date.value.slice(-2)
-        )}`;
+        message = `${figure.value} au ${date.value.slice(
+            0,
+            2
+        )} ${getAudibleMonth(date.value.slice(-2))}`;
     }
+    if (color.value === "bg-red") {
+        message =
+            message.length > 0
+                ? message + " (En progression défavorable)"
+                : message + "En progression défavorable";
+    } else if (color.value === "bg-green500") {
+        message =
+            message.length > 0
+                ? message + " (En progression favorable)"
+                : message + "En progression favorable";
+    }
+    return message;
 });
 
 function getAudibleMonth(month) {

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordBarreHistogramme.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordBarreHistogramme.vue
@@ -1,15 +1,18 @@
 <template>
     <div
+        role="img"
         ref="bar"
         class="rounded-sm w-2 mr-1 cursor-pointer"
         :class="hover ? hoverColor : color"
+        :aria-label="ariaLabel"
+        tabindex="-1"
         @mouseover="hover = true"
         @mouseleave="hover = false"
     ></div>
 </template>
 
 <script setup>
-import { defineProps, ref, toRefs, onMounted } from "vue";
+import { computed, defineProps, ref, toRefs, onMounted } from "vue";
 
 const props = defineProps({
     height: {
@@ -21,8 +24,11 @@ const props = defineProps({
     hoverColor: {
         type: String,
     },
+    figure: Number,
+    date: String,
+    dateFrom: String,
 });
-const { height, color, hoverColor } = toRefs(props);
+const { height, color, hoverColor, figure, date, dateFrom } = toRefs(props);
 const hover = ref(false);
 const bar = ref(null);
 
@@ -31,4 +37,36 @@ onMounted(() => {
     bar.value.style.height =
         height.value !== 0 ? `${height.value}rem` : "0.1rem";
 });
+
+const ariaLabel = computed(() => {
+    if (dateFrom.value) {
+        return `${figure.value} du ${dateFrom.value.slice(
+            0,
+            2
+        )} ${getAudibleMonth(dateFrom.value.slice(-2))} au ${date.value.slice(
+            0,
+            2
+        )} ${getAudibleMonth(date.value.slice(-2))}`;
+    } else {
+        return `${figure.value} au ${date.value.slice(0, 2)} ${getAudibleMonth(
+            date.value.slice(-2)
+        )}`;
+    }
+});
+
+function getAudibleMonth(month) {
+    return month
+        .replace("01", "janvier")
+        .replace("02", "février")
+        .replace("03", "mars")
+        .replace("04", "avril")
+        .replace("05", "mai")
+        .replace("06", "juin")
+        .replace("07", "juillet")
+        .replace("08", "août")
+        .replace("09", "septembre")
+        .replace("10", "octobre")
+        .replace("11", "novembre")
+        .replace("12", "décembre");
+}
 </script>

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
@@ -89,7 +89,7 @@
                 </div>
             </div>
             <div class="text-center mt-4">
-                <div :class="evolutionColor">
+                <p :class="evolutionColor">
                     <Icon
                         class="up"
                         v-if="isEvolutionPositive"
@@ -109,7 +109,7 @@
                         >
                         <span v-else class="text-xs">en 3 mois</span>
                     </span>
-                </div>
+                </p>
             </div>
         </div>
     </div>

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
@@ -69,7 +69,7 @@
                     class="sr-only"
                     :id="`description-${cardStats.id}`"
                 >
-                    Utiliser les touches Flêche vers le haut ou flêche vers le
+                    Utiliser les touches Flèche vers le haut ou Flèche vers le
                     bas pour vous déplacer dans l'histogramme
                 </p>
                 <div

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
@@ -55,17 +55,20 @@
                 v-if="displayFigure !== null"
                 :figure="displayFigure"
             />
-
             <div
                 class="flex justify-center items-end mt-2"
                 role="group"
                 :aria-label="`${cardStats.label}`"
                 tabindex="0"
-                aria-describedby="description"
+                :aria-describedby="`description-${cardStats.id}`"
                 @focus="onFocus"
                 @blur="onBlur"
             >
-                <p v-show="displayDescription" class="sr-only" id="description">
+                <p
+                    v-show="displayDescription"
+                    class="sr-only"
+                    :id="`description-${cardStats.id}`"
+                >
                     Utiliser les touches Flêche vers le haut ou flêche vers le
                     bas pour vous déplacer dans l'histogramme
                 </p>

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
@@ -55,13 +55,20 @@
                 v-if="displayFigure !== null"
                 :figure="displayFigure"
             />
+
             <div
                 class="flex justify-center items-end mt-2"
                 role="group"
-                aria-label="description de l'histogramme"
+                :aria-label="`${cardStats.label}`"
                 tabindex="0"
                 aria-describedby="description"
+                @focus="onFocus"
+                @blur="onBlur"
             >
+                <p v-show="displayDescription" class="sr-only" id="description">
+                    Utiliser les touches Flêche vers le haut ou flêche vers le
+                    bas pour vous déplacer dans l'histogramme
+                </p>
                 <div
                     v-for="(stat, index) in columns"
                     :key="index"
@@ -138,6 +145,8 @@ const maxNumber = computed(() => {
 });
 const displayFigure = ref(null);
 
+let displayDescription = ref(false);
+
 onMounted(setColumns);
 
 function onMouseOver(value) {
@@ -180,6 +189,14 @@ function setColumns() {
                 cardStats.value.color === "red" ? "bg-red400" : "bg-green400",
         },
     ];
+}
+
+function onFocus() {
+    displayDescription.value = true;
+}
+
+function onBlur() {
+    displayDescription.value = false;
 }
 </script>
 

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordCarteStatistique.vue
@@ -12,15 +12,13 @@
                 <Icon v-else :icon="icon" />
             </div>
             <div>
-                <div class="font-bold text-primary text-xl -mb-1">
-                    <span>
+                <p class="leading-tight">
+                    <span class="font-bold text-primary text-xl -mb-1">
                         <template v-if="cardStats.data.length > 0">{{
                             formatStat(cardStats.data.slice(-1)[0].figure)
                         }}</template>
                         <template v-else>0</template>
                     </span>
-                </div>
-                <p class="leading-tight">
                     {{ cardStats.label }}<br />
                     <span v-if="cardStats.figure_secondary">
                         <span
@@ -57,7 +55,13 @@
                 v-if="displayFigure !== null"
                 :figure="displayFigure"
             />
-            <div class="flex justify-center items-end mt-2">
+            <div
+                class="flex justify-center items-end mt-2"
+                role="group"
+                aria-label="description de l'histogramme"
+                tabindex="0"
+                aria-describedby="description"
+            >
                 <div
                     v-for="(stat, index) in columns"
                     :key="index"
@@ -68,6 +72,9 @@
                         :height="stat.height"
                         :color="stat.color"
                         :hoverColor="stat.hoverColor"
+                        :figure="stat.figure"
+                        :date="stat.date"
+                        :dateFrom="stat.dateFrom"
                     />
                 </div>
             </div>

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordValeurStatistique.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordVueEnsemble/TableauDeBordValeurStatistique.vue
@@ -1,11 +1,11 @@
 <template>
-    <div class="text-xs text-center">
+    <p class="text-xs text-center">
         {{ formatStat(figure.figure) }}
         <span v-if="figure.dateFrom"
             >du {{ figure.dateFrom }} au {{ figure.date }}</span
         >
         <span v-else>au {{ figure.date }}</span>
-    </div>
+    </p>
 </template>
 
 <script setup>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/whXIQ9Yb/2152

## 🛠 Description de la PR
## [X] ~~Page Connexion~~

*Formulaire de connexion*
*10.6 - **Majeur** : le bloc récapitulant les erreurs (`div.bg-red200`) propose une liste de liens dont la  nature n’est pas évidente (absence de mise en forme particulière).*
- [x] Mettre visuellement en évidence la présence des liens.

## [X] ~~Page Contact~~
*11.5 - **Bloquant** : les options de choix (actuellement structurées* `button`) ne sont pas regroupées de manière à leur associer la consigne*
- [x]  Regrouper les options de choix au sein d’un conteneur `fieldset` pourvu enfant `legend` qui accueillera l’intitulé de la consigne de regroupement
```
<fieldset>
<legend>Vous souhaitez…</legend>
```

*11.10 - **Bloquant** : les différents contrôles de choix doivent faire l’objet d’une sélection, or ce caractère n’est disponible qu’après formulaire.*
- [x] Indiquer visuellement dans la consigne de regroupement le caractère la sélection en précisant si elle peut être multiple ou pas.

## [X] ~~Charte d’engagement~~
*7.1 - **Bloquant** : les pseudo-cases à cocher “Je m'engage à respecter la charte…” et “En validant mon accès à Résorption-bidonvilles,...” ne sont pas sémantiquement appropriées (élément `button`) et ne restituent pas de nom accessible ni leur état de sélection.
- [x] Remplacer l’élément `button` par un élément `input[type=checkbox]` ;
- [x] Structurer au moyen d’un élément `label` l’intitulé “Je certifie que ces données personnelles ont été saisies avec mon accord” et l’associer à l’élément `input[type=checkbox]` au moyen d’un attribut `for`.

*11.10 - **Bloquant** : le caractère obligatoire des cases à cocher n’est disponible qu’après validation du formulaire.*
- [x] Indiquer dans le nom visible et accessible de la case à cocher le caractère obligatoire de la sélection.

*8.9 - **Majeur** : l’élément button[type=submit] contient des éléments div non valides.*
- [x] Remplacer les éléments div par des éléments span.

*Consultation*
*13.3 - **Majeur** : le document PDF* “charte-d-engagement-resorption-bidonvilles_v2.pdf” est proposé en téléchargement, mais ce document n’est pas accessible.
- [x] Proposer une version accessible du document ou une version alternative accessible du document (**en HTML, par exemple**).

## Accueil connecté
*Formulaire de recherche*
*7.1 - **Bloquant** : le composant de recherche avec autocomplétion présente plusieurs
problèmes :
	- Il ne dispose pas d’un nom accessible ;
	- Aucune sémantique ne vient préciser le comportement d’autocomplétion au
niveau du champ de saisie ;
	- La liste d’autocomplétion ne restitue elle-même aucune sémantique spécifique ;
	- L’utilisateur d’un lecteur d’écran n’est pas informé du nombre de résultats présents à l’affichage ;
	- L’utilisateur d’un lecteur d’écran n’a aucune indication d’aide à l’utilisation du composant
- [x] Remplacer l’élément `h1` par un élément `label` pourvu d’un attribut `for=”territorial_collectivity”` ;
- [x] Inclure un message d'aide (visible ou non) destiné à l’utilisateur d’un lecteur d'écran pour savoir comment utiliser le composant et notamment la liste de suggestions associée ;

*8.9 - **Majeur** : l’élément `button[type=submit]` contient des éléments `div` non valides.
- [x] Remplacer les éléments div par des éléments `span`.

# Section Vue d’ensemble*
*8.9 - **Majeur** : l’élément `div.font-bold.text-primary.text-xl.-mb-1>span` n’est pas sémantiquement approprié.*
- [x] Replacer le contenu de l’élément `span` dans l’élément `p.leading-tight` qui devrait aussi être son élément conteneur. (cf TableauDeBordCarteStatistiques.vue)

*7.1, 7.3 - **Majeur** :
- L’élément graphique complexe représentant une sorte d’histogramme de données n’est pas identifié (ni sémantique, ni nom accessible) ;
- Il est de plus dynamique, chaque élément graphique représentant une barre étant interactif et restituant une information ; or l’interaction avec ces éléments graphiques n’est pas possible au clavier.

- [x] Ajouter à l’élément graphique complexe (conteneur `div.flex.justify-center.items-end.mt-2`) :
	- [x] Un attribut `role=”group”` ;
	- [x] Un attribut `aria-label` avec pour valeur une description de l’histogramme concerné ;
	- [x] Un attribut `tabindex=”0”` ;
	- [x] Un attribut `aria-describedby` avec pour valeur la référence d’`id` de l’élément `p.ad` (voir ci-après).
- [x] Insérer après l’élément `div.flex.justify-center.items-end.mt-2` un élément `p.ad` et lui ajouter :
	- [x] Un contenu texte : “Utiliser les touches Gauche ou Droite pour se déplacer dans l’histogramme” ;
	- [x] Un attribut `id` dont la référence servira à l’attribut `aria-describedby` évoqué ci-dessus ;
	- [x]  Un style CSS qui cache l’élément par défaut (`display: none` ou une classe du type `visuallyhidden`)

- [x] Ajouter aux éléments représentant une barre de l’histogramme (`div.rounded-sm.w-2.mr-1.cursor-pointer`) :
	- [x] Un attribut `role=”img”` ;
	- [x] Un attribut `aria-label` avec pour valeur l’information affichée au survol, par exemple “63311 au 02/05” ;
	- [x] Un attribut `tabindex=”-1”`.

- [x] Ajouter les interactions suivantes à la prise de focus de l’élément conteneur :
	- [x] Afficher l’élément `p.ad` ;
- [x] Assurer la possibilité de naviguer au clavier sur l’ensemble des barres de l’histogramme au moyen des touches de direction Gauche et Droite et afficher alors l’information correspondante comme au survol ;
- [x] Assurer une visibilité du focus par défaut sur l’élément conteneur ou autrement sur l’élément graphique en cours de consultation.

*3.1 - **Majeur** : dans les histogrammes, les barres peuvent avoir différentes couleurs (bleu, rouge, vert), or l’information ainsi véhiculée ne peut reposer sur la seule couleur.*
- [x] Ajouter une mise en forme graphique pour distinguer ces différentes barres (motif de remplissage, par exemple).

*3.1 - **Majeur** : le contenu des éléments `div.bg-red200.text-red600` et `div.bg-green200.text-green600` fournit a priori une information par la couleur que le texte présent ne peut pas désambiguïser dans la mesure où les textes affichent soit une stagnation (+0%) soulignée en rouge soit une progression souligné en rouge ou en vert.*
- [x] Préciser d’une manière autre que la couleur l’information complémentaire fournie par cette dernière.

*8.9 - **Majeur** : les éléments `div.bg-red200.text-red600` et `div.bg-green200.text-green600` ne sont pas sémantiquement appropriés.
- [x] Remplacer les éléments `div` par un élément `p`.

*Section Site*
*9.2 - **Majeur** : l’élément `nav.pt-2.flex.flex-1.justify-between.items-start` n’est pas
sémantiquement approprié dans la mesure où le comportement du composant est
celui d’une boîte à onglets.*

- [x] Remplacer l’élément `nav` par un élément `div` pourvu d’un attribut `role=”tablist”` et d’un attribut `aria-label=”Types de sites”`, par exemple ;
- [ ] Pour le reste des caractérisations sémantiques à appliquer aux différents éléments du conteneur tablist, voir le design pattern Tabs : https://www.w3.org/WAI/ARIA/apg/patterns/tabs/.

**IMPORTANT** Ce point est partiellement traité: les onglets sont maintenant navigables avec la touche "Tabulation". Il faut encore rendre ces éléments navigables avec les touches "Flèche droite" et "Flèche gauche"

*9.3 - **Bloquant** : l’élément `ul.list-none.ml-4` contient des éléments `li` vides de contenu
(`li[id^=separator]`) qui ne sont pas sémantiquement appropriés.*
- [x] Supprimer les éléments `li[id^=separator]` et réaliser l’effet visuel de séparation au moyen d’un artifice CSS ;
- [x] **Remarque** : l’attribut `type` d’un élément `li` est obsolète et la valeur “separator” n’est pas valide.

*7.1, 7.3 - **Majeur** : les pseudo-boutons de navigation gauche et droite (éléments `div`) pour se déplacer dans la liste des sites ne restituent ni sémantique, ni nom accessible et n’est pas accessible au clavier.*
- [x] Remplacer l’élément `div` par un élément `button` ;
- [x] Ajouter à l’élément `button` un nom accessible ;
- [ ] Assurer la navigation et l’activation au clavier du bouton.

*8.9 - **Majeur** : l’élément `div` avec pour contenu “Mis à jour aujourd'hui” n’est pas sémantiquement approprié.*
- [x] Remplacer l’élément `div` par un élément `p`.

*8.9 - **Bloquant** : l’élément `main.mb-4` n’est pas valide.*
- [x] Remplacer l’élément main par un élément `p`.
	=> remplacé par une `<div>` car contient des éléments `<p>`

## 📸 Captures d'écran

## 🚨 Notes pour la mise en production
- ràs