### PR TITLE
#patch: (2215) Modification d'icônes et ajout d'un tooltip sur les tableaux de visualisation de données

### DIFF
--- a/packages/frontend/ui/src/components/ToolTip.vue
+++ b/packages/frontend/ui/src/components/ToolTip.vue
@@ -1,7 +1,7 @@
 <template>
     <div @mouseenter="hovered = true" @mouseleave="hovered = false" class="inline-block">
-        <div class="mt-10 ml-5 bg-yellow-200 shadow-md text-black py-4 px-6"
-            :class="hovered ? 'absolute z-50' : 'hidden'">
+        <div class="mt-10 text-pretty"
+        :class="[hovered ? 'absolute z-50' : 'hidden', tooltipSide, extraSize, extraStyle]">
             {{ tip }}
         </div>
         <slot />
@@ -9,12 +9,30 @@
 </template>
   
 <script setup>
-import { defineProps, toRefs, ref } from "vue";
+import { defineProps, toRefs, ref, computed } from "vue";
 
 const props = defineProps({
-    tip: String
+    tip: String,
+    side: {
+        type: String,
+        default: "left",
+        required: false,
+    },
+    extraStyle: {
+        type: String,
+        default: "ml-5 bg-yellow-200 shadow-md text-black py-4 px-6",
+        required: false,
+    },
 });
-const { tip } = toRefs(props);
+const { tip, side } = toRefs(props);
 const hovered = ref(false);
+
+const tooltipSide = computed(() => {
+    return side.value === "right" ? "right-0" : "left-0";
+});
+
+const extraSize = computed(() => {
+    return tip.value.length > 10 ? "max-w-60 min-w-40 w-full" : "";
+});
 </script>
   

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -3,7 +3,7 @@
         <Button
             v-if="isHover"
             variant="primaryOutline"
-            icon="sun-bright"
+            icon="temperature-high"
             iconPosition="left"
             type="button"
             size="sm"

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/cells/Heatwave/HeatwaveBody.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/cells/Heatwave/HeatwaveBody.vue
@@ -1,5 +1,9 @@
 <template>
-    <Icon class="text-red600" icon="sun-bright" v-if="town.heatwave === true" />
+    <Icon
+        class="text-red600"
+        icon="temperature-high"
+        v-if="town.heatwave === true"
+    />
 </template>
 
 <script setup>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/cells/Heatwave/number_of_inhabitants_with_heatwave.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/cells/Heatwave/number_of_inhabitants_with_heatwave.js
