### PR TITLE
#patch: (2153) Désactivation du message indiquant l'arrivée prochaine de la feature "intérêts et expertises"

### DIFF
--- a/packages/api/server/mails/src/activity_summary.mjml
+++ b/packages/api/server/mails/src/activity_summary.mjml
@@ -6,7 +6,6 @@
     </mj-head>
     <mj-body mj-class='bg-white'>
         <mj-include path='common/hero.mjml' />
-        <mj-include path='interests_and_expertise_popup/interests_and_expertise_popup.mjml' />
         <mj-section>
             <mj-column>
                 <mj-text mj-class='text-primary text-display pt-4 pb-4'>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/UUSdtDja/2153-mel-recap-hebdo-suppression-de-linfo-sur-comp%C3%A9tences

## 🛠 Description de la PR
L'email automatique de récapitulatif d'activité embarque toujours une mention indiquant qu'une fonctionnalité va bientôt voir le jour. Or, cette fonctionnalité est en production aujourd'hui. Le message n'a donc plus lieu d'être.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/34971399/33733a8c-8caa-491e-b6b0-4b91ccdda19b)

## 🚨 Notes pour la mise en production
RàS