### PR TITLE
#patch: (2154) Ajout de la possibilité d'ajout d'utilisateur à un organisme privé par un administrateur

### DIFF
--- a/packages/api/server/controllers/organization/searchPrivateOrganizations/organization.searchPrivateOrganizations.route.ts
+++ b/packages/api/server/controllers/organization/searchPrivateOrganizations/organization.searchPrivateOrganizations.route.ts
@@ -1,0 +1,10 @@
+import { type ApplicationWithCustomRoutes } from '#server/loaders/customRouteMethodsLoader';
+import validator from './organization.searchPrivateOrganizations.validator';
+import controller from './organization.searchPrivateOrganizations';
+
+export default (app: ApplicationWithCustomRoutes): void => {
+    app.customRoutes.get('/organizations/private-organizations/search', controller, validator, {
+        authenticate: false,
+        multipart: false,
+    });
+};

--- a/packages/api/server/controllers/organization/searchPrivateOrganizations/organization.searchPrivateOrganizations.ts
+++ b/packages/api/server/controllers/organization/searchPrivateOrganizations/organization.searchPrivateOrganizations.ts
@@ -1,0 +1,23 @@
+import searchPrivateOrganization from '#server/services/organization/searchPrivateOrganizations/searchPrivateOrganizations';
+import { Request, NextFunction, Response } from 'express';
+
+interface PrivateOrganizationSearchRequest extends Request {
+    query: {
+        query: string,
+    }
+}
+
+export default async (req: PrivateOrganizationSearchRequest, res: Response, next: NextFunction): Promise<void> => {
+    try {
+        const result = await searchPrivateOrganization(
+            req.query.query,
+        );
+        res.status(200).send(result);
+    } catch (error) {
+        res.status(500).send({
+            user_message: 'Une erreur est survenue lors de la lecture en base de données',
+        });
+
+        next(error.nativeError);
+    }
+};

--- a/packages/api/server/controllers/organization/searchPrivateOrganizations/organization.searchPrivateOrganizations.validator.ts
+++ b/packages/api/server/controllers/organization/searchPrivateOrganizations/organization.searchPrivateOrganizations.validator.ts
@@ -1,0 +1,10 @@
+/* eslint-disable newline-per-chained-call */
+import { query } from 'express-validator';
+
+export default [
+    query('query')
+        .exists().bail().withMessage('La recherche est obligatoire')
+        .isString().bail().withMessage('La recherche doit être une chaine de caractère')
+        .trim()
+        .isLength({ min: 1 }).bail().withMessage('La recherche doit faire au moins 1 caractère'),
+];

--- a/packages/api/server/controllers/user/_common/user.write.validator.ts
+++ b/packages/api/server/controllers/user/_common/user.write.validator.ts
@@ -236,6 +236,28 @@ export default (
             return true;
         }),
 
+    body('private_organization')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'private_organization')
+        .custom(async (value, { req }) => {
+            let organization: Organization;
+            try {
+                organization = await organizationModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification de l\'existence de la structure');
+            }
+
+            if (organization === null) {
+                throw new Error('La structure que vous avez sélectionnée n\'existe pas en base de données');
+            }
+
+            if (organization.type.category !== 'private_organization') {
+                throw new Error('La structure que vous avez sélectionnée est invalide');
+            }
+
+            req.body.organization_full = organization;
+            return true;
+        }),
+
     body('position')
         .if(isAUserCreationCallback)
         .trim()

--- a/packages/api/server/services/organization/searchPrivateOrganizations/searchPrivateOrganizations.ts
+++ b/packages/api/server/services/organization/searchPrivateOrganizations/searchPrivateOrganizations.ts
@@ -1,0 +1,49 @@
+import ServiceError from '#server/errors/ServiceError';
+import autocomplete from '#server/models/organizationModel/autocomplete';
+
+type OrganizationAutocompleteResult = {
+    id: number,
+    label: string
+    name: string,
+    similarity: number,
+};
+
+const searchPrivateOrganization = async (search: string): Promise<OrganizationAutocompleteResult[]> => {
+    try {
+        const organizations = await autocomplete(search, null, 'private_organization');
+
+        return Object.values(
+            organizations.reduce((acc, row) => {
+                if (acc[row.type_name] === undefined) {
+                    acc[row.type_name] = [];
+                }
+
+                if (row.similarity >= 0.75) {
+                    let territory;
+                    if (row.is_national === true) {
+                        territory = 'National';
+                    } else {
+                        territory = row.main_regions_names
+                            .concat(row.main_departements_names)
+                            .concat(row.main_epci_names)
+                            .concat(row.main_cities_names)
+                            .join(', ');
+                    }
+
+                    acc[row.type_name].push({
+                        id: row.id,
+                        label: territory,
+                        name: row.abbreviation || row.name,
+                        similarity: row.similarity,
+                    });
+                }
+
+                return acc;
+            }, {} as Record<string, OrganizationAutocompleteResult[]>),
+        ).flat();
+    } catch (error) {
+        throw new ServiceError('db_read_error', error);
+    }
+};
+
+export default searchPrivateOrganization;

