### PR TITLE
#patch: (2159) Affichage d'une croix rouge pour les options non activées

### DIFF
--- a/packages/frontend/ui/src/components/Input/CheckboxUi.vue
+++ b/packages/frontend/ui/src/components/Input/CheckboxUi.vue
@@ -5,6 +5,7 @@
                 class="inline-block rounded mr-2 text-center" type="checkbox" :checked="checked" :disabled="disabled" />
             <div v-else>
                 <Icon v-if="checked" class="text-tertiaryA11Y font-bold text-md" icon="fa-solid fa-check" />
+                <Icon v-else class="text-redA11Y font-bold text-md" icon="fa-solid fa-xmark" />
             </div>
             {{ label }}
         </label>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/1PPoN9ln/2159-gestion-des-droits-d%C3%A9placer-le-bloc-options-d%C3%A9j%C3%A0-coch%C3%A9es-au-niveau-territoire

## 🛠 Description de la PR
Update de la PR #969 pour ajouter une croix rouge sur les items non-sélectionnés de la liste

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/34971399/c44eddf5-a3df-45c9-8cee-8fac5b61ace6)

## 🚨 Notes pour la mise en production
RàS