@@ -2,7 +2,7 @@ import HeatwaveBody from "./HeatwaveBody.vue";
 import HeatwaveHead from "./HeatwaveHeadByInhabitant.vue";
 
 export default {
-    icon: "sun-bright",
+    icon: "temperature-high",
     title: "Nombre de personnes sous alerte canicule",
     headComponent: HeatwaveHead,
     bodyComponent: HeatwaveBody,

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/cells/Heatwave/number_of_towns_with_heatwave.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/cells/Heatwave/number_of_towns_with_heatwave.js
@@ -2,7 +2,7 @@ import HeatwaveBody from "./HeatwaveBody.vue";
 import HeatwaveHead from "./HeatwaveHeadByTown.vue";
 
 export default {
-    icon: "sun-bright",
+    icon: "temperature-high",
     title: "Nombre de sites sous alerte canicule",
     headComponent: HeatwaveHead,
     bodyComponent: HeatwaveBody,

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/cells/Towns/number_of_towns.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/cells/Towns/number_of_towns.js
@@ -2,7 +2,7 @@ import TownsBody from "./TownsBody.vue";
 import TownsHead from "./TownsHead.vue";
 
 export default {
-    icon: "map-pin",
+    icon: "location-dot",
     title: "Nombre de sites",
     headComponent: TownsHead,
     bodyComponent: TownsBody,

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartLivingCondition.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartLivingCondition.vue
@@ -5,7 +5,7 @@
         <div v-if="data !== undefined" class="flex mt-4 space-x-6">
             <ChartBigFigure
                 v-if="chartType === 'towns'"
-                icon="map-pin"
+                icon="location-dot"
                 :figure="formatStat(data.figures.towns_total.value)"
                 :evolution="formatStat(data.figures.towns_total.evolution)"
                 >Nombre total de sites</ChartBigFigure

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartTowns.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartTowns.vue
@@ -4,21 +4,21 @@
 
         <div class="flex mt-4 space-x-6">
             <ChartBigFigure
-                icon="map-pin"
+                icon="location-dot"
                 :figure="formatStat(data.figures.total.value)"
                 :evolution="formatStat(data.figures.total.evolution)"
                 >Tous sites</ChartBigFigure
             >
 
             <ChartBigFigure
-                icon="map-pin"
+                icon="location-dot"
                 :figure="formatStat(data.figures.less_than_10.value)"
                 :evolution="formatStat(data.figures.less_than_10.evolution)"
                 >Sites de moins de 10 habitants</ChartBigFigure
             >
 
             <ChartBigFigure
-                icon="map-pin"
+                icon="location-dot"
                 :figure="formatStat(data.figures.between_10_and_99.value)"
                 :evolution="
                     formatStat(data.figures.between_10_and_99.evolution)
@@ -27,7 +27,7 @@
             >
 
             <ChartBigFigure
-                icon="map-pin"
+                icon="location-dot"
                 :figure="formatStat(data.figures.more_than_99.value)"
                 :evolution="formatStat(data.figures.more_than_99.evolution)"
                 >Sites de plus de 100 habitants</ChartBigFigure

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/rows/HeaderRow.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/rows/HeaderRow.vue
@@ -25,30 +25,38 @@
                 /></span>
             </div>
         </th>
+
         <RbTitle
             tag="th"
             :title="col.title"
             @click="changeSort(col.uid)"
             class="text-right w-16 cursor-pointer bg-clip-padding bg-white hover:bg-G200"
-            v-for="col in columns"
+            v-for="(col, index) in columns"
             :key="col.uid"
         >
-            <Icon
-                v-if="!Object.keys(flagMap).includes(col.icon)"
-                class="text-lg text-black"
-                :icon="col.icon"
-            />
+            <ToolTip
+                class="inline-block ml-2 cursor-pointer"
+                :tip="col.title"
+                :side="index >= columns.length - 2 ? 'right' : 'left'"
+                extraStyle="bg-black/80 rounded-md shadow-md text-white text-left py-3 px-3"
+            >
+                <Icon
+                    v-if="!Object.keys(flagMap).includes(col.icon)"
+                    class="text-lg text-black"
+                    :icon="col.icon"
+                />
 
-            <img v-else :src="flagMap[col.icon].icon" class="w-6 ml-auto" />
-            <span
-                v-if="
-                    departementMetricsStore.sort[
-                        departementMetricsStore.activeTab
-                    ].id === col.uid
-                "
-                class="ml-2 text-G700"
-                ><Icon :icon="chevronState"
-            /></span>
+                <img v-else :src="flagMap[col.icon].icon" class="w-6 ml-auto" />
+                <span
+                    v-if="
+                        departementMetricsStore.sort[
+                            departementMetricsStore.activeTab
+                        ].id === col.uid
+                    "
+                    class="ml-2 text-G700"
+                    ><Icon :icon="chevronState"
+                /></span>
+            </ToolTip>
         </RbTitle>
         <th class="w-8 bg-white"></th>
     </tr>
@@ -59,6 +67,7 @@ import { computed, toRefs } from "vue";
 import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
 import { trackEvent } from "@/helpers/matomo";
 
+import ToolTip from "@resorptionbidonvilles/ui/src/components/ToolTip.vue";
 import flagFR from "@/assets/img/flags/fr.png";
 import flagEU from "@/assets/img/flags/eu.png";
 import flagExtraCommunautaires from "@/assets/img/flags/extra-communautaires.png";
@@ -72,7 +81,7 @@ const props = defineProps({
     },
 });
 const { columns } = toRefs(props);
-
+console.log("Columns", columns.value);
 const flagMap = {
     french: { icon: flagFR },
     european: { icon: flagEU },

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionLocalisation.vue/FicheActionLocalisation.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionLocalisation.vue/FicheActionLocalisation.vue
@@ -2,7 +2,7 @@
     <FicheRubrique title="Lieu" id="localisation">
         <FicheSousRubrique>
             <p>
-                <Icon icon="map-pin" class="mr-2" />
+                <Icon icon="location-dot" class="mr-2" />
                 <span class="font-bold">{{ label }}</span>
             </p>
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ruBG3e0W/2215-session-debugp1-icone-soleil-pour-canicule

## 🛠 Description de la PR
Cette PR remplace les icônes d'alerte canicule et de site pour les rendre plus parlants. Les 2 icônes ont été mises à jour sur la plateforme complète.
De plus, elle ajoute une tooltip pour aider à la compréhension. La tooltip s'activera en passant la souris sur l'icône en haut du tableau des données départementales.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/d0965e79-67b4-4c93-9047-1fdc6a9b7222)

## 🚨 Notes pour la mise en production
RàS