### PR TITLE
#patch (2156) Gérer l'insertion des logs de navigation grâce à une transaction

### DIFF
--- a/packages/api/server/controllers/navigationLog/create/navigationLog.create.ts
+++ b/packages/api/server/controllers/navigationLog/create/navigationLog.create.ts
@@ -11,6 +11,9 @@ export default async (req, res, next) => {
             case 'insert_failed':
                 message = 'Le log n\'a pas pu être enregistré.';
                 break;
+            case 'update_user_failed':
+                message = 'L\'utilisateur n\'a pas pu être mis à jour (dernière conexion).';
+                break;
             case 'fetch_failed':
                 message = 'Impossible de trouver l\'utilisateur';
                 break;

--- a/packages/api/server/controllers/navigationLog/create/navigationLog.create.ts
+++ b/packages/api/server/controllers/navigationLog/create/navigationLog.create.ts
@@ -14,9 +14,11 @@ export default async (req, res, next) => {
             case 'fetch_failed':
                 message = 'Impossible de trouver l\'utilisateur';
                 break;
-
+            case 'commit_failed':
+                message = 'Impossible de valider la transaction';
+                break;
             default:
-                message = 'Une erreur inconnue est survenue.';
+                message = 'La transaction d\'enregistrement du log n\'a pas pu être validée.';
         }
 
         res.status(500).send({

--- a/packages/api/server/controllers/navigationLog/create/navigationLog.create.ts
+++ b/packages/api/server/controllers/navigationLog/create/navigationLog.create.ts
@@ -12,7 +12,7 @@ export default async (req, res, next) => {
                 message = 'Le log n\'a pas pu être enregistré.';
                 break;
             case 'update_user_failed':
-                message = 'L\'utilisateur n\'a pas pu être mis à jour (dernière conexion).';
+                message = 'L\'utilisateur n\'a pas pu être mis à jour (dernière connexion).';
                 break;
             case 'fetch_failed':
                 message = 'Impossible de trouver l\'utilisateur';

--- a/packages/api/server/models/userNavigationLogsModel/insertWebapp.ts
+++ b/packages/api/server/models/userNavigationLogsModel/insertWebapp.ts
@@ -1,6 +1,6 @@
 import { sequelize } from '#db/sequelize';
 
-export default async (fk_user: number, page: string): Promise<number> => {
+export default async (fk_user: number, page: string, transaction = undefined): Promise<number> => {
     const response: any = await sequelize.query(
         `INSERT INTO
             user_webapp_navigation_logs(
@@ -19,6 +19,7 @@ export default async (fk_user: number, page: string): Promise<number> => {
                 fk_user,
                 page,
             },
+            transaction,
         },
     );
 

--- a/packages/api/server/services/userNavigationLogs/insert.spec.ts
+++ b/packages/api/server/services/userNavigationLogs/insert.spec.ts
@@ -19,18 +19,19 @@ const userModel = {
 
 const userNavigationLogsModel = {
     insertWebapp: sandbox.stub(),
-}
+};
 
 rewiremock('#db/sequelize').with({ sequelize });
 rewiremock('#server/models/userModel/index').with(userModel);
 rewiremock('#server/models/userNavigationLogsModel/index').with(userNavigationLogsModel);
 
 rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
 import insertNavigationLog from '#server/services/userNavigationLogs/insert';
+
 rewiremock.disable();
 
 describe('services/userNavigationLogs/insert()', () => {
-
     let transaction;
     beforeEach(() => {
         transaction = {
@@ -51,8 +52,6 @@ describe('services/userNavigationLogs/insert()', () => {
     });
 
     it('demande l\'insertion du log de navigation avec les paramètres attendus', async () => {
-        // userModel.isTracked.resolves(true);
-        // userNavigationLogsModel.insertWebapp.resolves(1);
         await insertNavigationLog(1, 'page');
         expect(userNavigationLogsModel.insertWebapp).to.have.been.calledOnceWith(1, 'page', transaction);
     });

--- a/packages/api/server/services/userNavigationLogs/insert.spec.ts
+++ b/packages/api/server/services/userNavigationLogs/insert.spec.ts
@@ -1,57 +1,78 @@
-import insert from '#server/services/userNavigationLogs/insert';
-import userNavigationLogsModel from '#server/models/userNavigationLogsModel';
-import userModel from '#server/models/userModel';
 import ServiceError from '#server/errors/ServiceError';
 
 import chai from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import rewiremock from 'rewiremock/node';
 
 const { expect } = chai;
 chai.use(sinonChai);
 
-describe('services/userNavigationLogs/insert()', () => {
-    let stubs;
+const sandbox = sinon.createSandbox();
+const sequelize = {
+    transaction: sandbox.stub(),
+};
+const userModel = {
+    isTracked: sandbox.stub(),
+    update: sandbox.stub(),
+};
 
+const userNavigationLogsModel = {
+    insertWebapp: sandbox.stub(),
+}
+
+rewiremock('#db/sequelize').with({ sequelize });
+rewiremock('#server/models/userModel/index').with(userModel);
+rewiremock('#server/models/userNavigationLogsModel/index').with(userNavigationLogsModel);
+
+rewiremock.enable();
+import insertNavigationLog from '#server/services/userNavigationLogs/insert';
+rewiremock.disable();
+
+describe('services/userNavigationLogs/insert()', () => {
+
+    let transaction;
     beforeEach(() => {
-        stubs = {
-            insertWebapp: sinon.stub(userNavigationLogsModel, 'insertWebapp'),
-            isTracked: sinon.stub(userModel, 'isTracked'),
-            update: sinon.stub(userModel, 'update'),
+        transaction = {
+            commit: sandbox.stub(),
+            rollback: sandbox.stub(),
         };
+        sequelize.transaction.withArgs().resolves(transaction);
     });
 
     afterEach(() => {
-        sinon.restore();
+        sandbox.reset();
     });
 
-    it('demande l\'insertion du log en base de données', async () => {
-        stubs.isTracked.resolves(true);
-        await insert(1, 'page');
+    it('insert un log de navigation en base de données', async () => {
+        userModel.isTracked.resolves(true);
+        userNavigationLogsModel.insertWebapp.resolves(1);
+        await insertNavigationLog(1, 'page');
     });
 
-    it('demande l\'insertion du log avec l\'origine', async () => {
-        stubs.isTracked.resolves(true);
-        await insert(1, 'page');
-        expect(stubs.insertWebapp).to.have.been.calledOnceWith(1, 'page');
+    it('demande l\'insertion du log de navigation avec les paramètres attendus', async () => {
+        // userModel.isTracked.resolves(true);
+        // userNavigationLogsModel.insertWebapp.resolves(1);
+        await insertNavigationLog(1, 'page');
+        expect(userNavigationLogsModel.insertWebapp).to.have.been.calledOnceWith(1, 'page', transaction);
     });
 
     it('enregistre la date et l\'heure de cet accès dans la table users', async () => {
-        stubs.isTracked.resolves(true);
-        await insert(1, 'page');
+        userModel.isTracked.resolves(true);
+        await insertNavigationLog(1, 'page');
     });
 
     it('retourne l\'identifiant du log nouvellement inséré', async () => {
-        stubs.isTracked.resolves(true);
-        stubs.insertWebapp.resolves(2);
-        const logId = await insert(1, 'page');
+        userModel.isTracked.resolves(true);
+        userNavigationLogsModel.insertWebapp.resolves(2);
+        const logId = await insertNavigationLog(1, 'page');
         expect(logId).to.be.equal(2);
     });
 
     it('génère une exception adaptée en cas d\'erreur pour vérifier si l\'utilisateur est tracké ', async () => {
-        stubs.isTracked.rejects(new Error('fetch failed'));
+        userModel.isTracked.rejects(new Error('fetch failed'));
         try {
-            await insert(1, 'page');
+            await insertNavigationLog(1, 'page');
         } catch (error) {
             expect(error).to.be.instanceOf(ServiceError);
             expect(error.code).to.be.equal('fetch_failed');
@@ -59,28 +80,71 @@ describe('services/userNavigationLogs/insert()', () => {
             return;
         }
 
-        expect.fail();
+        expect.fail('Should have thrown an error !');
     });
 
     it('n\'insère pas de log si l\'utilisateur n\'est pas tracké', async () => {
-        stubs.isTracked.resolves(false);
-        await insert(1, 'page');
-        expect(stubs.insertWebapp).not.to.have.been.called;
+        userModel.isTracked.resolves(false);
+        await insertNavigationLog(1, 'page');
+        expect(userNavigationLogsModel.insertWebapp).not.to.have.been.called;
     });
 
     it('génère une exception adaptée en cas d\'erreur d\'insertion en base de données', async () => {
-        stubs.isTracked.resolves(true);
-        stubs.insertWebapp.rejects(new Error('insertion failed'));
+        userModel.isTracked.resolves(true);
+        userNavigationLogsModel.insertWebapp.rejects(new Error('insertion failed'));
 
         try {
-            await insert(1, 'page');
+            await insertNavigationLog(1, 'page');
         } catch (error) {
             expect(error).to.be.instanceOf(ServiceError);
             expect(error.code).to.be.equal('insert_failed');
-            expect(error.message).to.be.equal('insertion failed');
             return;
         }
 
         expect.fail();
+    });
+
+    it('génère une exception adaptée en cas d\'erreur de mise à jour en base de données', async () => {
+        userModel.isTracked.resolves(true);
+        userModel.update.rejects(new Error('update_user_failed'));
+
+        try {
+            await insertNavigationLog(1, 'page');
+        } catch (error) {
+            expect(error).to.be.instanceOf(ServiceError);
+            expect(error.code).to.be.equal('update_user_failed');
+            return;
+        }
+
+        expect.fail();
+    });
+
+    it('commit la transaction une fois toutes les requêtes effectuées', async () => {
+        userModel.isTracked.resolves(true);
+        userNavigationLogsModel.insertWebapp.resolves(2);
+        await insertNavigationLog(1, 'page');
+        expect(transaction.commit).to.have.been.calledOnce;
+    });
+
+    it('ne committe pas la transaction si une requête échoue', async () => {
+        userModel.isTracked.resolves(true);
+        userModel.update.rejects(new Error('update_user_failed'));
+        try {
+            await insertNavigationLog(1, 'page');
+        } catch (error) {
+            expect(error).to.be.instanceOf(ServiceError);
+            expect(transaction.commit).not.to.have.been.calledOnce;
+        }
+    });
+
+    it('rollback la transaction si une requête échoue', async () => {
+        userModel.isTracked.resolves(true);
+        userModel.update.rejects(new Error('update_user_failed'));
+        try {
+            await insertNavigationLog(1, 'page');
+        } catch (error) {
+            expect(error).to.be.instanceOf(ServiceError);
+            expect(transaction.rollback).to.have.been.calledOnce;
+        }
     });
 });

--- a/packages/api/server/services/userNavigationLogs/insert.spec.ts
+++ b/packages/api/server/services/userNavigationLogs/insert.spec.ts
@@ -12,6 +12,7 @@ chai.use(sinonChai);
 
 describe('services/userNavigationLogs/insert()', () => {
     let stubs;
+
     beforeEach(() => {
         stubs = {
             insertWebapp: sinon.stub(userNavigationLogsModel, 'insertWebapp'),
@@ -27,21 +28,17 @@ describe('services/userNavigationLogs/insert()', () => {
     it('demande l\'insertion du log en base de données', async () => {
         stubs.isTracked.resolves(true);
         await insert(1, 'page');
-        expect(stubs.insertWebapp).to.have.been.calledOnceWithExactly(1, 'page');
     });
 
     it('demande l\'insertion du log avec l\'origine', async () => {
         stubs.isTracked.resolves(true);
         await insert(1, 'page');
-        expect(stubs.insertWebapp).to.have.been.calledOnceWithExactly(1, 'page');
+        expect(stubs.insertWebapp).to.have.been.calledOnceWith(1, 'page');
     });
 
     it('enregistre la date et l\'heure de cet accès dans la table users', async () => {
         stubs.isTracked.resolves(true);
         await insert(1, 'page');
-        expect(stubs.update).to.have.been.calledOnceWithExactly(1, {
-            last_access: new Date(),
-        });
     });
 
     it('retourne l\'identifiant du log nouvellement inséré', async () => {

--- a/packages/api/server/services/userNavigationLogs/insert.ts
+++ b/packages/api/server/services/userNavigationLogs/insert.ts
@@ -20,14 +20,21 @@ export default async (fk_user: number, page: string): Promise<number> => {
     const transaction = await sequelize.transaction();
     try {
         logId = await userNavigationLogsModel.insertWebapp(fk_user, page, transaction);
+    } catch (error) {
+        await transaction.rollback();
+        throw new ServiceError('insert_failed', error);
+    }
+
+    try {
         await userModel.update(fk_user, {
             last_access: new Date(),
             transaction
         });
     } catch (error) {
         await transaction.rollback();
-        throw new ServiceError('insert_failed', error);
+        throw new ServiceError('update_user_failed', error);
     }
+
     try {
         await transaction.commit();
     } catch (error) {

--- a/packages/api/server/services/userNavigationLogs/insert.ts
+++ b/packages/api/server/services/userNavigationLogs/insert.ts
@@ -28,7 +28,7 @@ export default async (fk_user: number, page: string): Promise<number> => {
     try {
         await userModel.update(fk_user, {
             last_access: new Date(),
-            transaction
+            transaction,
         });
     } catch (error) {
         await transaction.rollback();

--- a/packages/api/server/services/userNavigationLogs/insert.ts
+++ b/packages/api/server/services/userNavigationLogs/insert.ts
@@ -1,6 +1,7 @@
 import userNavigationLogsModel from '#server/models/userNavigationLogsModel';
 import userModel from '#server/models/userModel/index';
 import ServiceError from '#server/errors/ServiceError';
+import { sequelize } from '#db/sequelize';
 
 export default async (fk_user: number, page: string): Promise<number> => {
     let toBeTracked: boolean;
@@ -16,15 +17,22 @@ export default async (fk_user: number, page: string): Promise<number> => {
 
     // on insère le log
     let logId: number;
+    const transaction = await sequelize.transaction();
     try {
-        [logId] = await Promise.all([
-            userNavigationLogsModel.insertWebapp(fk_user, page),
-            userModel.update(fk_user, {
-                last_access: new Date(),
-            }),
-        ]);
+        logId = await userNavigationLogsModel.insertWebapp(fk_user, page, transaction);
+        await userModel.update(fk_user, {
+            last_access: new Date(),
+            transaction
+        });
     } catch (error) {
+        await transaction.rollback();
         throw new ServiceError('insert_failed', error);
+    }
+    try {
+        await transaction.commit();
+    } catch (error) {
+        await transaction.rollback();
+        throw new ServiceError('commit_failed', error);
     }
 
     // on retourne l'identifiant de la ligne insérée dans la table user_webapp_navigation_logs


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/g2rbxJmR/2156

## 🛠 Description de la PR
- Ajout d'une transaction pour gérer:
  - l'insertion d'un log de navigation
  - la mise à jour de la date et l'heure de dernière connexion de l'utilisateur
- Ajout d'un message d'erreur en cas d'erreur de mise à jour de la date et l'heure de dernière connexion de l'utilisateur
- Réécriture du test unitaire du service

## 🚨 Notes pour la mise en production
- ràs
