### PR TITLE
#patch (2157) Corriger l'encart sur les risques d'usurpation

### DIFF
--- a/packages/frontend/ui/src/components/Button.vue
+++ b/packages/frontend/ui/src/components/Button.vue
@@ -104,6 +104,11 @@ export default {
                     "border-2 border-secondary bg-secondary text-white hover:bg-secondaryDark",
                 tertiary:
                     "border-2 border-tertiary bg-tertiary text-white hover:bg-tertiaryDark hover:border-tertiaryDark",
+                tertiaryA11Y:
+                    "border-2 border-tertiaryA11Y bg-tertiaryA11Y text-white hover:bg-tertiaryA11Ydark hover:border-tertiaryA11Ydark",
+                tertiaryA11Yalt:
+                    "border-2 border-tertiaryA11Y bg-tertiaryA11Yalt text-white hover:bg-tertiaryA11Ydark hover:border-tertiaryA11Ydark",
+                
                 specialEvent:
                     "bg-yellow-200 text-black hover:bg-yellow-400",
                 primaryOutline:

--- a/packages/frontend/ui/tailwind.config.js
+++ b/packages/frontend/ui/tailwind.config.js
@@ -129,6 +129,9 @@ module.exports = {
 
                 // Green / Tertiary palette
                 tertiary: "#00AC8C",
+                tertiaryA11Y: "#026452",
+                tertiaryA11Yalt: "#1b5f53",
+                tertiaryA11Ydark: "#206054",
                 green700: "#1E7D3B",
                 green600: "#1f8d49",
                 green500: "#27A658",
@@ -137,6 +140,7 @@ module.exports = {
                 green100: "#E9F6EE",
 
                 // Red palette
+                redA11Y: "#A9000B",
                 red700: "#A9000B",
                 red600: "#E1000F",
                 red500: "#CA000D",

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionGrantAccess.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionGrantAccess.vue
@@ -1,7 +1,7 @@
 <template>
     <Button
         v-if="user.status === 'new'"
-        variant="tertiary"
+        variant="tertiaryA11Yalt"
         icon="paper-plane"
         iconPosition="left"
         :loading="isLoading"

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyAdminComments.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyAdminComments.vue
@@ -22,7 +22,7 @@
                 >Annuler mes changements</Button
             >
             <Button
-                variant="tertiary"
+                variant="tertiaryA11Yalt"
                 @click="updateAdminComments"
                 :disabled="!pendingAdminCommentsChanges"
                 :loading="isLoading"

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyWarning.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyWarning.vue
@@ -3,21 +3,17 @@
         <Icon icon="triangle-exclamation" /> N'envoyez
         <span class="font-bold underline">jamais</span> un accès si vous avez un
         doute sur l'identité de la personne pour éviter tout risque d'usurpation
-        d'identité.
-        <Link
-            withStyle
-            @click="openGuide('/doc/guide_de_l_administrateur.pdf')"
+        d'identité. Consulter le
+        <a
+            href="/doc/guide_de_l_administrateur.pdf"
+            aria-label="Téléchargez le guide des accès et de l'administrateur au format PDF"
+            class="text-blue700 hover:underline underline-offset-4 decoration-2"
         >
-            <Icon icon="file-pdf" /> Consulter le guide des accès et de
-            l'administrateur
-        </Link>
+            guide des accès et de l'administrateur</a
+        >.
     </div>
 </template>
 
 <script setup>
-import { Icon, Link } from "@resorptionbidonvilles/ui";
-
-function openGuide(link) {
-    window.location = link;
-}
+import { Icon } from "@resorptionbidonvilles/ui";
 </script>

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyWarning.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyWarning.vue
@@ -1,11 +1,23 @@
 <template>
     <div class="mt-6 bg-yellow-200 py-6 px-8">
         <Icon icon="triangle-exclamation" /> N'envoyez
-        <span class="font-bold underline">jamais</span> un accès tant que vous
-        avez un doute sur l’identité de la personne.
+        <span class="font-bold underline">jamais</span> un accès si vous avez un
+        doute sur l'identité de la personne pour éviter tout risque d'usurpation
+        d'identité.
+        <Link
+            withStyle
+            @click="openGuide('/doc/guide_de_l_administrateur.pdf')"
+        >
+            <Icon icon="file-pdf" /> Consulter le guide des accès et de
+            l'administrateur
+        </Link>
     </div>
 </template>
 
 <script setup>
-import { Icon } from "@resorptionbidonvilles/ui";
+import { Icon, Link } from "@resorptionbidonvilles/ui";
+
+function openGuide(link) {
+    window.location = link;
+}
 </script>

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnAccessDetails.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnAccessDetails.vue
@@ -4,7 +4,7 @@
             :text="user.access_request_message ? 'Demandé' : 'Créé'"
             :date="user.created_at"
             icon="flag"
-            color="text-secondary"
+            color="text-redA11Y"
             class="mb-2"
         />
 
@@ -62,7 +62,7 @@
             text="Activé"
             :date="user.user_accesses[0].used_at"
             icon="user-check"
-            color="text-tertiary"
+            color="text-tertiaryA11Y"
             class="mb-2"
         />
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/OS2yP2R3/2147

## 🛠 Description de la PR
Modifier l’encart jaune pour insister sur les risques d’usurpation d’identité , dans la page de validation des demandes d’accès.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/50863659/d28529a2-ef68-436e-b59c-6d3845cceb65)

## 🚨 Notes pour la mise en production
- ràs