### PR TITLE
#patch: (Issue/2158) Corriger le label des structures Services de l'Etat

### DIFF
--- a/packages/api/server/models/organizationModel/findByType.ts
+++ b/packages/api/server/models/organizationModel/findByType.ts
@@ -5,25 +5,53 @@ type OrganizationMin = {
     id: number,
     name: string,
     abbreviation: string | null,
-    organization_type_name: string,
+    territory: string | null,
 };
 
-export default (typeId: number): Promise<OrganizationMin[]> => sequelize.query(
+type StructureList = {
+    type: string,
+    organization_type_name: string,
+    organizations: OrganizationMin[],
+};
+
+export default (typeId: number): Promise<StructureList[]> => sequelize.query(
     `SELECT
-        organizations.organization_id AS id,
-        organizations.name,
-        organizations.abbreviation,
-        organization_types.name_singular AS organization_type_name
+        jsonb_build_object(
+            'type', intervention_areas.type,
+            'organization_type_name', organization_types.name_singular,
+            'organizations', jsonb_agg(
+                jsonb_build_object(
+                    'id', organizations.organization_id,
+                    'name', organizations.name,
+                    'abbreviation', organizations.abbreviation,
+                    'territory', CASE
+                        WHEN intervention_areas.type = 'city' THEN cities.fk_departement || ' - ' ||  cities.name
+                        WHEN intervention_areas.type = 'epci' THEN epci.name
+                        WHEN intervention_areas.type = 'departement' THEN departements.code || ' - ' || departements.name
+                        WHEN intervention_areas.type = 'region' THEN regions.name
+                        WHEN intervention_areas.type = 'nation' THEN 'France entière'
+                        ELSE NULL
+                    END
+                )
+                ORDER BY (
+                    CASE
+                        WHEN intervention_areas.type = 'departement' THEN departements.code
+                        WHEN intervention_areas.type = 'region' THEN regions.name
+                        WHEN intervention_areas.type = 'city' THEN cities.name
+                        WHEN intervention_areas.type = 'epci' THEN epci.name
+                    END
+                ) ASC
+            )
+        ) as structuresList
     FROM organizations
     LEFT JOIN organization_types ON organizations.fk_type = organization_types.organization_type_id
-    WHERE
-        organizations.fk_type = :typeId
-    ORDER BY
-        CASE organization_types.uid
-            WHEN 'rectorat' THEN SUBSTRING(organizations.name, '(?<=(?:d''|de la |de ))[A-Z].+')
-            ELSE '' END
-        ASC,
-        UNACCENT(organizations.name) ASC`,
+    LEFT JOIN intervention_areas ON organizations.organization_id = intervention_areas.fk_organization
+    LEFT JOIN regions ON intervention_areas.fk_region = regions.code
+    LEFT JOIN departements ON intervention_areas.fk_departement = departements.code
+    LEFT JOIN epci ON intervention_areas.fk_epci = epci.code
+    LEFT JOIN cities ON intervention_areas.fk_city = cities.code
+    WHERE organizations.fk_type = :typeId
+    GROUP BY intervention_areas.type, organization_types.name_singular;`,
     {
         type: QueryTypes.SELECT,
         replacements: {

--- a/packages/api/server/models/organizationModel/findByType.ts
+++ b/packages/api/server/models/organizationModel/findByType.ts
@@ -51,6 +51,8 @@ export default (typeId: number): Promise<StructureList[]> => sequelize.query(
     LEFT JOIN epci ON intervention_areas.fk_epci = epci.code
     LEFT JOIN cities ON intervention_areas.fk_city = cities.code
     WHERE organizations.fk_type = :typeId
+    AND
+    organizations.active = true
     GROUP BY intervention_areas.type, organization_types.name_singular;`,
     {
         type: QueryTypes.SELECT,

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.labels.js
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.labels.js
@@ -14,7 +14,7 @@ export default (variant) => ({
             variant === "demande-acces"
                 ? "Quelle structure ?"
                 : "Quelle est la structure de l'utilisateur ?",
-        organization_type: "Précisez le type de structure",
+        organization_type: "Précisez la structure",
         organization_public: "Territoire de rattachement",
         territorial_collectivity: "Territoire de la collectivité",
         association: "Nom de l'association",

--- a/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationPublic.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/inputs/FormUtilisateurInputOrganizationPublic.vue
@@ -5,6 +5,7 @@
         :label="label"
         :options="options"
         :loader="refreshOptions"
+        mode="grouped"
         ref="select"
         showMandatoryStar
     />
@@ -26,29 +27,31 @@ const select = ref(null);
 const organizationType = useFieldValue("organization_type");
 const { handleChange } = useField("organization_public");
 async function refreshOptions() {
+    const territoriesLabels = {
+        region: "Région",
+        departement: "Département",
+        city: "Commune",
+        nation: "National",
+    };
+
     options.value = [];
     const response = await getOrganizations(organizationType.value);
-    options.value = response.organizations.map((organization) => {
-        const regex = new RegExp(
-            `^${organization.organization_type_name} des?(?: la)? `,
-            "i"
-        );
-
-        let territoryLabel;
-        const nameWithoutType = organization.name.replace(regex, "");
-        if (
-            organization.name.toLowerCase() ===
-            organization.organization_type_name.toLowerCase()
-        ) {
-            territoryLabel = "France entière";
-        } else {
-            [, territoryLabel] = nameWithoutType.split(" - ");
-        }
-
-        return {
-            id: organization.id,
-            label: territoryLabel || nameWithoutType,
-        };
+    response.organizations.map((organization) => {
+        options.value.push({
+            label: territoriesLabels[organization.structureslist.type],
+            options: organization.structureslist.organizations.map(
+                (territory) => {
+                    return {
+                        id: territory.id,
+                        label:
+                            organization.structureslist
+                                .organization_type_name === "Sous-préfecture"
+                                ? `${territory.territory} - ${territory.name}`
+                                : territory.territory,
+                    };
+                }
+            ),
+        });
     });
 }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/lJ2YUv7J/2158-gestion-des-droits-corriger-le-label-des-structures-services-de-letat

## 🛠 Description de la PR
Cette PR apporte une modification de la gestion des "types de structures" dans un cas d'établissement public. Dans le formulaire d'ajout d'utilisateur, le choix de type de structure devient un choix de structure et, une fois la structure choisie, on doit choisir le territoire lié.
Ce qui était auparavant considéré comme la structure n'est plus affiché que comme un territoire possible, rendant la lecture plus facile.
Les départements sont affichés par ordre numérique du département, les villes et régions par ordre alphabétique.
Le cas spécifique des Sous-préfécture affiche maintenant le numéro du département, le département et le nom de la structure incluant la ville.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/34971399/954b442f-2ef3-492f-9917-c84b9c1c00de)

## 🚨 Notes pour la mise en production
RàS