### PR TITLE
#patch: (2213) Refonte initiale de la visualisation de données et intégration du composant DSFR SegmentedSet+Segmented

### DIFF
--- a/packages/frontend/ui/src/components/Dsfr/DsfrSegmented.vue
+++ b/packages/frontend/ui/src/components/Dsfr/DsfrSegmented.vue
@@ -1,0 +1,68 @@
+<template>
+    <div class="fr-segmented__element text-xs">
+        <input
+            :id="id"
+            type="radio"
+            :name="name"
+            :value="value"
+            :checked="modelValue === value"
+            :disabled="disabled"
+            :aria-disabled="disabled"
+            v-bind="$attrs"
+            @change="handleChange"
+        />
+        <label :for="id" class="fr-label text-xs">
+          <Icon v-if="icon" :icon="icon" class="text-blue600" />
+            <span v-if="icon">&nbsp;</span>
+            {{ label }}
+        </label>
+    </div>
+</template>
+
+<script lang="js" setup>
+import { toRefs, computed } from 'vue'
+import { Icon } from "@resorptionbidonvilles/ui";
+import { default as getRandomId } from '../../utils/getRandomString.js';
+
+const props = defineProps({
+  hint: {type: String, default: ''},
+  icon: {type: String, default: null},
+  label: {type: String, default: ''},
+  modelValue: {type: String, default: ''},
+  name: {type: String, default: ''},
+  value: { type: String, required: true },
+  disabled: { type: Boolean, default: false }
+})
+
+const { icon, label, modelValue, value, disabled, name } = toRefs(props);
+const id = computed(() => getRandomId(4))
+const emit = defineEmits(['update:modelValue'])
+
+const handleChange = (event) => {
+  emit('update:modelValue', event.target.value)
+}
+</script>
+
+<style scoped>
+@import "@gouvfr/dsfr/dist/dsfr.css";
+@import "@gouvminint/vue-dsfr/styles";
+
+.fr-segmented__element {
+  --border-default-grey: var(--grey-900-175);
+  --grey-900-175: #ddd;
+  --border-active-blue-france: #000091;
+  --text-active-blue-france: #000091;
+}
+
+.fr-segmented__element input:hover {
+  --background-default-grey-hover: var(--grey-1000-50-hover);
+  --grey-1000-50-hover: #f6f6f6;
+}
+
+.fr-segmented__element input:checked+label {
+  box-shadow: inset 0 0 0 1px #000091;
+  box-shadow: inset 0 0 0 1px var(--border-active-blue-france);
+  color: #000091;
+  color: var(--text-active-blue-france);
+}
+</style>

--- a/packages/frontend/ui/src/components/Dsfr/DsfrSegmentedSet.vue
+++ b/packages/frontend/ui/src/components/Dsfr/DsfrSegmentedSet.vue
@@ -1,0 +1,123 @@
+<template>
+    <div class="fr-form-group">
+        <fieldset
+            class="fr-segmented"
+            :class="{
+                'fr-segmented--sm': small,
+                'fr-segmented--no-legend': !legend,
+            }"
+            :disabled="disabled"
+        >
+            <legend
+                v-if="legend"
+                :id="titleId"
+                class="fr-segmented__legend"
+                :class="{
+                    'fr-segmented__legend--inline': inline,
+                }"
+            >
+                <slot name="legend">
+                    {{ legend }}
+                </slot>
+                <span v-if="hint" class="fr-hint-text">
+                    {{ hint }}
+                </span>
+            </legend>
+
+            <div class="fr-segmented__elements">
+                <slot>
+                    <Segmented
+                        v-for="(option, i) of options"
+                        :key="option.value || i"
+                        :name="name || option.name"
+                        v-bind="{
+                            ...option,
+                            disabled: disabled || option.disabled,
+                        }"
+                        v-model="localValue"
+                    />
+                </slot>
+            </div>
+        </fieldset>
+    </div>
+    <DsfrSegmented />
+</template>
+
+<script lang="js" setup>
+import { toRefs, computed } from 'vue'
+import Segmented from './DsfrSegmented.vue'
+import { default as getRandomId } from '../../utils/getRandomString.js'
+
+const props = defineProps({
+  titleId: () => getRandomId('radio-button', 'group'),
+  legend: {
+    type: String,
+    default: '',
+  },
+  name: {
+    type: String,
+    default: 'no-name'
+},
+  options: {
+    type: Array,
+    required: true,
+    default: () => []
+  },
+  small: {
+    type: Boolean,
+    default: false
+  },
+  disabled: {
+    type: Boolean,
+    default: false
+  },
+  modelValue: {
+    type: String,
+    default: ''
+  }
+})
+
+const { titleId, legend, name, options } = toRefs(props);
+
+
+const emit = defineEmits(['update:modelValue'])
+
+const onChange = ($event) => {
+  if ($event === props.modelValue) {
+    return
+  }
+  emit('update:modelValue', $event)
+}
+
+const localValue = computed({
+  get: () => props.modelValue,
+  set: (val) => emit('update:modelValue', val)
+})
+</script>
+
+<style scoped>
+@import "@gouvfr/dsfr/dist/dsfr.css";
+@import "@gouvminint/vue-dsfr/styles";
+
+.fr-segmented__elements {
+  --border-default-grey: var(--grey-900-175);
+  --grey-900-175: #ddd;
+  @apply verticalSet;
+}
+
+@media (screen(lg)) {
+  .fr-segmented__elements {
+    @apply horizontalSet
+  }
+}
+
+.verticalSet {
+  flex-direction: column;
+  margin-left: 0;
+}
+
+.horizontalSet {
+  flex-direction: row;
+  margin-left: 0;
+}
+</style>

