### PR TITLE
#patch (2179) Corriger le format de la date "updatedAt" dans  l'export des sites

### DIFF
--- a/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
+++ b/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
@@ -1013,7 +1013,7 @@ export default (closingSolutions: ClosingSolution[]) => {
         },
         updatedAt: {
             title: 'Site mis à jour le',
-            data: ({ updatedAt }: Shantytown) => (updatedAt ? tsToString(updatedAt, 'd/m/Y') : ''),
+            data: ({ updatedAt }: Shantytown) => (updatedAt ? new Date(updatedAt * 1000) : ''),
             width: COLUMN_WIDTHS.SMALL,
         },
         actors: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ETC0RO9U/2179

## 🛠 Description de la PR
Corriger la date de dernière mise à jour des sites pour permettre le tri 

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/50863659/12030e82-14f6-4eaa-8c45-b8d0365d1e34)

## 🚨 Notes pour la mise en production
- ràs