### PR TITLE
Fix: (2153) Désactivation du message indiquant l'arrivée prochaine de la feature "intérêts et expertises"

### DIFF
--- a/packages/api/server/mails/dist/activity_summary.html
+++ b/packages/api/server/mails/dist/activity_summary.html
@@ -135,68 +135,6 @@
         <tbody>
           
               <tr>
-                <td align="left" style="font-size:0px;padding:0;padding-bottom:0.5rem;word-break:break-word;">
-                  
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#FF6F4c;">Nouveau !</div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                  
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:bold;line-height:1.5em;text-align:left;color:#000091;">Résorption-bidonvilles évolue pour offrir une expérience plus personnalisée.</div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                  
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Dans les prochains jours, vous serez invité à indiquer vos sujets d'intérêts et d'expertises sur la plateforme pour relier compétences et besoins !</div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td align="left" style="font-size:0px;padding:0;padding-top:0.5rem;word-break:break-word;">
-                  
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Merci à vous !</div>
-    
-                </td>
-              </tr>
-            
-        </tbody>
-      </table>
-    
-      </div>
-    
-          <!--[if mso | IE]></td></tr></table><![endif]-->
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        
-      </div>
-    
-      
-      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    
-      
-      <div style="margin:0px auto;max-width:600px;">
-        
-        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-          <tbody>
-            <tr>
-              <td style="direction:ltr;font-size:0px;padding:0 0 16px 0;text-align:center;">
-                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-            
-      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-        
-      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-        <tbody>
-          
-              <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-top:1rem;padding-bottom:1rem;word-break:break-word;">
                   
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Semaine du {{ var:from }} au {{ var:to }}</div>

--- a/packages/api/server/mails/dist/activity_summary.text
+++ b/packages/api/server/mails/dist/activity_summary.text
@@ -1,9 +1,3 @@
-Nouveau !
-Résorption-bidonvilles évolue pour offrir une expérience plus personnalisée.
-Dans les prochains jours, vous serez invité à indiquer vos sujets d'intérêts et
-d'expertises sur la plateforme pour relier compétences et besoins !
-Merci à vous !
-
 Semaine du {{ var:from }} au {{ var:to }}
 {% if var:show_question_summary %}
 Actus de l'espace d'entraide


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/UUSdtDja/2153-mel-recap-hebdo-suppression-de-linfo-sur-comp%C3%A9tences

## 🛠 Description de la PR
L'email automatique de récapitulatif d'activité embarque toujours une mention indiquant qu'une fonctionnalité va bientôt voir le jour. Or, cette fonctionnalité est en production aujourd'hui. Le message n'a donc plus lieu d'être.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/34971399/33733a8c-8caa-491e-b6b0-4b91ccdda19b)

## 🚨 Notes pour la mise en production
RàS