--- a/packages/frontend/ui/src/index.mjs
+++ b/packages/frontend/ui/src/index.mjs
@@ -11,6 +11,7 @@ export { default as CheckboxUi } from './components/Input/CheckboxUi.vue';
 export { default as ContentWrapper } from './components/ContentWrapper.vue';
 export { default as DatepickerInput } from './components/Input/DatepickerInput.vue';
 export { default as Dropdown } from './components/Dropdown.vue';
+export { default as DsfrSegmentedSet } from './components/Dsfr/DsfrSegmentedSet.vue';
 export { default as ErrorSummary } from './components/ErrorSummary.vue';
 export { default as Fieldset } from './components/Fieldset.vue';
 export { default as FilArianne } from './components/FilArianne.vue';

--- a/packages/frontend/webapp/package.json
+++ b/packages/frontend/webapp/package.json
@@ -12,6 +12,8 @@
     "lint:all": "eslint --no-error-on-unmatched-pattern --max-warnings=0 --ext .vue,.js,.jsx,.cjs,.mjs src cypress public"
   },
   "dependencies": {
+    "@gouvfr/dsfr": "1.12.1",
+    "@gouvminint/vue-dsfr": "^5.19.0",
     "@sentry/vue": "^7.54.0",
     "@turf/turf": "^6.5.0",
     "@vuepic/vue-datepicker": "^3.5.3",

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/DonneesStatistiquesDepartementOnglets.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/DonneesStatistiquesDepartementOnglets.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="pt-4 px-4 mb-6 border-b-1 border-b-g300">
+    <div class="pt-4 px-4 mb-0 border-b-1 border-b-g300">
         <Tab
             @click="switchTab(tab.id)"
             v-for="tab in tabs"

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/chartTabs/EvolutionCharts.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/chartTabs/EvolutionCharts.vue
@@ -1,62 +1,4 @@
 <template>
-    <header class="flex flex-col xl:flex-row lg:space-x-4 justify-between">
-        <div class="flex space-x-4 items-end">
-            <div>
-                <p>Du</p>
-                <DatepickerInput
-                    withoutMargin
-                    :maxDate="to"
-                    name="from"
-                    :disabled="departementMetricsStore.evolution.isLoading"
-                />
-            </div>
-            <div>
-                <p>Au</p>
-                <DatepickerInput
-                    withoutMargin
-                    :minDate="from"
-                    :maxDate="today"
-                    name="to"
-                    :disabled="departementMetricsStore.evolution.isLoading"
-                />
-            </div>
-
-            <Button
-                v-if="
-                    !departementMetricsStore.evolution.isLoading &&
-                    datesAreNotLoaded &&
-                    values.from &&
-                    values.to
-                "
-                @click="update"
-                >Valider</Button
-            >
-        </div>
-        <div class="hidden xl:block">
-            <p>&nbsp;</p>
-            <p class="flex space-x-4 items-center">
-                <Button
-                    variant="primaryOutline"
-                    :disabled="departementMetricsStore.evolution.isLoading"
-                    @click="setLastYear"
-                    >L'année dernière</Button
-                >
-                <Button
-                    variant="primaryOutline"
-                    :disabled="departementMetricsStore.evolution.isLoading"
-                    @click="setLastMonth"
-                    >Le mois dernier</Button
-                >
-                <Button
-                    variant="primaryOutline"
-                    :disabled="departementMetricsStore.evolution.isLoading"
-                    @click="setLastWeek"
-                    >La semaine dernière</Button
-                >
-            </p>
-        </div>
-    </header>
-
     <div
         class="mt-12 text-center text-3xl text-primary"
         v-if="departementMetricsStore.evolution.isLoading"
@@ -80,11 +22,8 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
-import { useForm } from "vee-validate";
-import { trackEvent } from "@/helpers/matomo";
+import { computed } from "vue";
 
-import { Button, DatepickerInput, Spinner } from "@resorptionbidonvilles/ui";
 import ViewErrorInline from "@/components/ViewErrorInline/ViewErrorInline.vue";
 import EvolutionChartTabSummary from "./EvolutionChartTabSummary.vue";
 import EvolutionChartTabInhabitants from "./EvolutionChartTabInhabitants.vue";
@@ -105,101 +44,4 @@ const tabs = {
 const currentTabComponent = computed(() => {
     return tabs[departementMetricsStore.activeTab];
 });
-
-const today = ref(new Date());
-
-const { values, setFieldValue } = useForm({
-    initialValues: {
-        from: new Date(departementMetricsStore.evolution.from),
-        to: new Date(departementMetricsStore.evolution.to),
-    },
-});
-
-const datesAreNotLoaded = computed(() => {
-    if (
-        !departementMetricsStore.evolution.loaded.from ||
-        !departementMetricsStore.evolution.loaded.to
-    ) {
-        return true;
-    }
-
-    if (!values.from || !values.to) {
-        return false;
-    }
-
-    return (
-        values.from.toISOString().slice(0, 10) !==
-            departementMetricsStore.evolution.loaded.from
-                .toISOString()
-                .slice(0, 10) ||
-        values.to.toISOString().slice(0, 10) !==
-            departementMetricsStore.evolution.loaded.to
-                .toISOString()
-                .slice(0, 10)
-    );
-});
-
-function setLastYear() {
-    const newTo = new Date();
-    newTo.setDate(new Date().getDate() - 1);
-
-    const newFrom = new Date();
-    newFrom.setDate(new Date().getDate() - 1);
-    newFrom.setFullYear(new Date().getFullYear() - 1);
-
-    setFieldValue("from", newFrom);
-    setFieldValue("to", newTo);
-    trackEvent(
-        "Visualisation des données départementales",
-        "Changement dates",
-        "L'année dernière"
-    );
-    update();
-}
-
-function setLastMonth() {
-    const newTo = new Date();
-    newTo.setDate(new Date().getDate() - 1);
-
-    const newFrom = new Date();
-    newFrom.setDate(new Date().getDate() - 1);
-    newFrom.setMonth(new Date().getMonth() - 1);
-
-    setFieldValue("from", newFrom);
-    setFieldValue("to", newTo);
-    trackEvent(
-        "Visualisation des données départementales",
-        "Changement dates",
-        "Le mois dernier"
-    );
-    update();
-}
-
-function setLastWeek() {
-    const newTo = new Date();
-    newTo.setDate(new Date().getDate() - 1);
-
-    const newFrom = new Date();
-    newFrom.setDate(new Date().getDate() - 8);
-
-    setFieldValue("from", newFrom);
-    setFieldValue("to", newTo);
-    trackEvent(
-        "Visualisation des données départementales",
-        "Changement dates",
-        "La semaine dernière"
-    );
-    update();
-}
-
-function update() {
-    departementMetricsStore.evolution.from = values.from;
-    departementMetricsStore.evolution.to = values.to;
-    trackEvent(
-        "Visualisation des données départementales",
-        "Changement dates",
-        `${values.from.toLocaleDateString()} - ${values.to.toLocaleDateString()}`
-    );
-    departementMetricsStore.fetchEvolution(departementMetricsStore.departement);
-}
 </script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/FiltrageTemporel.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/FiltrageTemporel.vue
@@ -1,0 +1,59 @@
+<template>
+    <div>
+        <DsfrSegmentedSet
+            :small="true"
+            :options="[
+                {
+                    label: 'Les 2 années écoulées',
+                    value: '2-annees-ecoulees',
+                    icon: 'chart-simple',
+                },
+                {
+                    label: 'L\'année écoulée',
+                    value: 'annee-ecoulee',
+                    icon: 'chart-simple',
+                },
+                {
+                    label: 'Le mois passé',
+                    value: 'mois-passe',
+                    icon: 'chart-simple',
+                },
+                {
+                    label: 'Les 7 derniers jours',
+                    value: '7-derniers-jours',
+                    icon: 'chart-simple',
+                },
+                {
+                    label: 'Période personnalisée',
+                    value: 'periode-personnalisee',
+                    icon: 'chart-simple',
+                },
+                {
+                    label: 'Situation à date',
+                    value: 'situation-a-date',
+                    icon: 'table-list',
+                },
+            ]"
+            v-model="selectedOption"
+            name="synthese-timelaps"
+        />
+    </div>
+</template>
+
+<script setup>
+import { ref, watch } from "vue";
+import { DsfrSegmentedSet } from "@resorptionbidonvilles/ui";
+
+import updateDataRange from "../../utils/updateDataRange";
+
+const selectedOption = ref("2-annees-ecoulees");
+const emit = defineEmits(["update:modelValue"]);
+
+watch(selectedOption, (value) => {
+    const optionsNoTrigger = ["periode-personnalisee"];
+    if (!optionsNoTrigger.includes(value)) {
+        updateDataRange(value);
+    }
+    emit("update:modelValue", value);
+});
+</script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/PeriodePersonnalisee.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/PeriodePersonnalisee.vue
@@ -1,0 +1,115 @@
+<template>
+    <div class="flex flex-col space-x-4 items-start my-4 pb-6 border-y-1">
+        <div class="flex flex-row w-full justify-between">
+            <p class="text-md font-bold py-4">Période personnalisée</p>
+            <Icon class="mr-2 content-center" icon="angle-down" />
+        </div>
+        <div class="flex flex-row gap-4">
+            <div>
+                <p>Du</p>
+                <DatepickerInput
+                    withoutMargin
+                    :maxDate="to"
+                    name="from"
+                    v-model="departementMetricsStore.evolution.from"
+                    :disabled="departementMetricsStore.evolution.isLoading"
+                />
+            </div>
+            <div>
+                <p>Au</p>
+                <DatepickerInput
+                    withoutMargin
+                    :minDate="from"
+                    :maxDate="today"
+                    name="to"
+                    v-model="departementMetricsStore.evolution.to"
+                    :disabled="departementMetricsStore.evolution.isLoading"
+                />
+            </div>
+
+            <Button
+                v-if="
+                    !departementMetricsStore.evolution.isLoading &&
+                    datesAreNotLoaded &&
+                    values.from &&
+                    values.to
+                "
+                class="h-9 mb-px place-self-end"
+                @click="update"
+                >Valider</Button
+            >
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { toRefs, computed, watch } from "vue";
+import { useForm } from "vee-validate";
+
+import { Button, DatepickerInput, Icon } from "@resorptionbidonvilles/ui";
+import { useDepartementMetricsStore } from "@/stores/metrics.departement.store.js";
+import updateDataRange from "../../utils/updateDataRange";
+
+const props = defineProps({
+    dateRange: { type: String, required: true },
+});
+const { dateRange } = toRefs(props);
+const today = new Date();
+const departementMetricsStore = useDepartementMetricsStore();
+
+const { values } = useForm({
+    initialValues: {
+        from: new Date(departementMetricsStore.evolution.from),
+        to: new Date(departementMetricsStore.evolution.to),
+    },
+});
+
+const to = computed(() => {
+    const todayMinor1 = new Date().setDate(today.getDate() - 1);
+    const toMinor1 = new Date(departementMetricsStore.evolution.to).setDate(
+        new Date(departementMetricsStore.evolution.to).getDate() - 1
+    );
+
+    return todayMinor1 < toMinor1 ? todayMinor1 : toMinor1;
+});
+
+const from = computed(() => {
+    const fromPlus1 = new Date(departementMetricsStore.evolution.from).setDate(
+        new Date(departementMetricsStore.evolution.from).getDate() + 1
+    );
+
+    return today < fromPlus1 ? today : fromPlus1;
+});
+
+const datesAreNotLoaded = computed(() => {
+    if (
+        !departementMetricsStore.evolution.loaded.from ||
+        !departementMetricsStore.evolution.loaded.to
+    ) {
+        return true;
+    }
+
+    if (!values.from || !values.to) {
+        return false;
+    }
+
+    return (
+        values.from.toISOString().slice(0, 10) !==
+            departementMetricsStore.evolution.loaded.from
+                .toISOString()
+                .slice(0, 10) ||
+        values.to.toISOString().slice(0, 10) !==
+            departementMetricsStore.evolution.loaded.to
+                .toISOString()
+                .slice(0, 10)
+    );
+});
+
+const update = () => {
+    updateDataRange(null, values.from, values.to);
+};
+
+watch(dateRange, () => {
+    update();
+});
+</script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/rows/HeaderRow.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/rows/HeaderRow.vue
@@ -81,7 +81,7 @@ const props = defineProps({
     },
 });
 const { columns } = toRefs(props);
