### PR TITLE
#minor (2165) Permettre aux admins nationaux de changer le rôle d'un utilisateur

### DIFF
--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -5,30 +5,27 @@
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-        "project": "./tsconfig.json"
+        "project": "./packages/api/tsconfig.json"
     },
     "env": {
         "mocha": true
     },
     "rules": {
-        "@typescript-eslint/indent": [
-            "error",
-            4
-        ],
+        "indent": "off",
+        "@typescript-eslint/indent": "error",
         "@typescript-eslint/naming-convention": [
             "off"
         ],
-        "indent": [
+        "@typescript-eslint/no-throw-literal": "off",
+        "import/no-extraneous-dependencies": 2,
+        "import/extensions": [
             "error",
-            4,
+            "ignorePackages",
             {
-                "SwitchCase": 1
+                "js": "never",
+                "ts": "never",
             }
         ],
-        "@typescript-eslint/no-throw-literal": [
-            "off"
-        ],
-        "import/no-extraneous-dependencies": 2,
         "prefer-promise-reject-errors": 0,
         "max-len": "off",
         "camelcase": "off",
@@ -39,6 +36,9 @@
     },
     "settings": {
         "import/resolver": {
+            "node": {
+                "extensions": [".js", ".ts"]
+            },
             "alias": {
                 "map": [
                     [

--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -5,7 +5,7 @@
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-        "project": "./packages/api/tsconfig.json"
+        "project": "./tsconfig.json"
     },
     "env": {
         "mocha": true

--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -11,21 +11,24 @@
         "mocha": true
     },
     "rules": {
-        "indent": "off",
-        "@typescript-eslint/indent": "error",
+        "@typescript-eslint/indent": [
+            "error",
+            4
+        ],
         "@typescript-eslint/naming-convention": [
             "off"
         ],
-        "@typescript-eslint/no-throw-literal": "off",
-        "import/no-extraneous-dependencies": 2,
-        "import/extensions": [
+        "indent": [
             "error",
-            "ignorePackages",
+            4,
             {
-                "js": "never",
-                "ts": "never",
+                "SwitchCase": 1
             }
         ],
+        "@typescript-eslint/no-throw-literal": 
+            "off"
+        ,
+        "import/no-extraneous-dependencies": 2,
         "prefer-promise-reject-errors": 0,
         "max-len": "off",
         "camelcase": "off",
@@ -36,9 +39,6 @@
     },
     "settings": {
         "import/resolver": {
-            "node": {
-                "extensions": [".js", ".ts"]
-            },
             "alias": {
                 "map": [
                     [

--- a/packages/api/server/controllers/user/setRoleRegular/user.setRoleRegular.ts
+++ b/packages/api/server/controllers/user/setRoleRegular/user.setRoleRegular.ts
@@ -16,6 +16,6 @@ export default async (req, res, next) => {
             user_message: message,
         });
 
-        next(error.nativeError || error);
+        return next(error.nativeError || error);
     }
-}
+};

--- a/packages/api/server/controllers/user/setRoleRegular/user.setRoleRegular.ts
+++ b/packages/api/server/controllers/user/setRoleRegular/user.setRoleRegular.ts
@@ -1,4 +1,3 @@
-import userModel from '#server/models/userModel';
 import setRoleRegularService from '#server/services/user/setRoleRegular';
 
 const ERROR_RESPONSES = {

--- a/packages/api/server/controllers/user/setRoleRegular/user.setRoleRegular.ts
+++ b/packages/api/server/controllers/user/setRoleRegular/user.setRoleRegular.ts
@@ -11,7 +11,7 @@ export default async (req, res, next) => {
         const updatedUser = await setRoleRegularService(req.user, req.body.user.id, req.body.role.id);
         return res.status(200).send(updatedUser);
     } catch (error) {
-        const { code, message } = ERROR_RESPONSES[error && error.code] || ERROR_RESPONSES.undefined;
+        const { code, message } = ERROR_RESPONSES[error?.code] || ERROR_RESPONSES.undefined;
         res.status(code).send({
             user_message: message,
         });

--- a/packages/api/server/services/user/setRoleRegular.spec.ts
+++ b/packages/api/server/services/user/setRoleRegular.spec.ts
@@ -13,11 +13,9 @@ const sandbox = sinon.createSandbox();
 
 const userModelUpdate = sandbox.stub();
 const findOneUser = sandbox.stub();
-const findOneRole = sandbox.stub();
 
 rewiremock('#server/models/userModel/update').withDefault(userModelUpdate);
 rewiremock('#server/models/userModel/findOne').withDefault(findOneUser);
-rewiremock('#server/models/roleModel/findOne').withDefault(findOneRole);
 
 rewiremock.enable();
 // eslint-disable-next-line import/first, import/newline-after-import
@@ -49,7 +47,7 @@ describe('services/user/setRoleRegular', () => {
     
     it('lève une erreur si l\'utilisateur n\'est pas "Administrateur local" et le rôle est "intervenant"', async () => {
         try {
-            await setRoleRegular(regularUser, 2, fakeIntervenerRole.name);
+            await setRoleRegular(regularUser, 2, fakeIntervenerRole.role_id);
             expect.fail('should have thrown an error');
         } catch (error) {
             expect(error).to.be.an.instanceOf(ServiceError);

--- a/packages/api/server/services/user/setRoleRegular.spec.ts
+++ b/packages/api/server/services/user/setRoleRegular.spec.ts
@@ -1,0 +1,99 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { rewiremock } from '#test/rewiremock';
+import ServiceError from '#server/errors/ServiceError';
+import { serialized as fakeUser } from '#test/utils/user';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+// mock all dependencies
+const sandbox = sinon.createSandbox();
+
+const userModelUpdate = sandbox.stub();
+const findOneUser = sandbox.stub();
+const findOneRole = sandbox.stub();
+
+rewiremock('#server/models/userModel/update').withDefault(userModelUpdate);
+rewiremock('#server/models/userModel/findOne').withDefault(findOneUser);
+rewiremock('#server/models/roleModel/findOne').withDefault(findOneRole);
+
+rewiremock.enable();
+// eslint-disable-next-line import/first, import/newline-after-import
+import setRoleRegular from './setRoleRegular';
+rewiremock.disable();
+
+function getRandomIndex(valueMax: number) {
+    return Math.floor(Math.random() * valueMax) + 1;
+}
+
+
+const regularUser = fakeUser({ id: 1, is_superuser: false, is_admin: false });
+const adminUser = fakeUser({ id: 2, is_admin: true });
+const superAdminUser = fakeUser({ id: 3, is_admin: true, is_superuser: true });
+
+const fakeIntervenerRole = { role_id: 'intervener', name: 'Intervenant' };
+const fakeRegularRoles = [
+    { role_id: 'association', name: 'Opérateur' },
+    { role_id: 'collaborator', name: 'Partenaire institutionnel' },
+    { role_id: 'direct_collaborator', name: 'Correspondant' },
+    { role_id: 'external_observator', name: 'Observateur externe' },
+];
+
+describe('services/user/setRoleRegular', () => {
+
+    afterEach(() => {
+        sandbox.reset();
+    });
+    
+    it('lève une erreur si l\'utilisateur n\'est pas "Administrateur local" et le rôle est "intervenant"', async () => {
+        try {
+            await setRoleRegular(regularUser, 2, fakeIntervenerRole.name);
+            expect.fail('should have thrown an error');
+        } catch (error) {
+            expect(error).to.be.an.instanceOf(ServiceError);
+            expect(error.code).to.equal('permission_denied');
+        }
+    });
+
+    it('lève une erreur si un "Administrateur local" tente d\'affecter un rôle autre que "Intervenant"', async () => {
+        try {
+            const roleId = fakeRegularRoles[getRandomIndex(fakeRegularRoles.length - 1)].role_id;
+            await setRoleRegular(adminUser, 2, roleId);
+            expect.fail('should have thrown an error');
+        } catch (error) {
+            expect(error).to.be.an.instanceOf(ServiceError);
+            expect(error.code).to.equal('permission_denied');
+        }
+    });
+
+    it('lève une erreur si un utilisateur ordinaire essaie d\'affecter un rôle autre que "Intervenant"', async () => {
+        try {
+            const roleId = fakeRegularRoles[getRandomIndex(fakeRegularRoles.length - 1)].role_id;
+            await setRoleRegular(regularUser, 2, roleId);
+            expect.fail('should have thrown an error');
+        } catch (error) {
+            expect(error).to.be.an.instanceOf(ServiceError);
+            expect(error.code).to.equal('permission_denied');
+        }
+    });
+
+    it('change le rôle ordinaire d\'un utilisateur', async () => {
+        const roleId = fakeRegularRoles[getRandomIndex(fakeRegularRoles.length - 1)].role_id;
+        await setRoleRegular(superAdminUser, 2, roleId);
+        expect(userModelUpdate).to.have.been.calledOnce;
+        expect(userModelUpdate).to.have.been.calledOnceWith(
+            2, { fk_role_regular: roleId },
+        );
+        expect(findOneUser).to.have.been.calledOnce;
+    });
+
+    it('retourne l\'utilisateur mis à jour', async () => {
+        const roleId = fakeRegularRoles[getRandomIndex(fakeRegularRoles.length - 1)].role_id;
+        const updatedUser = fakeUser();
+        findOneUser.resolves(updatedUser);
+        const result = await setRoleRegular(superAdminUser, 2, roleId);
+        expect(result).to.equal(updatedUser);
+    });
+});

--- a/packages/api/server/services/user/setRoleRegular.spec.ts
+++ b/packages/api/server/services/user/setRoleRegular.spec.ts
@@ -40,11 +40,10 @@ const fakeRegularRoles = [
 ];
 
 describe('services/user/setRoleRegular', () => {
-
     afterEach(() => {
         sandbox.reset();
     });
-    
+
     it('lève une erreur si l\'utilisateur n\'est pas "Administrateur local" et le rôle est "intervenant"', async () => {
         try {
             await setRoleRegular(regularUser, 2, fakeIntervenerRole.role_id);

--- a/packages/api/server/services/user/setRoleRegular.ts
+++ b/packages/api/server/services/user/setRoleRegular.ts
@@ -1,18 +1,10 @@
-import { sequelize } from '#db/sequelize';
 import userModelUpdate from '#server/models/userModel/update';
 import findOneUser from '#server/models/userModel/findOne';
-import findOneRole from '#server/models/roleModel/findOne';
 import ServiceError from '#server/errors/ServiceError';
 import { User } from '#root/types/resources/User.d';
-import can from '#server/utils/permission/can';
 
-type RoleRaw = {
-    id: string,
-    name: string,
-};
-
-function canUpdateRole(user: User, role: RoleRaw): void {
-    if (role && role.name !== 'intervener')
+function canUpdateRole(user: User, roleId: string): void {
+    if (roleId && roleId === 'intervener')
     {
         if (user.is_admin !== true) {
             throw new ServiceError('permission_denied', new Error('Vous devez être Administrateur Local pour pouvoir accorder ce rôle'));
@@ -26,14 +18,7 @@ function canUpdateRole(user: User, role: RoleRaw): void {
 
 export default async (currentUser: User, userToUpdateId: number, roleId: string): Promise<User> => {
 
-    let role: RoleRaw = undefined;
-    try {
-        role = await findOneRole(roleId, 'regular');
-    } catch {
-        throw new ServiceError('role_not_found', new Error('Le role n\'existe pas'));
-    }
-
-    canUpdateRole(currentUser, role);
+    canUpdateRole(currentUser, roleId);
 
     let updatedUser: User;
     try {

--- a/packages/api/server/services/user/setRoleRegular.ts
+++ b/packages/api/server/services/user/setRoleRegular.ts
@@ -1,0 +1,48 @@
+import { sequelize } from '#db/sequelize';
+import userModelUpdate from '#server/models/userModel/update';
+import findOneUser from '#server/models/userModel/findOne';
+import findOneRole from '#server/models/roleModel/findOne';
+import ServiceError from '#server/errors/ServiceError';
+import { User } from '#root/types/resources/User.d';
+import can from '#server/utils/permission/can';
+
+type RoleRaw = {
+    id: string,
+    name: string,
+};
+
+function canUpdateRole(user: User, role: RoleRaw): void {
+    if (role && role.name !== 'intervener')
+    {
+        if (user.is_admin !== true) {
+            throw new ServiceError('permission_denied', new Error('Vous devez être Administrateur Local pour pouvoir accorder ce rôle'));
+        }
+    } else {
+        if (user.is_superuser !== true) {
+            throw new ServiceError('permission_denied', new Error('Vous devez être Administrateur National pour pouvoir accorder ce rôle'));
+        }
+    }
+}
+
+export default async (currentUser: User, userToUpdateId: number, roleId: string): Promise<User> => {
+
+    let role: RoleRaw = undefined;
+    try {
+        role = await findOneRole(roleId, 'regular');
+    } catch {
+        throw new ServiceError('role_not_found', new Error('Le role n\'existe pas'));
+    }
+
+    canUpdateRole(currentUser, role);
+
+    let updatedUser: User;
+    try {
+        await userModelUpdate(userToUpdateId, {
+            fk_role_regular: roleId,
+        });
+        updatedUser = await findOneUser(userToUpdateId, { extended: true }, null, 'read');
+    } catch (error) {
+        throw new ServiceError('update_role_regular_failure', error);
+    }
+    return updatedUser;
+};

--- a/packages/api/server/services/user/setRoleRegular.ts
+++ b/packages/api/server/services/user/setRoleRegular.ts
@@ -4,20 +4,16 @@ import ServiceError from '#server/errors/ServiceError';
 import { User } from '#root/types/resources/User.d';
 
 function canUpdateRole(user: User, roleId: string): void {
-    if (roleId && roleId === 'intervener')
-    {
+    if (roleId && roleId === 'intervener') {
         if (user.is_admin !== true) {
             throw new ServiceError('permission_denied', new Error('Vous devez être Administrateur Local pour pouvoir accorder ce rôle'));
         }
-    } else {
-        if (user.is_superuser !== true) {
-            throw new ServiceError('permission_denied', new Error('Vous devez être Administrateur National pour pouvoir accorder ce rôle'));
-        }
+    } else if (user.is_superuser !== true) {
+        throw new ServiceError('permission_denied', new Error('Vous devez être Administrateur National pour pouvoir accorder ce rôle'));
     }
 }
 
 export default async (currentUser: User, userToUpdateId: number, roleId: string): Promise<User> => {
-
     canUpdateRole(currentUser, roleId);
 
     let updatedUser: User;

--- a/packages/frontend/common/utils/stringUtils.js
+++ b/packages/frontend/common/utils/stringUtils.js
@@ -1,0 +1,5 @@
+export default function majFirstName(firstName) {
+    return firstName.replace(/^[a-z]|-[a-z]/g, (a) => {
+        return a.toUpperCase();
+    });
+}

--- a/packages/frontend/common/utils/stringUtils.js
+++ b/packages/frontend/common/utils/stringUtils.js
@@ -1,5 +1,3 @@
 export default function majFirstName(firstName) {
-    return firstName.replace(/^[a-z]|-[a-z]/g, (a) => {
-        return a.toUpperCase();
-    });
-}
+    return firstName.toLowerCase().replace(/\b\w/g, (match) => match.toUpperCase());
+};

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionSetIntervenant.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionSetIntervenant.vue
@@ -1,6 +1,8 @@
 <template>
     <Button
         v-if="
+            userStore.user?.is_admin &&
+            !userStore.user?.is_superuser &&
             !user.is_admin &&
             user.role_id !== 'intervener' &&
             user.status !== 'inactive'
@@ -15,6 +17,7 @@
 <script setup>
 import { defineProps, toRefs } from "vue";
 import { Button } from "@resorptionbidonvilles/ui";
+import { useUserStore } from "@/stores/user.store";
 
 const props = defineProps({
     user: Object,
@@ -22,4 +25,5 @@ const props = defineProps({
     disabled: Boolean,
 });
 const { user, isLoading, disabled } = toRefs(props);
+const userStore = useUserStore();
 </script>

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionSetRole.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionSetRole.vue
@@ -1,0 +1,49 @@
+<template>
+    <Button
+        v-if="
+            userStore.user?.is_superuser &&
+            !user.is_admin &&
+            user.status !== 'inactive'
+        "
+        type="button"
+        variant="primaryOutline"
+        :loading="isLoading"
+        :disabled="disabled"
+        @click="openChangeRoleModale"
+        >Changer le rôle</Button
+    >
+</template>
+
+<script setup>
+import { computed, defineProps, toRefs } from "vue";
+import { Button } from "@resorptionbidonvilles/ui";
+import { useModaleStore } from "@/stores/modale.store";
+import { useUserStore } from "@/stores/user.store";
+import ModaleChangerRoleUser from "@/components/ModaleChangerRoleUser/ModaleChangerRoleUser.vue";
+
+const props = defineProps({
+    user: Object,
+    isLoading: Boolean,
+    disabled: Boolean,
+});
+const { user, isLoading, disabled } = toRefs(props);
+
+const userStore = useUserStore();
+
+const simplifiedUser = computed(() => {
+    return {
+        id: user.value.id,
+        firstName: user.value.first_name,
+        lastName: user.value.last_name,
+        roleId: user.value.role_id,
+        roleName: user.value.role,
+    };
+});
+
+function openChangeRoleModale() {
+    const modaleStore = useModaleStore();
+    modaleStore.open(ModaleChangerRoleUser, {
+        user: simplifiedUser.value,
+    });
+}
+</script>

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActions.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActions.vue
@@ -37,6 +37,8 @@ import FicheAccesActionCopyActivationLink from "./FicheAccesActionCopyActivation
 import FicheAccesActionReactivate from "./FicheAccesActionReactivate.vue";
 import FicheAccesActionDenyAccess from "./FicheAccesActionDenyAccess.vue";
 import FicheAccesActionGrantAccess from "./FicheAccesActionGrantAccess.vue";
+import FicheAccesActionModifyOptions from "./FicheAccesActionModifyOptions.vue";
+import FicheAccesActionSetRole from "./FicheAccesActionSetRole.vue";
 
 const props = defineProps({
     user: {
@@ -90,6 +92,20 @@ const actions = [
         component: FicheAccesActionGrantAccess,
         action: (...args) => {
             return grantAccess(...args, options.value);
+        },
+    },
+    {
+        id: "modify_options",
+        component: FicheAccesActionModifyOptions,
+        action: (...args) => {
+            return modifyOptions(...args, options.value);
+        },
+    },
+    {
+        id: "set_role",
+        component: FicheAccesActionSetRole,
+        action: () => {
+            return null;
         },
     },
 ];

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActions.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActions.vue
@@ -37,7 +37,6 @@ import FicheAccesActionCopyActivationLink from "./FicheAccesActionCopyActivation
 import FicheAccesActionReactivate from "./FicheAccesActionReactivate.vue";
 import FicheAccesActionDenyAccess from "./FicheAccesActionDenyAccess.vue";
 import FicheAccesActionGrantAccess from "./FicheAccesActionGrantAccess.vue";
-import FicheAccesActionModifyOptions from "./FicheAccesActionModifyOptions.vue";
 import FicheAccesActionSetRole from "./FicheAccesActionSetRole.vue";
 
 const props = defineProps({
@@ -92,13 +91,6 @@ const actions = [
         component: FicheAccesActionGrantAccess,
         action: (...args) => {
             return grantAccess(...args, options.value);
-        },
-    },
-    {
-        id: "modify_options",
-        component: FicheAccesActionModifyOptions,
-        action: (...args) => {
-            return modifyOptions(...args, options.value);
         },
     },
     {

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyOptions.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyOptions.vue
@@ -1,5 +1,8 @@
 <template>
-    <div class="pt-2 pb-4 px-1 lg:px-4 bg-G300" v-if="optionList.length > 0">
+    <div
+        class="pt-2 pb-4 px-1 lg:px-4 bg-G300"
+        v-if="optionList && optionList.length > 0"
+    >
         <p class="font-bold">
             Options
             <Warning v-if="user.status !== 'new'" class="font-normal text-sm"
@@ -35,7 +38,7 @@ const inputStore = useInputsStore();
 const props = defineProps({
     user: {
         type: Object,
-        required: true,
+        required: false,
     },
     options: {
         type: Array,
@@ -52,7 +55,7 @@ const { values, setFieldValue } = useForm({
 
 const accessPermission = computed(() => {
     const configStore = useConfigStore();
-    return configStore.config.permissions_description[user.value.role_id];
+    return configStore.config.permissions_description[user.value?.role_id];
 });
 
 watch(values, () => {

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyRole.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyRole.vue
@@ -13,7 +13,7 @@
                 title="À l’échelle nationale"
                 :items="accessPermission.national_permissions"
                 :options="options"
-            ></FicheAccesBodyPermissionDetails>
+            />
 
             <FicheAccesBodyPermissionDetails
                 v-if="accessPermission.local_permissions?.length > 0"
@@ -21,7 +21,7 @@
                 :items="accessPermission.local_permissions"
                 :user="user"
                 :options="options"
-            ></FicheAccesBodyPermissionDetails>
+            />
         </template>
         <div class="flex items-center justify-end">
             <Button

--- a/packages/frontend/webapp/src/components/FicheRubrique/FicheGrille.vue
+++ b/packages/frontend/webapp/src/components/FicheRubrique/FicheGrille.vue
@@ -1,7 +1,7 @@
 <template>
     <FicheSousRubrique>
         <div
-            class="flex flex-col md:flex-row space-y-2 md:space-y-0 justify-between"
+            class="flex flex-col md:flex-row space-y-2 md:space-y-0 md:space-x-4 md:justify-between"
         >
             <div><slot name="col1" /></div>
             <div class="break-words"><slot name="col2" /></div>

--- a/packages/frontend/webapp/src/components/FicheRubrique/FicheGrille.vue
+++ b/packages/frontend/webapp/src/components/FicheRubrique/FicheGrille.vue
@@ -1,6 +1,8 @@
 <template>
     <FicheSousRubrique>
-        <div class="grid grid-cols-2">
+        <div
+            class="flex flex-col md:flex-row space-y-2 md:space-y-0 justify-between"
+        >
             <div><slot name="col1" /></div>
             <div class="break-words"><slot name="col2" /></div>
         </div>

--- a/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUser.vue
+++ b/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUser.vue
@@ -1,0 +1,121 @@
+<template>
+    <Modal closeWhenClickOutside @close="onClose" ref="modale">
+        <template v-slot:title> Changer le rôle d'un utilisateur </template>
+
+        <template v-slot:body>
+            <ModaleChangerRoleUserIdentiteEtRole
+                class="border-b p-6 mb-8"
+                :user="user"
+            />
+            <ModaleChangerRoleUserListeRole
+                :options="filteredRoles"
+                @update-role="setNewRole"
+            />
+
+            <ErrorSummary v-if="error" :message="error" class="mb-0 mt-6" />
+        </template>
+
+        <template v-slot:footer>
+            <Button
+                variant="primaryText"
+                :loading="loading"
+                @click="() => modale.close()"
+                >Annuler</Button
+            >
+            <Button
+                class="ml-5"
+                :loading="loading"
+                @click.prevent="updateUserRole"
+                >Valider</Button
+            >
+        </template>
+    </Modal>
+</template>
+
+<script setup>
+import { toRefs, ref, computed } from "vue";
+import { Button, ErrorSummary, Modal } from "@resorptionbidonvilles/ui";
+import { useNotificationStore } from "@/stores/notification.store";
+import { useModaleStore } from "@/stores/modale.store";
+import ModaleChangerRoleUserIdentiteEtRole from "./ModaleChangerRoleUserIdentiteEtRole.vue";
+import ModaleChangerRoleUserListeRole from "./ModaleChangerRoleUserListeRole.vue";
+import { useConfigStore } from "@/stores/config.store";
+import { useAccesStore } from "@/stores/acces.store";
+
+const configStore = useConfigStore();
+const { roles } = configStore.config;
+
+const props = defineProps({
+    user: {
+        type: Object,
+        required: true,
+    },
+});
+
+const { user } = toRefs(props);
+
+const modale = ref(null);
+
+const loading = ref(false);
+const error = ref(null);
+const errorSummary = ref({});
+const role = ref(null);
+
+const notificationStore = useNotificationStore();
+
+function reset() {
+    loading.value = false;
+    error.value = null;
+}
+
+function onClose() {
+    reset();
+}
+
+const filteredRoles = computed(() => {
+    return roles.filter(
+        (role) =>
+            role.id !== user.value.roleId && role.id !== "national_establisment"
+    );
+});
+
+function setNewRole(e) {
+    role.value = e;
+}
+
+async function updateUserRole() {
+    if (loading.value === true) {
+        return;
+    }
+
+    loading.value = true;
+    error.value = null;
+    errorSummary.value = {};
+
+    try {
+        const modaleStore = useModaleStore();
+        const accesStore = useAccesStore();
+        await accesStore.updateUserRole(
+            user.value.id,
+            role.value,
+            filteredRoles.value
+        );
+
+        notificationStore.success(
+            "Rôle mis à jour",
+            "Le rôle de l'utilisateur a bien été modifié"
+        );
+        modaleStore.close();
+    } catch (e) {
+        console.log(e);
+        notificationStore.error(
+            "Le changement de rôle a échoué",
+            error.value?.user_message || "Une erreur inconnue est survenue"
+        );
+        error.value = e?.user_message || "Une erreur inconnue est survenue";
+    }
+    loading.value = false;
+
+    return true;
+}
+</script>

--- a/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUserIdentiteEtRole.vue
+++ b/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUserIdentiteEtRole.vue
@@ -1,8 +1,8 @@
 <template>
     <FicheGrille :border="false" :marginTop="false">
         <template v-slot:col1>
-            <p class="font-bold">Nom Prénom</p>
-            <p>{{ formattedFirstName }} {{ user.lastName.toUpperCase() }}</p>
+            <p class="font-bold">NOM Prénom</p>
+            <p>{{ user.lastName.toUpperCase() }} {{ formattedFirstName }}</p>
         </template>
 
         <template v-slot:col2>

--- a/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUserIdentiteEtRole.vue
+++ b/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUserIdentiteEtRole.vue
@@ -2,7 +2,7 @@
     <FicheGrille :border="false" :marginTop="false">
         <template v-slot:col1>
             <p class="font-bold">Nom Prénom</p>
-            <p>{{ user.firstName }} {{ user.lastName }}</p>
+            <p>{{ formattedFirstName }} {{ user.lastName.toUpperCase() }}</p>
         </template>
 
         <template v-slot:col2>
@@ -15,11 +15,13 @@
 </template>
 
 <script setup>
-import { toRefs } from "vue";
+import { computed, toRefs } from "vue";
 import FicheGrille from "@/components/FicheRubrique/FicheGrille.vue";
+import majFirstName from "@common/utils/stringUtils";
 
 const props = defineProps({
     user: Object,
 });
 const { user } = toRefs(props);
+const formattedFirstName = computed(() => majFirstName(user.value.firstName));
 </script>

--- a/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUserIdentiteEtRole.vue
+++ b/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUserIdentiteEtRole.vue
@@ -1,0 +1,25 @@
+<template>
+    <FicheGrille :border="false" :marginTop="false">
+        <template v-slot:col1>
+            <p class="font-bold">Nom Prénom</p>
+            <p>{{ user.firstName }} {{ user.lastName }}</p>
+        </template>
+
+        <template v-slot:col2>
+            <p class="font-bold">Rôle actuel</p>
+            <p>
+                {{ user.roleName }}
+            </p>
+        </template>
+    </FicheGrille>
+</template>
+
+<script setup>
+import { toRefs } from "vue";
+import FicheGrille from "@/components/FicheRubrique/FicheGrille.vue";
+
+const props = defineProps({
+    user: Object,
+});
+const { user } = toRefs(props);
+</script>

--- a/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUserListeRole.vue
+++ b/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUserListeRole.vue
@@ -1,0 +1,31 @@
+<template>
+    <p class="text-xl font-bold mb-4 pl-4">Nouveau rôle</p>
+    <ul class="mb-4 pl-12">
+        <li v-for="role in options" :key="role.id">
+            <label :for="role.id">
+                <input
+                    type="radio"
+                    :id="role.id"
+                    :value="role.id"
+                    name="userRole"
+                    @click="updateRole"
+                />
+                {{ role.name }}
+            </label>
+        </li>
+    </ul>
+</template>
+<script setup>
+import { toRefs, defineEmits } from "vue";
+
+const props = defineProps({
+    options: Array,
+    model: String,
+});
+const { options } = toRefs(props);
+const emit = defineEmits(["update-role"]);
+
+function updateRole(event) {
+    emit("update-role", event.target.value);
+}
+</script>

--- a/packages/frontend/webapp/src/stores/acces.store.js
+++ b/packages/frontend/webapp/src/stores/acces.store.js
@@ -5,6 +5,7 @@ import { get, list } from "@/api/users.api";
 import enrichUserWithAccessStatus from "@/utils/enrichUserWithAccessStatus";
 import enrichUserWithLocationName from "@/utils/enrichUserWithLocationName";
 import accessStatuses from "@/utils/access_statuses";
+import { setRoleRegular } from "@/api/users.api";
 import Fuse from "fuse.js";
 
 const ITEMS_PER_PAGE = 50;
@@ -123,6 +124,16 @@ export const useAccesStore = defineStore("acces", () => {
             return Math.ceil(filteredAcces.value.length / ITEMS_PER_PAGE);
         }),
         total: computed(() => filteredAcces.value.length),
+
+        async updateUserRole(userId, newRole, roles) {
+            const updatedUser = await setRoleRegular(userId, newRole);
+            if (updatedUser && hash.value[userId]) {
+                hash.value[userId].role = roles.find(
+                    (role) => role.id === newRole
+                ).name;
+                hash.value[userId].role_id = newRole;
+            }
+        },
 
         updateUser(userId, user) {
             if (hash.value[userId]) {

--- a/packages/frontend/webapp/src/stores/acces.store.js
+++ b/packages/frontend/webapp/src/stores/acces.store.js
@@ -1,11 +1,10 @@
 import { defineStore } from "pinia";
 import { ref, computed, watch } from "vue";
 import { useEventBus } from "@common/helpers/event-bus";
-import { get, list } from "@/api/users.api";
+import { get, list, setRoleRegular } from "@/api/users.api";
 import enrichUserWithAccessStatus from "@/utils/enrichUserWithAccessStatus";
 import enrichUserWithLocationName from "@/utils/enrichUserWithLocationName";
 import accessStatuses from "@/utils/access_statuses";
-import { setRoleRegular } from "@/api/users.api";
 import Fuse from "fuse.js";
 
 const ITEMS_PER_PAGE = 50;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/PWXGG9Kf/2165

## 🛠 Description de la PR
- Créer d'un service pour modifier un rôle ordinaire
- Créer un test au service `setRoleRegular`
- Limiter l'affichage du bouton **"Définir comme « Intervenant »"** aux admins locaux, puisque les administrateurs nationaux dispose d'un formulaire pour affecter tous les rôle ordinaires
- Ajouter l'action et la modale **"Modifier le rôle"**
- Corriger la configuration du linter

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/50863659/c4ac63cc-f614-422d-b425-f67debdb4c2e)

## 🚨 Notes pour la mise en production
- ràs