### PR TITLE
#patch (2160) Corriger la date de dernière correction

### DIFF
--- a/packages/api/server/models/userModel/_common/query.ts
+++ b/packages/api/server/models/userModel/_common/query.ts
@@ -98,6 +98,12 @@ export default async (where: Where | String = [], filters: UserQueryFilters = {}
             FROM user_to_expertise_topics
             LEFT JOIN expertise_topics ON user_to_expertise_topics.fk_expertise_topic = expertise_topics.uid
             GROUP BY user_to_expertise_topics.fk_user
+        ),
+        user_last_connection AS (
+            SELECT
+                uwnl.fk_user, MAX(uwnl.datetime) AS user_log_last_access
+            FROM user_webapp_navigation_logs uwnl
+            GROUP BY uwnl.fk_user
         )
 
         SELECT
@@ -120,7 +126,7 @@ export default async (where: Where | String = [], filters: UserQueryFilters = {}
             COALESCE(user_expertise_topics.topics, array[]::text[]) AS topics,
             COALESCE(email_unsubscriptions.unsubscriptions, array[]::enum_user_email_subscriptions_email_subscription[]) AS email_unsubscriptions,
             COALESCE(question_subscriptions.subscriptions, array[]::text[]) AS question_subscriptions,
-            users.last_access,
+            user_log_last_access AS last_access,
             users.admin_comments,
             v_user_areas.is_national,
             users.use_custom_intervention_area,
@@ -166,6 +172,8 @@ export default async (where: Where | String = [], filters: UserQueryFilters = {}
             question_subscriptions ON question_subscriptions.fk_user = users.user_id
         LEFT JOIN
             user_expertise_topics ON user_expertise_topics.fk_user = users.user_id
+        LEFT JOIN
+            user_last_connection ON user_last_connection.fk_user = users.user_id
         ${whereClause.length > 0 ? `WHERE ${whereClause}` : ''}
         ORDER BY
             CASE


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ZidwJyCp/2160

## 🛠 Description de la PR
- Récupérer la date dernière connexion d'un utilisateur à partir de la table des logs plutôt que depuis le champ `last_access` de la table `users` car ce dernier est réinitialisé en cas de réactivation du compte.
- Cette correction impacte le formulaire de consultation d'un accès et l'export de tous les accès.

## 📸 Captures d'écran
- SO

## 🚨 Notes pour la mise en production
- Rien à signaler