### PR TITLE
#patch: (2230) Amélioration des graphiques d'évolution nationale

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiques/DonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/DonneesStatistiques.vue
@@ -37,7 +37,10 @@
                     :metrics="metricsStore.filteredMetrics"
                     :collapseByDefault="metricsStore.metrics.length > 1"
                 />
-                <EvolutionNationale v-if="activeTab === 'evolution'" />
+                <EvolutionNationale
+                    v-if="activeTab === 'evolution'"
+                    class="pt-6"
+                />
             </template>
         </main>
     </ContentWrapper>

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
@@ -124,14 +124,14 @@ const options = computed(() => {
                     },
                     axisLabel: {
                         formatter: (value) => {
-                            return value.toLocaleString();
+                            return Math.floor(value).toLocaleString();
                         },
                     },
                     splitLine: {
                         show: false,
                     },
                     min: function (value) {
-                        return value.min - value.min * 0.04;
+                        return Math.floor(value.min - value.min * 0.04);
                     },
                 },
                 {
@@ -140,7 +140,7 @@ const options = computed(() => {
                     position: "right",
                     alignTicks: false,
                     min: function (value) {
-                        return value.min - value.min * 0.04;
+                        return Math.floor(value.min - value.min * 0.04);
                     },
                     max: "dataMax",
                     axisLine: {
@@ -151,7 +151,7 @@ const options = computed(() => {
                     },
                     axisLabel: {
                         formatter: (value) => {
-                            return value.toLocaleString();
+                            return Math.floor(value).toLocaleString();
                         },
                     },
                     splitLine: {

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
@@ -130,13 +130,18 @@ const options = computed(() => {
                     splitLine: {
                         show: false,
                     },
+                    min: function (value) {
+                        return value.min - value.min * 0.04;
+                    },
                 },
                 {
                     type: "value",
                     name: "Sites",
                     position: "right",
                     alignTicks: false,
-                    min: 0,
+                    min: function (value) {
+                        return value.min - value.min * 0.04;
+                    },
                     max: "dataMax",
                     axisLine: {
                         show: true,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/tXIDedSo/2230-mettre-en-avant-l%C3%A9volution-nationale-sur-les-graphiques

## 🛠 Description de la PR
Cette PR améliore la lisibilité et compréhension des graphiques d'évolution nationale en augmentant le contraste mathématique entre les points "max" et pointes "min".

## 📸 Captures d'écran
Cette courbe quasiment plate:
![image](https://github.com/user-attachments/assets/d9afe663-f752-4896-abc3-193c6a9e1540)
Va devenir:
![image](https://github.com/user-attachments/assets/b71a734b-44b7-4739-ac1c-e87b18ce2df4)

## 🚨 Notes pour la mise en production
RàS