--- a/packages/frontend/webapp/src/api/organizations.api.js
+++ b/packages/frontend/webapp/src/api/organizations.api.js
@@ -23,6 +23,14 @@ export function autocompleteAssociation(str) {
     );
 }
 
+export function autocompletePrivateOrganization(str) {
+    return axios.get(
+        `/organizations/private-organizations/search?query=${encodeURIComponent(
+            str
+        )}`
+    );
+}
+
 export function autocompleteTerritorialCollectivity(str) {
     return axios.get(
         `/organizations/territorial-collectivities/search?query=${encodeURIComponent(

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.labels.js
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.labels.js
@@ -19,6 +19,7 @@ export default (variant) => ({
         territorial_collectivity: "Territoire de la collectivité",
         association: "Nom de l'association",
         organization_administration: "Nom de la structure",
+        private_organization: "Nom de l'organisme privé",
         organization_other:
             "Précisez le nom et le territoire de votre structure",
         position:

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.schema.js
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.schema.js
@@ -185,7 +185,6 @@ export default (
     schema.private_organization = object()
         .when("organization_category", {
             is: "private_organization",
-            // then: (schema) => schem.required(),
             then: (schema) =>
                 schema.required().customSchema(
                     object({

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.schema.js
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.schema.js
@@ -70,7 +70,12 @@ addMethod(object, "customSchema", function (schema) {
     );
 });
 
-export default (variant, allowNewOrganization, language) => {
+export default (
+    variant,
+    allowNewOrganization,
+    allowPrivateOrganization,
+    language
+) => {
     const schema = {};
     const labels = labelsFn(variant)[language];
 
@@ -113,6 +118,7 @@ export default (variant, allowNewOrganization, language) => {
     // organization category
     const organizationCategory = string().label(labels.organization_category);
     const organizationCategories = organizationCategoriesFn({
+        private_organization: allowPrivateOrganization,
         other: allowNewOrganization,
     });
     function makeOrganizationCategoryRequired(schema) {
@@ -176,6 +182,20 @@ export default (variant, allowNewOrganization, language) => {
             then: (schema) => schema.required(),
         })
         .label(labels.organization_administration);
+    schema.private_organization = object()
+        .when("organization_category", {
+            is: "private_organization",
+            // then: (schema) => schem.required(),
+            then: (schema) =>
+                schema.required().customSchema(
+                    object({
+                        data: object({
+                            id: number().required(),
+                        }).required(),
+                    })
+                ),
+        })
+        .label(labels.private_organization);
     schema.organization_other = string()
         .when("organization_category", {
             is: "other",

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
@@ -64,6 +64,15 @@
                     :allowPrivateOrganization="allowPrivateOrganization"
                 />
 
+                <!-- Administrations centrales -->
+                <template
+                    v-if="values.organization_category === 'administration'"
+                >
+                    <FormUtilisateurInputOrganizationAdministration
+                        :label="labels.organization_administration"
+                    />
+                </template>
+
                 <!-- Services de l'état -->
                 <template
                     v-if="
@@ -97,15 +106,6 @@
                         :label="labels.association"
                         @change="onAssociationChange"
                         ref="associationInput"
-                    />
-                </template>
-
-                <!-- Administrations centrales -->
-                <template
-                    v-if="values.organization_category === 'administration'"
-                >
-                    <FormUtilisateurInputOrganizationAdministration
-                        :label="labels.organization_administration"
                     />
                 </template>
 

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
@@ -61,6 +61,7 @@
                     :showMandatoryStar="variant === 'creer-utilisateur'"
                     :label="labels.organization_category"
                     :allowNewOrganization="allowNewOrganization"
+                    :allowPrivateOrganization="allowPrivateOrganization"
                 />
 
                 <!-- Services de l'état -->
@@ -105,6 +106,17 @@
                 >
                     <FormUtilisateurInputOrganizationAdministration
                         :label="labels.organization_administration"
+                    />
+                </template>
+
+                <!-- Organisme Privé -->
+                <template
+                    v-if="
+                        values.organization_category === 'private_organization'
+                    "
+                >
+                    <FormUtilisateurInputOrganizationPrivate
+                        :label="labels.private_organization"
                     />
                 </template>
 
@@ -167,6 +179,7 @@ import FormUtilisateurInputIsActor from "./inputs/FormUtilisateurInputIsActor.vu
 import FormUtilisateurInputOrganizationCategory from "./inputs/FormUtilisateurInputOrganizationCategory.vue";
 import FormUtilisateurInputOrganizationType from "./inputs/FormUtilisateurInputOrganizationType.vue";
 import FormUtilisateurInputOrganizationPublic from "./inputs/FormUtilisateurInputOrganizationPublic.vue";
+import FormUtilisateurInputOrganizationPrivate from "./inputs/FormUtilisateurInputOrganizationPrivate.vue";
 import FormUtilisateurInputTerritorialCollectivity from "./inputs/FormUtilisateurInputTerritorialCollectivity.vue";
 import FormUtilisateurInputAssociation from "./inputs/FormUtilisateurInputAssociation.vue";
 import FormUtilisateurInputOrganizationAdministration from "./inputs/FormUtilisateurInputOrganizationAdministration.vue";
@@ -203,9 +216,17 @@ const { variant, submit, language } = toRefs(props);
 const allowNewOrganization = computed(() => {
     return variant.value === "demande-acces";
 });
+const allowPrivateOrganization = computed(() => {
+    return variant.value === "creer-utilisateur";
+});
 
 const schema = computed(() => {
-    return schemaFn(variant.value, allowNewOrganization.value, language.value);
+    return schemaFn(
+        variant.value,
+        allowNewOrganization.value,
+        allowPrivateOrganization.value,
+        language.value
+    );
 });
 const labels = computed(() => {
     return labelsFn(variant.value)[language.value];

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
@@ -117,6 +117,8 @@
                 >
                     <FormUtilisateurInputOrganizationPrivate
                         :label="labels.private_organization"
+                        @change="onPrivateOrganizationChange"
+                        ref="privateOrganizationInput"
                     />
                 </template>
 
@@ -212,6 +214,7 @@ const props = defineProps({
 
 const form = ref(null);
 const associationInput = ref(null);
+const privateOrganizationInput = ref(null);
 const { variant, submit, language } = toRefs(props);
 const allowNewOrganization = computed(() => {
     return variant.value === "demande-acces";
@@ -257,6 +260,20 @@ function onAssociationChange(value) {
     }
 }
 
+function onPrivateOrganizationChange(value) {
+    if (value?.data === null) {
+        if (allowPrivateOrganization.value === true) {
+            form.value.setFieldValue("organization_category", "other");
+        } else {
+            alert(
+                "Vous devez créer une nouvelle structure ou en faire la demande aux administrateurs nationaux."
+            );
+        }
+
+        privateOrganizationInput.value.clear();
+    }
+}
+
 function intermediateSubmit(values) {
     const formattedValues = { ...values };
     formattedValues.territorial_collectivity = formattedValues
@@ -265,6 +282,10 @@ function intermediateSubmit(values) {
         : null;
     formattedValues.association = formattedValues.association?.data
         ? formattedValues.association.data.id
+        : null;
+    formattedValues.private_organization = formattedValues.private_organization
+        ?.data
+        ? formattedValues.private_organization.data.id
         : null;
     return submit.value(formattedValues);
 }

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationCategory.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationCategory.vue
@@ -19,10 +19,14 @@ import { defineProps, toRefs } from "vue";
 const props = defineProps({
     label: String,
     allowNewOrganization: Boolean,
+    allowPrivateOrganization: Boolean,
 });
-const { label, allowNewOrganization } = toRefs(props);
+const { label, allowNewOrganization, allowPrivateOrganization } = toRefs(props);
 
 const items = computed(() => {
-    return itemsFn({ other: allowNewOrganization.value });
+    return itemsFn({
+        private_organization: allowPrivateOrganization.value || false,
+        other: allowNewOrganization.value,
+    });
 });
 </script>

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationPrivate.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationPrivate.vue
@@ -1,0 +1,75 @@
+<template>
+    <Autocomplete
+        name="private_organization"
+        :label="label"
+        placeholder="Nom ou acronyme de l'organisme privé"
+        :fn="autocompleteFn"
+        v-model="privateOrganization"
+        showCategory
+        ref="autocompleteInput"
+        showMandatoryStar
+    />
+</template>
+
+<script setup>
+import { defineProps, ref, toRefs, computed, defineEmits, watch } from "vue";
+import { useFieldValue } from "vee-validate";
+import { Autocomplete } from "@resorptionbidonvilles/ui";
+import { autocompletePrivateOrganization } from "@/api/organizations.api.js";
+
+const props = defineProps({
+    modelValue: {
+        type: Object,
+        required: false,
+        default: () => {},
+    },
+});
+const { modelValue } = toRefs(props);
+
+const autocompleteInput = ref(null);
+const emit = defineEmits(["update:modelValue", "change"]);
+const privateOrganization = computed({
+    get() {
+        return modelValue.value;
+    },
+    set(value) {
+        emit("update:modelValue", value);
+    },
+});
+const value = useFieldValue("private_organization");
+
+// obligés d'émettre un événement différent de update:modelValue car ce dernier est émis
+// deux fois pour chaque changement de valeur
+// ici, "change" ne sera émis qu'une seule fois
+watch(value, (newValue) => {
+    emit("change", newValue);
+});
+
+async function autocompleteFn(value) {
+    const results = await autocompletePrivateOrganization(value);
+    const mappedResults = results.map((org) => ({
+        id: org.id,
+        label: org.label,
+        selectedLabel: `${org.name} — ${org.label}`,
+        category: org.name,
+        data: {
+            id: org.id,
+        },
+    }));
+    mappedResults.unshift({
+        id: "autre",
+        selectedLabel: "",
+        label: "Je ne trouve pas mon organisme privé",
+        category: "",
+        data: null,
+    });
+
+    return mappedResults;
+}
+
+defineExpose({
+    clear() {
+        autocompleteInput.value.clear();
+    },
+});
+</script>

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationPrivate.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationPrivate.vue
@@ -56,13 +56,6 @@ async function autocompleteFn(value) {
             id: org.id,
         },
     }));
-    mappedResults.unshift({
-        id: "autre",
-        selectedLabel: "",
-        label: "Je ne trouve pas mon organisme privé",
-        category: "",
-        data: null,
-    });
 
     return mappedResults;
 }

--- a/packages/frontend/webapp/src/utils/organization_categories.js
+++ b/packages/frontend/webapp/src/utils/organization_categories.js
@@ -2,8 +2,9 @@ export default (options = {}) => {
     const cats = [
         {
             value: "public_establishment",
-            label: "Service de l'état, établissement, ou organisme public",
+            label: "Service déconcentré de l'État, établissement ou organisme public",
         },
+        { value: "administration", label: "Administration centrale" },
         {
             value: "territorial_collectivity",
             label: "Collectivité territoriale",
@@ -12,15 +13,17 @@ export default (options = {}) => {
             value: "association",
             label: "Association",
         },
-        { value: "administration", label: "Administration centrale" },
     ];
+
+    if (options.private_organization === true) {
+        cats.push({
+            value: "private_organization",
+            label: "Organisme privé autre qu'associatif",
+        });
+    }
 
     if (options.other === true) {
         cats.push({ value: "other", label: "Autre" });
-    }
-
-    if (options.private_organization === true) {
-        cats.push({ value: "private_organization", label: "Organisme privé" });
     }
 
     return cats;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/W7szuwlo/2154-gestion-des-droits-permettre-%C3%A0-un-admin-de-cr%C3%A9er-un-utilisateur-dun-organisme-priv%C3%A9

## 🛠 Description de la PR
Un administrateur doit pouvoir ajouter un utilisateur dans un organisme privé depuis l'interface d'administration.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/34971399/0dc9bf88-6fe0-42b3-a699-00f4934728b5)

## 🚨 Notes pour la mise en production
RàS