### PR TITLE
#patch (2161) Autoriser l'export des sites aux intervenants

### DIFF
--- a/packages/api/db/migrations/30000076-01-insert-export-shantytown-role_permission.js
+++ b/packages/api/db/migrations/30000076-01-insert-export-shantytown-role_permission.js
@@ -1,0 +1,24 @@
+module.exports = {
+
+    up: (queryInterface) => {
+        return queryInterface.sequelize.query(
+            `INSERT INTO role_permissions(fk_role_regular, fk_feature, fk_entity, allowed, allow_all) VALUES 
+                (
+                    'intervener',
+                    'export',
+                    'shantytown',
+                    true,
+                    false
+                )`,
+        );
+    },
+
+    down: queryInterface => queryInterface.sequelize.query(
+        `DELETE FROM role_permissions 
+        WHERE
+            fk_role_regular = 'intervener' 
+        AND
+            fk_feature = 'export'
+        AND
+            fk_entity = 'shantytown'`),
+};


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/PuNYnXYp/2161

## 🛠 Description de la PR
- Donne aux intervenants (`role_regular` intervener) la permission d'exporter les sites de leur territoire

## 🚨 Notes pour la mise en production
- Migration à exécuter `30000076-01-insert-export-shantytown-role_permission.js`