### PR TITLE
update: Correction de bugs de déploiement et amélioration des graphs

### DIFF
--- a/packages/frontend/ui/src/components/Input/DatepickerInput.vue
+++ b/packages/frontend/ui/src/components/Input/DatepickerInput.vue
@@ -23,7 +23,8 @@ import InputWrapper from "./utils/InputWrapper.vue";
 import InputLabel from "./utils/InputLabel.vue";
 import InputError from "./utils/InputError.vue";
 
-import { useDepartementMetricsStore } from "@stores/metrics.departement.store.js";
+// import { useDepartementMetricsStore } from "@stores/metrics.departement.store.js";
+import { useDepartementMetricsStore } from "../webapp/src/stores/metrics.departement.store";
 
 const props = defineProps({
     id: String,

--- a/packages/frontend/ui/src/components/Input/DatepickerInput.vue
+++ b/packages/frontend/ui/src/components/Input/DatepickerInput.vue
@@ -3,7 +3,7 @@
         <InputLabel :label="label" :info="info" :inlineInfo="inlineInfo" :showMandatoryStar="showMandatoryStar" :for="`dp-input-${id}`" />
 
         <div :class="width">
-            <DatePicker v-model="date" locale="fr" :format-locale="fr" :format="departementMetricsStore.activeTab === 'evolution' ? 'LLLL yyyy' : 'dd LLLL yyyy'"
+            <DatePicker v-model="date" locale="fr" :format-locale="fr" :format="section === 'evolution' ? 'LLLL yyyy' : 'dd LLLL yyyy'"
                 :disabled="isSubmitting || disabled" autoApply :enableTimePicker="false"
                 :input-class-name="focusClasses.ring"
                 :preventMinMaxNavigation="$attrs.maxDate || $attrs.minDate" v-bind="$attrs" :uid="id">
@@ -22,9 +22,6 @@ import focusClasses from "../../../../common/utils/focus_classes";
 import InputWrapper from "./utils/InputWrapper.vue";
 import InputLabel from "./utils/InputLabel.vue";
 import InputError from "./utils/InputError.vue";
-
-// import { useDepartementMetricsStore } from "@stores/metrics.departement.store.js";
-import { useDepartementMetricsStore } from "../webapp/src/stores/metrics.departement.store";
 
 const props = defineProps({
     id: String,
@@ -61,15 +58,18 @@ const props = defineProps({
         required: false,
         default: false
     },
+    section: {
+        required: false,
+        type: String
+    }
 });
 
-const { id, name, label, info, inlineInfo, showMandatoryStar, rules, disabled, modelValue, width, withoutMargin } = toRefs(props);
+const { id, name, label, info, inlineInfo, showMandatoryStar, rules, disabled, modelValue, width, withoutMargin, section } = toRefs(props);
 const isSubmitting = useIsSubmitting();
 const { handleChange, errors, value } = useField(name.value, rules.value, {
     initialValue: modelValue.value
 });
 const emit = defineEmits(["update:modelValue"]);
-const departementMetricsStore = useDepartementMetricsStore();
 
 const date = computed({
     get() {

--- a/packages/frontend/ui/src/components/Input/DatepickerInput.vue
+++ b/packages/frontend/ui/src/components/Input/DatepickerInput.vue
@@ -23,7 +23,7 @@ import InputWrapper from "./utils/InputWrapper.vue";
 import InputLabel from "./utils/InputLabel.vue";
 import InputError from "./utils/InputError.vue";
 
-import { useDepartementMetricsStore } from "../../../../webapp/src/stores/metrics.departement.store.js";
+import { useDepartementMetricsStore } from "@stores/metrics.departement.store";
 
 const props = defineProps({
     id: String,

--- a/packages/frontend/ui/src/components/Input/DatepickerInput.vue
+++ b/packages/frontend/ui/src/components/Input/DatepickerInput.vue
@@ -23,7 +23,7 @@ import InputWrapper from "./utils/InputWrapper.vue";
 import InputLabel from "./utils/InputLabel.vue";
 import InputError from "./utils/InputError.vue";
 
-import { useDepartementMetricsStore } from "@stores/metrics.departement.store";
+import { useDepartementMetricsStore } from "@stores/metrics.departement.store.js";
 
 const props = defineProps({
     id: String,

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -83,7 +83,6 @@ import Carto from "@/components/Carto/Carto.vue";
 import marqueurSiteStats from "@/utils/marqueurSiteStats";
 import marqueurLocationStats from "@/utils/marqueurLocationStats";
 import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
-
 import { Icon } from "@resorptionbidonvilles/ui";
 const departementMetricsStore = useDepartementMetricsStore();
 const carto = ref(null);

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/Dates.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/Dates.vue
@@ -7,6 +7,7 @@
                 departementMetricsStore.activeTab === 'evolution' ? 'De' : 'Du'
             "
             withoutMargin
+            :section="departementMetricsStore.activeTab"
             @update:modelValue="(date) => updateDate('from', date)"
         />
         <DatepickerInput
@@ -17,6 +18,7 @@
                 departementMetricsStore.activeTab === 'evolution' ? 'À' : 'Au'
             "
             withoutMargin
+            :section="departementMetricsStore.activeTab"
             @update:modelValue="(date) => updateDate('to', date)"
         />
         <Button

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartInhabitants.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartInhabitants.vue
@@ -55,17 +55,32 @@ const chartData = computed(() => {
         generateDataset(
             "Nombre d'habitants intra-UE",
             "0, 0, 255",
-            data.charts.european
+            data.charts.european,
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
         generateDataset(
             "Nombre d'habitants extra-UE",
             "255, 0, 0",
-            data.charts.foreign
+            data.charts.foreign,
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
         generateDataset(
             "Nombre total d'habitants",
             "0, 255, 0",
-            data.charts.total
+            data.charts.total,
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
     ];
 

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartInhabitants.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartInhabitants.vue
@@ -98,6 +98,11 @@ const options = computed(() => {
             xAxis: {
                 ...chartOptions.line.options.xAxis,
                 data: data.charts.labels,
+                axisTick: {
+                    show: true,
+                    alignWithLabel: false,
+                    interval: 0,
+                },
             },
         },
     };

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartJustice.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartJustice.vue
@@ -18,10 +18,16 @@
             >
         </div>
 
-        <LineChart
+        <!-- <LineChart
             class="mt-6"
             :chartOptions="chartOptions"
             :chartData="chartData"
+        /> -->
+        <LineChart
+            class="mt-6"
+            :chartOptions="options"
+            :chartData="chartData.datasets"
+            :graphId="`evolution-justice`"
         />
     </section>
 </template>
@@ -30,7 +36,7 @@
 import formatStat from "@/utils/formatStat";
 import { computed } from "vue";
 import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
-import { LineChart } from "@/helpers/chart";
+import LineChart from "@/components/Graphs/GraphBase.vue";
 import ChartBigFigure from "./ChartBigFigure.vue";
 import chartOptions from "../../utils/GraphiquesDonneesStatistiques/ChartOptions";
 import generateDataset from "../../utils/GraphiquesDonneesStatistiques/generateDataset";
@@ -46,23 +52,39 @@ const chartData = computed(() => {
     max.global = Math.max(max.police, max.complaints);
 
     const datasets = [
-        generateDataset(
-            "Nombre de CFP",
-            "rgba(0, 0, 255, 0.5)",
-            data.charts.police,
-            max.global
-        ),
+        generateDataset("Nombre de CFP", "0, 0, 255", data.charts.police, {
+            lineStyle: { opacity: 1 },
+            area: true,
+            symbolSize: 1,
+        }),
         generateDataset(
             "Nombre de plaintes",
-            "rgba(255, 0, 0, 0.5)",
+            "255, 0, 0",
             data.charts.complaints,
-            max.global
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
     ];
 
     return {
         labels: data.charts.labels,
         datasets,
+    };
+});
+
+const options = computed(() => {
+    return {
+        ...chartOptions.line,
+        options: {
+            ...chartOptions.line.options,
+            xAxis: {
+                ...chartOptions.line.options.xAxis,
+                data: data.charts.labels,
+            },
+        },
     };
 });
 </script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartJustice.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartJustice.vue
@@ -53,7 +53,7 @@ const chartData = computed(() => {
 
     const datasets = [
         generateDataset("Nombre de CFP", "0, 0, 255", data.charts.police, {
-            lineStyle: { opacity: 1 },
+            lineStyle: { opacity: 1, width: 2, color: "rgba(0, 0, 255, 1)" },
             area: true,
             symbolSize: 1,
         }),
@@ -83,6 +83,11 @@ const options = computed(() => {
             xAxis: {
                 ...chartOptions.line.options.xAxis,
                 data: data.charts.labels,
+                axisTick: {
+                    show: true,
+                    alignWithLabel: false,
+                    interval: 0,
+                },
             },
         },
     };

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartLivingCondition.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartLivingCondition.vue
@@ -82,12 +82,22 @@ const chartData = computed(() => {
                 chartType.value === "towns"
                     ? "towns_total"
                     : "inhabitants_total"
-            ]
+            ],
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
         generateDataset(
             chartLabel.value,
             "0, 255, 0",
-            data.value.charts[livingConditionType.value]
+            data.value.charts[livingConditionType.value],
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
     ];
 

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartLivingCondition.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartLivingCondition.vue
@@ -115,6 +115,11 @@ const options = computed(() => {
             xAxis: {
                 ...chartOptions.line.options.xAxis,
                 data: data.value.charts.labels,
+                axisTick: {
+                    show: true,
+                    alignWithLabel: false,
+                    interval: 0,
+                },
             },
         },
     };

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartTowns.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartTowns.vue
@@ -60,17 +60,32 @@ const chartData = computed(() => {
         generateDataset(
             "Sites de moins de 10 habitants",
             "255, 0, 0",
-            data.charts.less_than_10
+            data.charts.less_than_10,
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
         generateDataset(
             "Sites de moins de 100 habitants",
             "0, 0, 255",
-            data.charts.between_10_and_99
+            data.charts.between_10_and_99,
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
         generateDataset(
             "Sites de plus de 100 habitants",
             "0, 255, 0",
-            data.charts.more_than_99
+            data.charts.more_than_99,
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
         ),
     ];
 

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartTowns.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartTowns.vue
@@ -103,6 +103,11 @@ const options = computed(() => {
             xAxis: {
                 ...chartOptions.line.options.xAxis,
                 data: data.charts.labels,
+                axisTick: {
+                    show: true,
+                    alignWithLabel: false,
+                    interval: 0,
+                },
             },
         },
     };

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/generateDataset.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/generateDataset.js
@@ -34,7 +34,7 @@ export default function generateDataset(label, color, data, options = {}) {
             focus: "none",
             scale: 10,
             itemStyle: {
-                color: "255, 0, 0",
+                color: `rgba(${color}, 1)`,
                 borderColor: "rgba(70, 249, 60, 1)",
             },
         },

--- a/packages/frontend/webapp/vite.config.mjs
+++ b/packages/frontend/webapp/vite.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
         alias: {
             "@common": fileURLToPath(new URL("../common", import.meta.url)),
             "@": fileURLToPath(new URL("./src", import.meta.url)),
+            "@stores": fileURLToPath(new URL("./src/stores/", import.meta.url)),
         },
     },
 });

--- a/packages/frontend/www/nuxt.config.ts
+++ b/packages/frontend/www/nuxt.config.ts
@@ -39,6 +39,6 @@ export default defineNuxtConfig({
     },
     alias: {
         "@common": fileURLToPath(new URL("../common/", import.meta.url)),
-        "@stores": fileURLToPath(new URL("../webapp/src/stores/", import.meta.url))
+        "@stores": fileURLToPath(new URL("../webapp/src/stores", import.meta.url))
     }
 });

--- a/packages/frontend/www/nuxt.config.ts
+++ b/packages/frontend/www/nuxt.config.ts
@@ -2,9 +2,6 @@ import { fileURLToPath } from "url";
 
 // https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
 export default defineNuxtConfig({
-    alias: {
-        "@common": "/../common",
-    },
     modules: [
         "@nuxtjs/tailwindcss",
         ["@nuxtjs/i18n", {
@@ -26,9 +23,6 @@ export default defineNuxtConfig({
                 host: "localhost"
             }
         }
-    },
-    build: {
-        
     },
     runtimeConfig: {
         public: {

--- a/packages/frontend/www/nuxt.config.ts
+++ b/packages/frontend/www/nuxt.config.ts
@@ -38,6 +38,7 @@ export default defineNuxtConfig({
         }
     },
     alias: {
-        "@common": fileURLToPath(new URL("../common/", import.meta.url))
+        "@common": fileURLToPath(new URL("../common/", import.meta.url)),
+        "@stores": fileURLToPath(new URL("../webapp/src/stores/", import.meta.url))
     }
 });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/DAPOirmQ/2208-visu-donn%C3%A9es-v1-graphiques-de-la-vue-agr%C3%A9g%C3%A9e-france-m%C3%A9tro

## 🛠 Description de la PR
Cette PR amène une version version des graphiques avec un paramétrage les rendant plus lisibles ainsi qu'une nouvelle méthode de calcul des sites ouverts à date.
De plus, cette PR modifie la façon dont le DatePickerInput vérifie si l'on est sur l'onglet d'évolution nationale, ce qui causait des erreurs au déploiement.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS