### PR TITLE
#patch : (2217) Modifications (design et wording) dans la partie visualisation de donnée

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/ChartBigFigure.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/ChartBigFigure.vue
@@ -8,8 +8,7 @@
             <Icon v-else class="text-xl" :icon="icon" />
             <span class="font-bold text-3xl">{{ figure }}</span>
             <span class="font-bold text-lg" :class="color"
-                >(<template v-if="evolution >= 0">+</template
-                >{{ evolution }} %)</span
+                >({{ formatedEvolution }})</span
             >
         </div>
         <label class="text-sm"><slot /></label>
@@ -79,5 +78,11 @@ const color = computed(() => {
     }
 
     return (evolution.value < 0 ? colors.positive : colors.negative).color;
+});
+
+const formatedEvolution = computed(() => {
+    return `${evolution.value >= 0 ? "+ " : "- "}${Math.abs(
+        evolution.value
+    )} %`;
 });
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/mZLxzm7u/2217-visu-donn%C3%A9es-v1-contenu-des-onglets-evolution-vue-d%C3%A9partementale

## 🛠 Description de la PR
La PR intègre des modifications visuelles:
- Suppression de l'onglet de visualisation de données des habitants (car doublon de l'onglet "synthèse")
- Suppression (temporaire) de l'onglet "juridique" en attendant l'intégration des datas de procédures administratives
- Mise en place d'un "gap de sécurité" sur l'affichage des graphs, donnant un delta de 2% à(aux) l'axe(s) Y pour éviter que la courbe ne dépasse l'axe

Elle apporte également des modifications de wording:
- Harmonisation du terme "intra UE" et "extra UE" sans tiret
- Ajout d'un espace entre le symbole mathématique et le chiffre dans les "big figures" d'évolution départementale de la visualisation de données

## 📸 Captures d'écran
Suppression d'onglets de visualisation de données:
![image](https://github.com/user-attachments/assets/73e69d3b-1bd1-40f6-8dbc-886658155e4b)

Harmonisation des termes "intra UE" et "extra UE":
![image](https://github.com/user-attachments/assets/12a188d7-22ce-4fc5-af5d-ba7603f7aad2)

Ajout de l'espace entre +/- et le chiffre:
![image](https://github.com/user-attachments/assets/48eaf344-7b14-4a29-ba05-be8815c3cfcd)

## 🚨 Notes pour la mise en production
Une erreur de gestion de branches fait que j'ai push dans 'develop' la majeure partie du patch. Mais aucun impact sur la MEP.