### PR TITLE
#patch: (2203) Suppression du bandeau "Visualisation des données"

### DIFF
--- a/packages/frontend/webapp/src/views/ListeDesActionsView.vue
+++ b/packages/frontend/webapp/src/views/ListeDesActionsView.vue
@@ -9,7 +9,6 @@
         <ContentWrapper>
             <FilArianne :items="ariane" class="mb-8" />
         </ContentWrapper>
-        <BandeauPromotionVisualisationDonnees />
         <ListeDesActions />
     </LayoutSearch>
 </template>
@@ -21,8 +20,6 @@ import { useActionsStore } from "@/stores/actions.store";
 import { ContentWrapper, FilArianne } from "@resorptionbidonvilles/ui";
 import LayoutSearch from "@/components/LayoutSearch/LayoutSearch.vue";
 import ListeDesActions from "@/components/ListeDesActions/ListeDesActions.vue";
-
-import BandeauPromotionVisualisationDonnees from "@/components/BandeauPromotionVisualisationDonnees/BandeauPromotionVisualisationDonnees.vue";
 
 const ariane = [{ label: "Accueil", to: "/" }, { label: "Actions" }];
 

--- a/packages/frontend/webapp/src/views/ListeDesSitesView.vue
+++ b/packages/frontend/webapp/src/views/ListeDesSitesView.vue
@@ -9,7 +9,6 @@
         <ContentWrapper>
             <FilArianne :items="ariane" class="mb-8" />
         </ContentWrapper>
-        <BandeauPromotionVisualisationDonnees />
         <ListeDesSites />
     </LayoutSearch>
 </template>
@@ -22,7 +21,6 @@ import { trackEvent } from "@/helpers/matomo";
 import { ContentWrapper, FilArianne } from "@resorptionbidonvilles/ui";
 import LayoutSearch from "@/components/LayoutSearch/LayoutSearch.vue";
 import ListeDesSites from "@/components/ListeDesSites/ListeDesSites.vue";
-import BandeauPromotionVisualisationDonnees from "@/components/BandeauPromotionVisualisationDonnees/BandeauPromotionVisualisationDonnees.vue";
 
 const ariane = [{ label: "Accueil", to: "/" }, { label: "Sites" }];
 const townsStore = useTownsStore();


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/40wXj89x/2203-site-action-retrait-du-bandeau-de-promotion-visudonn%C3%A9e

## 🛠 Description de la PR
La PR supprime l'affichage du bandeau "Nouveau - Visualisation des données" des pages "Actions" et "Sites".
La PR ne supprime pas le bandeau en tant que composant pour pouvoir le réutiliser.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS