### PR TITLE
#patch: (2214) Remodelage du bandeau des chiffre globaux dans la visualisation de données des départements

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/DonneesStatistiquesDepartementBigFigures.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/DonneesStatistiquesDepartementBigFigures.vue
@@ -7,52 +7,123 @@
             }}</span>
         </h1>
         <div
-            class="bg-G100 border border-G300 rounded py-4 px-6 flex items-stretch"
+            class="bg-G100 border border-G300 rounded py-4 px-6 flex md:flex-row flex-col items-stretch"
         >
-            <div class="flex space-x-5 self-center flex-1">
-                <p>
-                    <span class="font-bold text-3xl">{{
-                        formatStat(metrics.summary.number_of_towns.all)
-                    }}</span
-                    ><br />site<template
-                        v-if="metrics.summary.number_of_towns.all > 1"
-                        >s</template
+            <div class="flex flex-col mb-2 md:mb-0">
+                <!-- md:w-2/5 -->
+                <p class="font-bold w-full">Sites de + de 10 personnes</p>
+                <div class="flex flex-col xs:flex-row gap-2 xs:space-x-5">
+                    <div
+                        class="bg-G200 rounded-md p-2 flex flex-col flex-wrap items-center"
                     >
-                </p>
-                <p>
-                    <span class="font-bold text-3xl">{{
-                        formatStat(metrics.summary.number_of_persons.all)
-                    }}</span
-                    ><br />personne<template
-                        v-if="metrics.summary.number_of_persons.all > 1"
-                        >s</template
+                        <div
+                            class="flex flex-col lg:flex-row flex-wrap items-center justify-center"
+                        >
+                            <div class="flex flex-row">
+                                <img
+                                    :src="flagEU"
+                                    class="w-12 h-8 mr-1 ml-1"
+                                    alt=""
+                                />
+                                <p class="text-3xl font-bold">
+                                    {{
+                                        formatStat(
+                                            metrics.summary.number_of_persons
+                                                .eu_only
+                                        )
+                                    }}
+                                </p>
+                            </div>
+                            <p class="text-sm ml-1 mr-0">
+                                habitant<template
+                                    v-if="
+                                        metrics.summary.number_of_persons
+                                            .eu_only > 1
+                                    "
+                                    >s</template
+                                >
+                            </p>
+                        </div>
+                        <p class="font-normal text-sm text-center">
+                            exclusivement européens
+                        </p>
+                    </div>
+                    <div
+                        class="bg-G200 rounded-md p-2 flex flex-row items-center gap-1"
                     >
-                </p>
+                        <i class="fa-solid fa-map-pin text-2xl" />
+                        <p>
+                            <span class="font-bold text-3xl">{{
+                                formatStat(
+                                    metrics.summary.number_of_towns.eu_only
+                                )
+                            }}</span>
+                        </p>
+                        <p>
+                            site<template
+                                v-if="
+                                    metrics.summary.number_of_towns.eu_only > 1
+                                "
+                                >s</template
+                            >
+                        </p>
+                    </div>
+                </div>
             </div>
             <div class="w-px bg-G300 mx-6"></div>
-            <div>
-                <p>Sites avec exclusivement des ressortissants européens</p>
-                <div class="flex space-x-5">
-                    <p>
-                        <span class="font-bold text-lg">{{
-                            formatStat(metrics.summary.number_of_towns.eu_only)
-                        }}</span
-                        ><br />site<template
-                            v-if="metrics.summary.number_of_towns.eu_only > 1"
-                            >s</template
+            <div class="flex flex-col mb-2 md:mb-0">
+                <!-- md:w-2/5 -->
+                <p class="font-bold">Tous sites</p>
+                <div
+                    class="flex flex-col xs:flex-row gap-2 xs:space-x-5 items-center h-full"
+                >
+                    <div class="bg-G200 rounded-md p-2 flex flex-col flex-wrap">
+                        <div
+                            class="flex flex-col lg:flex-row flex-wrap items-center md:justify-center"
                         >
-                    </p>
-                    <p>
-                        <span class="font-bold text-lg">{{
-                            formatStat(
-                                metrics.summary.number_of_persons.eu_only
-                            )
-                        }}</span
-                        ><br />personne<template
-                            v-if="metrics.summary.number_of_persons.eu_only > 1"
-                            >s</template
+                            <div class="flex flex-row">
+                                <i class="fa-solid fa-people-group text-2xl" />
+                                <p class="text-3xl font-bold">
+                                    {{
+                                        formatStat(
+                                            metrics.summary.number_of_persons
+                                                .all
+                                        )
+                                    }}
+                                </p>
+                            </div>
+                            <p class="text-sm ml-1 mr-0">
+                                habitant<template
+                                    v-if="
+                                        metrics.summary.number_of_persons.all >
+                                        1
+                                    "
+                                    >s</template
+                                >
+                            </p>
+                        </div>
+                        <p
+                            class="font-normal text-sm text-center xl:text-start"
                         >
-                    </p>
+                            toutes origines
+                        </p>
+                    </div>
+                    <div
+                        class="bg-G200 rounded-md p-2 flex flex-row items-center gap-1"
+                    >
+                        <i class="fa-solid fa-map-pin text-2xl" />
+                        <p>
+                            <span class="font-bold text-3xl">{{
+                                formatStat(metrics.summary.number_of_towns.all)
+                            }}</span>
+                        </p>
+                        <p>
+                            site<template
+                                v-if="metrics.summary.number_of_towns.all > 1"
+                                >s</template
+                            >
+                        </p>
+                    </div>
                 </div>
             </div>
             <div class="w-px bg-G300 mx-6"></div>
@@ -139,6 +210,7 @@ import formatStat from "@/utils/formatStat";
 import formatDate from "@common/utils/formatDate";
 
 import { Icon } from "@resorptionbidonvilles/ui";