-console.log("Columns", columns.value);
+
 const flagMap = {
     french: { icon: flagFR },
     european: { icon: flagEU },

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/updateDataRange.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/updateDataRange.js
@@ -1,0 +1,48 @@
+import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
+import { trackEvent } from "@/helpers/matomo";
+
+const departementMetricsStore = useDepartementMetricsStore();
+
+export default (dateRange = null, from = null, to = null) => {
+    if (dateRange) {
+        departementMetricsStore.currentFormat = "summary";
+        departementMetricsStore.activeTab = "summary";
+        if (dateRange === "2-annees-ecoulees") {
+            from = new Date(
+                new Date().setFullYear(new Date().getFullYear() - 2)
+            );
+            to = new Date(new Date().setDate(new Date().getDate() - 1));
+        }
+        if (dateRange === "annee-ecoulee") {
+            from = new Date(
+                new Date().setFullYear(new Date().getFullYear() - 1)
+            );
+            to = new Date(new Date().setDate(new Date().getDate() - 1));
+        }
+        if (dateRange === "mois-passe") {
+            from = new Date(new Date().setMonth(new Date().getMonth() - 1));
+            to = new Date(new Date().setDate(new Date().getDate() - 1));
+        }
+        if (dateRange === "7-derniers-jours") {
+            from = new Date(new Date().setDate(new Date().getDate() - 7));
+            to = new Date(new Date().setDate(new Date().getDate() - 1));
+        }
+        if (dateRange === "situation-a-date") {
+            departementMetricsStore.currentFormat = "table";
+            return;
+        }
+    }
+
+    if (from && to) {
+        departementMetricsStore.evolution.from = from;
+        departementMetricsStore.evolution.to = to;
+        trackEvent(
+            "Visualisation des données départementales",
+            "Changement dates",
+            `${from.toLocaleDateString()} - ${to.toLocaleDateString()}`
+        );
+        departementMetricsStore.fetchEvolution(
+            departementMetricsStore.departement
+        );
+    }
+};

--- a/packages/frontend/webapp/src/stores/metrics.departement.store.js
+++ b/packages/frontend/webapp/src/stores/metrics.departement.store.js
@@ -21,7 +21,7 @@ export const useDepartementMetricsStore = defineStore(
             justice: { id: "city_name", order: "asc" },
         });
         const metrics = ref({});
