### PR TITLE
#patch: (2190) Bloquer l'URL de modification des territoires d'intervention aux profils autre qu'admin national

### DIFF
--- a/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
+++ b/packages/api/server/controllers/user/setInterventionAreas/user.setInterventionAreas.ts
@@ -19,7 +19,7 @@ export default async (req: UserSetInterventionAreasRequest, res: Response, next:
     try {
         if (req.user.is_superuser !== true) {
             res.status(403).send({
-                user_message: 'La modification des territoires d\'intervention est temporairement réservée aux administrateurs nationaux',
+                user_message: 'La modification des territoires d\'intervention est réservée aux administrateurs nationaux',
             });
             return;
         }

--- a/packages/frontend/webapp/src/helpers/router.js
+++ b/packages/frontend/webapp/src/helpers/router.js
@@ -388,6 +388,14 @@ const router = createRouter({
                 navTab: "administration",
                 displayOrderOnSiteMap: 0,
             },
+            beforeEnter: (to, from, next) => {
+                const userStore = useUserStore();
+                if (userStore.isLoggedIn && userStore.user?.is_superuser) {
+                    next();
+                } else {
+                    next("/page-interdite");
+                }
+            },
         },
         {
             path: "/utilisateurs/permissions",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/dE2gSgho/2190-gestion-des-droits-bloquer-lurl-de-modification-des-territoires-dintervention-aux-profils-autre-quadmin-national

## 🛠 Description de la PR
La PR met en place la sécurisation de l'URL de modification de territoire d'intervention d'un utilisateur/d'une structure.
Seul un admin national aura accès et verra le bouton.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS