### PR TITLE
#patch: (2224) Filtrage des données d'évolution nationales sur la France métropolitaine uniquement

### DIFF
--- a/packages/api/server/models/metricsModel/getNationalEvolutionData.ts
+++ b/packages/api/server/models/metricsModel/getNationalEvolutionData.ts
@@ -33,6 +33,12 @@ export default async (user, from: Date, to: Date): Promise<NationalEvolutionMetr
     shantytown_origins
   JOIN
     shantytowns ON shantytowns.shantytown_id = shantytown_origins.fk_shantytown
+  JOIN
+    cities AS c ON shantytowns.fk_city = c.code
+  JOIN
+    departements AS d ON c.fk_departement = d.code
+  WHERE
+    d.code NOT IN ('971', '972', '973', '974', '975', '976', '977', '978', '984', '986', '987', '988', '989')
   GROUP BY
     fk_shantytown
   HAVING
@@ -53,6 +59,12 @@ LEFT JOIN shantytowns st ON
   AND st.shantytown_id IN (SELECT fk_shantytown FROM aggregated_origins)
 LEFT JOIN aggregated_origins ao ON
   st.shantytown_id = ao.fk_shantytown
+JOIN
+  cities AS c ON st.fk_city = c.code
+JOIN
+  departements AS d ON c.fk_departement = d.code
+WHERE
+  d.code NOT IN ('971', '972', '973', '974', '975', '976', '977', '978', '984', '986', '987', '988', '989')
 GROUP BY
   ms.month
 ORDER BY

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
@@ -3,8 +3,8 @@
     <section v-else>
         <section class="mb-8">
             <h1 class="font-bold text-primary text-lg">
-                Nombre de sites et d'habitants (exclusivement intra UE et + de
-                10 personnes)
+                Nombre de sites et d'habitants en France métropolitaine
+                (exclusivement intra UE et + de 10 personnes)
             </h1>
             <LineChart
                 class="mt-6"
@@ -15,8 +15,8 @@
         </section>
         <section>
             <h1 class="font-bold text-primary text-lg">
-                Nombre de sites et d'habitants (toutes origines et + de 10
-                personnes)
+                Nombre de sites et d'habitants en France métropolitaine (toutes
+                origines et + de 10 personnes)
             </h1>
             <LineChart
                 class="mt-6"

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
@@ -134,7 +134,7 @@ const options = computed(() => {
                         return Math.floor(value.min - value.min * 0.04);
                     },
                     max: function (value) {
-                        return Math.ceil(value.max + value.max * 0.02);
+                        return Math.ceil(value.max + value.max * 0.04);
                     },
                 },
                 {

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
@@ -133,6 +133,9 @@ const options = computed(() => {
                     min: function (value) {
                         return Math.floor(value.min - value.min * 0.04);
                     },
+                    max: function (value) {
+                        return Math.ceil(value.max + value.max * 0.02);
+                    },
                 },
                 {
                     type: "value",
@@ -142,7 +145,9 @@ const options = computed(() => {
                     min: function (value) {
                         return Math.floor(value.min - value.min * 0.04);
                     },
-                    max: "dataMax",
+                    max: function (value) {
+                        return Math.ceil(value.max + value.max * 0.04);
+                    },
                     axisLine: {
                         show: true,
                     },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JqKWjxw3/2224-update-filtrer-les-graphs-d%C3%A9volution-nationale-pour-supprimer-les-sites-o-m

## 🛠 Description de la PR
La PR ajoute un filtrage par défaut des sites Outre-Mer sur les graphiques d'évolution nationale. Le titre des graphique intègre aussi une spécification "France métropolitaine".
De plus, la PR ajoute une modification des axes Y pour assurer un affichage correct des données max.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/f83db7e3-539f-4ffb-8771-8027ed256c94)

## 🚨 Notes pour la mise en production
RàS