+import flagEU from "@/assets/img/flags/eu.png";
 
 const props = defineProps({
     metrics: {

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/DonneesStatistiquesDepartementBigFigures.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/DonneesStatistiquesDepartementBigFigures.vue
@@ -10,29 +10,30 @@
             class="bg-G100 border border-G300 rounded py-4 px-6 flex md:flex-row flex-col items-stretch"
         >
             <div class="flex flex-col mb-2 md:mb-0">
-                <!-- md:w-2/5 -->
                 <p class="font-bold w-full">Sites de + de 10 personnes</p>
                 <div class="flex flex-col xs:flex-row gap-2 xs:space-x-5">
                     <div
-                        class="bg-G200 rounded-md p-2 flex flex-col flex-wrap items-center"
+                        class="bg-G200 rounded-md p-2 flex flex-col flex-wrap items-center xl:items-start"
                     >
                         <div
-                            class="flex flex-col lg:flex-row flex-wrap items-center justify-center"
+                            class="flex flex-row flex-wrap items-end justify-center"
                         >
-                            <div class="flex flex-row">
+                            <div class="flex flex-row items-center">
                                 <img
                                     :src="flagEU"
-                                    class="w-12 h-8 mr-1 ml-1"
+                                    class="w-9 h-6 mr-1 ml-0"
                                     alt=""
                                 />
-                                <p class="text-3xl font-bold">
+                                <span
+                                    class="text-3xl font-bold align-baseline leading-none"
+                                >
                                     {{
                                         formatStat(
                                             metrics.summary.number_of_persons
                                                 .eu_only
                                         )
                                     }}
-                                </p>
+                                </span>
                             </div>
                             <p class="text-sm ml-1 mr-0">
                                 habitant<template
@@ -49,48 +50,58 @@
                         </p>
                     </div>
                     <div
-                        class="bg-G200 rounded-md p-2 flex flex-row items-center gap-1"
+                        class="bg-G200 rounded-md px-2 flex flex-row flex-row items-center justify-center"
                     >
-                        <i class="fa-solid fa-map-pin text-2xl" />
-                        <p>
-                            <span class="font-bold text-3xl">{{
-                                formatStat(
-                                    metrics.summary.number_of_towns.eu_only
-                                )
-                            }}</span>
-                        </p>
-                        <p>
-                            site<template
-                                v-if="
-                                    metrics.summary.number_of_towns.eu_only > 1
-                                "
-                                >s</template
+                        <div class="flex flex-row items-end gap-1">
+                            <div
+                                class="flex flex-row gap-1 items-end align-baseline leading-none"
                             >
-                        </p>
+                                <i class="fa-solid fa-location-dot text-2xl" />
+                                <span
+                                    class="font-bold text-3xl align-baseline leading-none"
+                                    >{{
+                                        formatStat(
+                                            metrics.summary.number_of_towns
+                                                .eu_only
+                                        )
+                                    }}</span
+                                >
+                            </div>
+                            <p class="text-sm">
+                                site<template
+                                    v-if="
+                                        metrics.summary.number_of_towns
+                                            .eu_only > 1
+                                    "
+                                    >s</template
+                                >
+                            </p>
+                        </div>
                     </div>
                 </div>
             </div>
             <div class="w-px bg-G300 mx-6"></div>
             <div class="flex flex-col mb-2 md:mb-0">
-                <!-- md:w-2/5 -->
                 <p class="font-bold">Tous sites</p>
-                <div
-                    class="flex flex-col xs:flex-row gap-2 xs:space-x-5 items-center h-full"
-                >
-                    <div class="bg-G200 rounded-md p-2 flex flex-col flex-wrap">
+                <div class="flex flex-col xs:flex-row gap-2 xs:space-x-5">
+                    <div
+                        class="bg-G200 rounded-md p-2 flex flex-col flex-wrap items-center xl:items-start"
+                    >
                         <div
-                            class="flex flex-col lg:flex-row flex-wrap items-center md:justify-center"
+                            class="flex flex-row flex-wrap items-end justify-center"
                         >
-                            <div class="flex flex-row">
+                            <div class="flex flex-row items-center gap-1">
                                 <i class="fa-solid fa-people-group text-2xl" />
-                                <p class="text-3xl font-bold">
+                                <span
+                                    class="text-3xl font-bold align-baseline leading-none"
+                                >
                                     {{
                                         formatStat(
                                             metrics.summary.number_of_persons
                                                 .all
                                         )
                                     }}
-                                </p>
+                                </span>
                             </div>
                             <p class="text-sm ml-1 mr-0">
                                 habitant<template
@@ -109,20 +120,31 @@
                         </p>
                     </div>
                     <div
-                        class="bg-G200 rounded-md p-2 flex flex-row items-center gap-1"
+                        class="bg-G200 rounded-md p-2 flex flex-row flex-row items-center justify-center"
                     >
-                        <i class="fa-solid fa-map-pin text-2xl" />
-                        <p>
-                            <span class="font-bold text-3xl">{{
-                                formatStat(metrics.summary.number_of_towns.all)
-                            }}</span>
-                        </p>
-                        <p>
-                            site<template
-                                v-if="metrics.summary.number_of_towns.all > 1"
-                                >s</template
+                        <div class="flex flex-row items-end gap-1">
+                            <div
+                                class="flex flex-row gap-1 items-end align-baseline leading-none"
                             >
-                        </p>
+                                <i class="fa-solid fa-location-dot text-2xl" />
+                                <span
+                                    class="font-bold text-3xl align-baseline leading-none"
+                                    >{{
+                                        formatStat(
+                                            metrics.summary.number_of_towns.all
+                                        )
+                                    }}</span
+                                >
+                            </div>
+                            <p class="text-sm">
+                                site<template
+                                    v-if="
+                                        metrics.summary.number_of_towns.all > 1
+                                    "
+                                    >s</template
+                                >
+                            </p>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -160,7 +182,7 @@
                             "
                             >s</template
                         >
-                        sans nombre de personnes ou indications de l'origine
+                        sans nombre de personnes ou indication de l'origine
                     </p>
                     <p v-else>
                         Les nombres et origines des personnes sont renseignées


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/5WuydKmn/2214-visu-donn%C3%A9es-v1-ordre-des-chiffres-globaux

## 🛠 Description de la PR
Cette PR apporte des modifications sur le design du bandeau des chiffres globaux départementaux dans la visualisation de données afin de mettre en avant les indicateurs suivis par la DIHAL.

## 📸 Captures d'écran
L'ancien bandeau 
![image](https://github.com/user-attachments/assets/9ecb3e86-b340-4074-ba02-e7e6e895ede8)
devient maintenant
![image](https://github.com/user-attachments/assets/7f57ebdd-18a2-41c9-ae0f-44c821ea85f8)
et elle intègre une responsivness accrue
![image](https://github.com/user-attachments/assets/5b9ea3c4-eb29-45d6-88b0-6be972582e82)


## 🚨 Notes pour la mise en production
RàS