-        const currentFormat = ref("table");
+        const currentFormat = ref("summary");
         const evolution = {
             from: ref(new Date()),
             to: ref(new Date()),
@@ -72,6 +72,7 @@ export const useDepartementMetricsStore = defineStore(
         function reset() {
             departement.value = null;
             activeTab.value = "summary";
+            currentFormat.value = "summary";
             error.value = null;
             sort.value = {
                 summary: { id: "city_name", order: "asc" },
@@ -81,7 +82,6 @@ export const useDepartementMetricsStore = defineStore(
                 justice: { id: "city_name", order: "asc" },
             };
             metrics.value = {};
-            currentFormat.value = "table";
             collapsedCities.value = {};
             evolution.from.value.setTime(new Date());
             evolution.to.value.setTime(new Date());
@@ -93,8 +93,9 @@ export const useDepartementMetricsStore = defineStore(
             evolution.error.value = null;
             evolution.data.value = null;
             lastMapView.value = null;
-
-            evolution.from.value.setDate(evolution.from.value.getDate() - 8);
+            evolution.from.value.setFullYear(
+                evolution.from.value.getFullYear() - 2
+            );
             evolution.to.value.setDate(evolution.to.value.getDate() - 1);
         }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/vMy9gpgB/2213-visu-donn%C3%A9es-v1-refonte-du-bandeau-evolution-situation-%C3%A0-date-vue-d%C3%A9partementale

## 🛠 Description de la PR
La PR amène un nouveau design de la fonctionnalité de filtrage temporel sur la visualisation de données. Elle intègre le premier composant provenant de @gouvfr/dsfr (segmentedSet).
Elle amène un changement d'affichage par défaut, mettant en avant les graphiques d'évolution plutôt que la situation à date.
Le composant DSFR tel qu'utilisé génère également une modification du design de période personnalisée pour ne l'afficher qu'en cas de besoin.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/e483f248-d0e0-40e3-a8c3-632f25a6f4f6)
![image](https://github.com/user-attachments/assets/d25effaf-c065-4848-a160-11056e468747)

## 🚨 Notes pour la mise en production
RàS