### PR TITLE
patch: (2228) Intégration du tracking d'event sur le composant de recherche

### DIFF
--- a/packages/frontend/webapp/src/components/InputLocation/InputLocation.vue
+++ b/packages/frontend/webapp/src/components/InputLocation/InputLocation.vue
@@ -13,6 +13,7 @@ import { defineProps, toRefs, computed, defineEmits, ref } from "vue";
 import { Autocomplete } from "@resorptionbidonvilles/ui";
 import { autocomplete } from "@/api/locations.api.js";
 import formatLocationLabel from "@/utils/formatLocationLabel.js";
+import { trackEvent } from "@/helpers/matomo";
 
 const props = defineProps({
     modelValue: {
@@ -29,6 +30,13 @@ const location = computed({
         return modelValue.value;
     },
     set(value) {
+        if (value) {
+            trackEvent(
+                "Recherche autocomplete",
+                "Utilisation du module de recherche",
+                `${window.location.href.split("/").pop()}: ${value.search}`
+            );
+        }
         emit("update:modelValue", value);
     },
 });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/0w1RoRVV/2228-tb-ajout-du-tracking-sur-les-recherches

## 🛠 Description de la PR
Cette PR ajoute un tracking Matomo sur les events de recherche sur le Tableau de Bord, les sites, actions et zone d'entraide afin de déterminer son niveau utilisation.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS