### PR TITLE
#patch: (2203) Ajout du message indiquant le caractère obligatoire de champs de formulaires

### DIFF
--- a/packages/frontend/webapp/src/components/FormCreerStructure/FormCreerStructure.vue
+++ b/packages/frontend/webapp/src/components/FormCreerStructure/FormCreerStructure.vue
@@ -1,5 +1,6 @@
 <template>
     <form>
+        <IndicationCaractereObligatoire />
         <FormParagraph :title="labels.name" showMandatoryStar>
             <FormCreerStructureInputName :question="question" />
         </FormParagraph>
@@ -71,6 +72,7 @@ import FormCreerStructureInputNewTypeName from "./inputs/FormCreerStructureInput
 import FormCreerStructureInputNewTypeAbbreviation from "./inputs/FormCreerStructureInputNewTypeAbbreviation.vue";
 import FormCreerStructureInputNewTypeDefaultRole from "./inputs/FormCreerStructureInputNewTypeDefaultRole.vue";
 import FormCreerStructureInputInterventionAreas from "./inputs/FormCreerStructureInputInterventionAreas.vue";
+import IndicationCaractereObligatoire from "@/components/IndicationCaractereObligatoire/IndicationCaractereObligatoire.vue";
 
 const { handleSubmit, setErrors, errors, isSubmitting } = useForm({
     validationSchema: schema,

--- a/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/FormDeclarationAction.vue
@@ -1,6 +1,7 @@
 <template>
     <ArrangementLeftMenu :tabs="tabs" autonav>
         <template v-slot:menuTitle>Rubriques</template>
+        <IndicationCaractereObligatoire class="mb-6" />
 
         <FormDeclarationActionCaracteristiques class="mt-6" :mode="mode" />
         <FormDeclarationActionLocalisation
@@ -51,6 +52,7 @@ import FormDeclarationActionLocalisation from "./sections/FormDeclarationActionL
 import FormDeclarationActionContacts from "./sections/FormDeclarationActionContacts.vue";
 import FormDeclarationActionFinances from "./sections/FormDeclarationActionFinances.vue";
 import FormDeclarationActionIndicateurs from "./sections/FormDeclarationActionIndicateurs.vue";
+import IndicationCaractereObligatoire from "@/components/IndicationCaractereObligatoire/IndicationCaractereObligatoire.vue";
 import schemaFn from "./FormDeclarationAction.schema";
 
 const props = defineProps({

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -1,6 +1,7 @@
 <template>
     <ArrangementLeftMenu :tabs="tabs" autonav>
         <template v-slot:menuTitle>Rubriques</template>
+        <IndicationCaractereObligatoire />
 
         <FormDeclarationDeSiteInfo v-if="town === null" :mode="mode" />
         <FormDeclarationDeSiteDateDeMaj
@@ -73,6 +74,7 @@ import FormDeclarationDeSiteHabitants from "./sections/FormDeclarationDeSiteHabi
 import FormDeclarationDeSiteConditionsDeVie from "./sections/FormDeclarationDeSiteConditionsDeVie.vue";
 import FormDeclarationDeSiteConditionsDeVieV1 from "./sections/FormDeclarationDeSiteConditionsDeVieV1.vue";
 import FormDeclarationDeSiteProcedureJudiciaire from "./sections/FormDeclarationDeSiteProcedureJudiciaire.vue";
+import IndicationCaractereObligatoire from "@/components/IndicationCaractereObligatoire/IndicationCaractereObligatoire.vue";
 import schemaFn from "./FormDeclarationDeSite.schema";
 
 const props = defineProps({

--- a/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
+++ b/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
@@ -1,6 +1,8 @@
 <template>
     <form>
         <DragZone @drop="attachmentsInput?.addFiles">
+            <IndicationCaractereObligatoire />
+
             <FormParagraph :title="labels.question" showMandatoryStar>
                 <FormNouvelleQuestionInputQuestion
                     :disabled="mode === 'edit'"
@@ -50,6 +52,7 @@ import isDeepEqual from "@/utils/isDeepEqual";
 
 import { ErrorSummary, FormParagraph } from "@resorptionbidonvilles/ui";
 import DragZone from "@/components/DragZone/DragZone.vue";
+import IndicationCaractereObligatoire from "@/components/IndicationCaractereObligatoire/IndicationCaractereObligatoire.vue";
 import FormNouvelleQuestionInputQuestion from "./inputs/FormNouvelleQuestionInputQuestion.vue";
 import FormNouvelleQuestionInputPeopleAffected from "./inputs/FormNouvelleQuestionInputPeopleAffected.vue";
 import FormNouvelleQuestionInputDetails from "./inputs/FormNouvelleQuestionInputDetails.vue";

--- a/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/FormUtilisateur/FormUtilisateur.vue
@@ -10,6 +10,9 @@
         <template v-slot:alert><slot name="alert" /></template>
 
         <template v-slot:body="{ values }">
+            <IndicationCaractereObligatoire
+                v-if="variant === 'creer-utilisateur'"
+            />
             <FormUtilisateurInputEmail
                 :value="$route.query.email"
                 :showMandatoryStar="variant === 'creer-utilisateur'"
@@ -192,6 +195,7 @@ import FormUtilisateurInputReferral from "./inputs/FormUtilisateurInputReferral.
 import FormUtilisateurInputReferralOther from "./inputs/FormUtilisateurInputReferralOther.vue";
 import FormUtilisateurInputReferralWordOfMouth from "./inputs/FormUtilisateurInputReferralWordOfMouth.vue";
 import FormUtilisateurInputLegal from "./inputs/FormUtilisateurInputLegal.vue";
+import IndicationCaractereObligatoire from "@/components/IndicationCaractereObligatoire/IndicationCaractereObligatoire.vue";
 
 // form
 import schemaFn from "./FormUtilisateur.schema";

--- a/packages/frontend/webapp/src/components/IndicationCaractereObligatoire/IndicationCaractereObligatoire.vue
+++ b/packages/frontend/webapp/src/components/IndicationCaractereObligatoire/IndicationCaractereObligatoire.vue
@@ -1,0 +1,10 @@
+<template>
+    <div class="mb-12 italic">
+        Les champs indiqués par <MandatoryStar class="font-bold" /> sont
+        obligatoires.
+    </div>
+</template>
+
+<script setup>
+import { MandatoryStar } from "@resorptionbidonvilles/ui";
+</script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/WpHNvJ7W/2204-accessibilit%C3%A9-ajouter-une-explication-du-caract%C3%A8re-obligatoire

## 🛠 Description de la PR
La PR ajoute un composant permettant l'affichage du message indiquant le caractère obligatoire de certains champs de formulaires.

## 📸 Captures d'écran
![image](https://github.com/MTES-MCT/resorption-bidonvilles/assets/34971399/962f062d-5c9f-4b98-aa05-37ec033e3dcb)

## 🚨 Notes pour la mise en production
RàS