### PR TITLE
#patch (2166) Limiter l'extension des territoires aux admins nationaux

### DIFF
--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
@@ -17,7 +17,12 @@ interface UserSetInterventionAreasRequest extends Request {
 
 export default async (req: UserSetInterventionAreasRequest, res: Response, next: NextFunction) => {
     try {
-        const user = await setInterventionAreas(
+        if (req.user.is_superuser !== true) {
+            res.status(403).send({
+                user_message: 'La modification des territoires d\'intervention est temporairement réservée aux administrateurs nationaux',
+            });
+            return;
+        }        const user = await setInterventionAreas(
             req.user,
             req.userToUpdate,
             req.body.organization_areas,

--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
@@ -22,7 +22,8 @@ export default async (req: UserSetInterventionAreasRequest, res: Response, next:
                 user_message: 'La modification des territoires d\'intervention est temporairement réservée aux administrateurs nationaux',
             });
             return;
-        }        const user = await setInterventionAreas(
+        }        
+        const user = await setInterventionAreas(
             req.user,
             req.userToUpdate,
             req.body.organization_areas,

--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
@@ -22,7 +22,7 @@ export default async (req: UserSetInterventionAreasRequest, res: Response, next:
                 user_message: 'La modification des territoires d\'intervention est temporairement réservée aux administrateurs nationaux',
             });
             return;
-        }        
+        }
         const user = await setInterventionAreas(
             req.user,
             req.userToUpdate,

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnUserDetails.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnUserDetails.vue
@@ -44,7 +44,7 @@
         >Modifier ces informations</Button
     >
     <Button
-        v-if="userStore.user?.id !== user.id"
+        v-if="userStore.user?.is_superuser"
         class="mt-2"
         size="sm"
         icon="building-user"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ZEiXZJSh/2166

## 🛠 Description de la PR
- Limiter l'accès au bouton "Modifier les territoires" aux administrateurs nationaux
- Limiter l'exécution de la requêtes de modification des territoires aux administrateurs nationaux côté back

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/50863659/37f495d4-e09b-42d6-be97-e1ea97df37b7)

## 🚨 Notes pour la mise en production
- ràs