### PR TITLE
#patch: (2218) Refonte de l'onglet synthèse des données départementales

### DIFF
--- a/packages/api/server/services/metrics/_utils/initializeDepartementEvolutionMetrics.ts
+++ b/packages/api/server/services/metrics/_utils/initializeDepartementEvolutionMetrics.ts
@@ -9,6 +9,14 @@ export default (listOfDateLabels: string[]):DepartementMetricsEvolution => {
         inhabitants: {
             towns: {
                 figures: {
+                    european: {
+                        value: 0,
+                        evolution: 0,
+                    },
+                    foreign: {
+                        value: 0,
+                        evolution: 0,
+                    },
                     total: {
                         value: 0,
                         evolution: 0,
@@ -28,6 +36,8 @@ export default (listOfDateLabels: string[]):DepartementMetricsEvolution => {
                 },
                 charts: {
                     labels: listOfDateLabels,
+                    european: zeros(n),
+                    foreign: zeros(n),
                     total: zeros(n),
                     less_than_10: zeros(n),
                     between_10_and_99: zeros(n),

--- a/packages/api/server/services/metrics/_utils/initializeListOfDates.ts
+++ b/packages/api/server/services/metrics/_utils/initializeListOfDates.ts
@@ -19,7 +19,7 @@ export default (argFrom: Date, argTo: Date): DateObject[] => {
 
     let diff = getMonthDiff(argFrom, argTo);
     let step = 'months';
-    let format = 'MMMM';
+    let format = 'MMMM YYYY';
 
 
     if (diff < 3) {

--- a/packages/api/server/services/metrics/getDepartementEvolutionMetrics.ts
+++ b/packages/api/server/services/metrics/getDepartementEvolutionMetrics.ts
@@ -82,9 +82,11 @@ export default async (user: User, departementCode: string, argFrom: Date, argTo:
             }
             if (row.origins.length === 1 && row.origins[0] === 'european') {
                 metrics.inhabitants.inhabitants.charts.european[i] += row.population_total;
+                metrics.inhabitants.towns.charts.european[i] += 1;
             }
             if (row.origins.length === 1 && row.origins[0] === 'other') {
                 metrics.inhabitants.inhabitants.charts.foreign[i] += row.population_total;
+                metrics.inhabitants.towns.charts.foreign[i] += 1;
             }
 
             // on remplit les chiffres des conditions de vie

--- a/packages/api/types/resources/DepartementMetricsEvolution.d.ts
+++ b/packages/api/types/resources/DepartementMetricsEvolution.d.ts
@@ -2,6 +2,14 @@ export type DepartementMetricsEvolution = {
     inhabitants: {
         towns: {
             figures: {
+                european: {
+                    value: number,
+                    evolution: number,
+                },
+                foreign: {
+                    value: number,
+                    evolution: number,
+                },
                 total: {
                     value: number,
                     evolution: number,
@@ -21,6 +29,8 @@ export type DepartementMetricsEvolution = {
             },
             charts: {
                 labels: string[],
+                european: number[],
+                foreign: number[],
                 total: number[],
                 less_than_10: number[],
                 between_10_and_99: number[],

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/chartTabs/EvolutionChartTabSummary.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/chartTabs/EvolutionChartTabSummary.vue
@@ -1,24 +1,9 @@
 <template>
-    <EvolutionChartInhabitants />
-    <EvolutionChartTowns class="mt-6" />
-    <EvolutionChartLivingCondition
-        class="mt-6"
-        chartLabel="Sites avec accès à l'eau"
-        :data="data.water"
-        chartType="towns"
-        icon="faucet-drip"
-        livingConditionType="towns_with_access_to_water"
-        ><template v-slot:title> Accès à l'eau </template>
-    </EvolutionChartLivingCondition>
+    <EvolutionChartEurope />
+    <EvolutionChartForeigner class="mt-6" />
 </template>
 
 <script setup>
-import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
-
-import EvolutionChartInhabitants from "../charts/EvolutionChartInhabitants.vue";
-import EvolutionChartTowns from "../charts/EvolutionChartTowns.vue";
-import EvolutionChartLivingCondition from "../charts/EvolutionChartLivingCondition.vue";
-
-const departementMetricsStore = useDepartementMetricsStore();
-const data = departementMetricsStore.evolution.data.livingConditions;
+import EvolutionChartEurope from "../charts/EvolutionChartEurope.vue";
+import EvolutionChartForeigner from "../charts/EvolutionChartForeigner.vue";
 </script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/ChartBigFigure.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/ChartBigFigure.vue
@@ -1,17 +1,21 @@
 <template>
     <article>
         <div
-            class="px-2 py-3 flex items-center justify-center space-x-2"
+            class="p-2 flex justify-center rounded-md flex-col"
             :class="background"
         >
-            <img v-if="img" :src="img" width="40" :alt="alt" />
-            <Icon v-else class="text-xl" :icon="icon" />
-            <span class="font-bold text-3xl">{{ figure }}</span>
-            <span class="font-bold text-lg" :class="color"
-                >({{ formatedEvolution }})</span
-            >
+            <div class="flex flex-col md:flex-row gap-2 items-center">
+                <div class="flex flex-row gap-2 items-center">
+                    <img v-if="img" :src="img" class="w-9 h-6" :alt="alt" />
+                    <Icon v-else class="text-xl" :icon="icon" />
+                    <span class="font-bold text-3xl">{{ figure }}</span>
+                </div>
+                <span class="font-bold text-lg" :class="color"
+                    >({{ formatedEvolution }})</span
+                >
+            </div>
+            <label class="text-sm text-center md:text-left"><slot /></label>
         </div>
-        <label class="text-sm"><slot /></label>
     </article>
 </template>
 

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartEurope.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartEurope.vue
@@ -1,0 +1,181 @@
+<template>
+    <section>
+        <h1 class="font-bold text-primary text-lg">
+            Nombre de sites et d'habitants (exclusivement intra UE)
+        </h1>
+
+        <div class="flex mt-4 space-x-6">
+            <ChartBigFigure
+                :img="flagEU"
+                alt="Estimation du nombre d'habitants intra UE"
+                :figure="formatStat(data.inhabitants.figures.european.value)"
+                :evolution="
+                    formatStat(data.inhabitants.figures.european.evolution)
+                "
+                >Sites exclusivement intra UE</ChartBigFigure
+            >
+
+            <ChartBigFigure
+                icon="location-dot"
+                :figure="formatStat(data.towns.figures.total.value)"
+                :evolution="formatStat(data.towns.figures.total.evolution)"
+                >Tous sites</ChartBigFigure
+            >
+        </div>
+
+        <LineChart
+            class="mt-6"
+            :chartOptions="options"
+            :chartData="chartData.datasets"
+            :graphId="`evolution-inhabitants`"
+        />
+    </section>
+</template>
+
+<script setup>
+import formatStat from "@/utils/formatStat";
+import { computed } from "vue";
+import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
+import LineChart from "@/components/Graphs/GraphBase.vue";
+import ChartBigFigure from "./ChartBigFigure.vue";
+import flagEU from "@/assets/img/flags/eu.png";
+import chartOptions from "../../utils/GraphiquesDonneesStatistiques/ChartOptions";
+import generateDataset from "../../utils/GraphiquesDonneesStatistiques/generateDataset";
+
+const departementMetricsStore = useDepartementMetricsStore();
+const data = departementMetricsStore.evolution.data.inhabitants;
+
+const chartData = computed(() => {
+    const datasets = [
+        generateDataset(
+            "Habitants intra UE",
+            "81, 108, 157",
+            data.inhabitants.charts.european,
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
+        ),
+        generateDataset(
+            "Sites exclusivement intra UE",
+            "0, 0, 255",
+            data.towns.charts.total,
+            {
+                yAxisIndex: 1,
+                lineStyle: { width: 2, color: "rgba(0, 0, 255, 1)" },
+                symbolSize: 1,
+            }
+        ),
+    ];
+
+    return {
+        labels: data.inhabitants.charts.labels,
+        datasets,
+    };
+});
+
+// const options = computed(() => {
+//     return {
+//         ...chartOptions.line,
+//         options: {
+//             ...chartOptions.line.options,
+//             xAxis: {
+//                 ...chartOptions.line.options.xAxis,
+//                 data: data.inhabitants.charts.labels,
+//                 axisTick: {
+//                     show: true,
+//                     alignWithLabel: false,
+//                     interval: 0,
+//                 },
+//             },
+//         },
+//     };
+// });
+
+const options = computed(() => {
+    return {
+        ...chartOptions.line,
+        options: {
+            ...chartOptions.line.options,
+            xAxis: {
+                ...chartOptions.line.options.xAxis,
+                data: data.inhabitants.charts.labels,
+                axisTick: {
+                    show: true,
+                    alignWithLabel: false,
+                    interval: 0,
+                },
+            },
+            yAxis: [
+                {
+                    type: "value",
+                    name: "Habitants",
+                    position: "left",
+                    alignTicks: true,
+                    axisLine: {
+                        show: true,
+                    },
+                    axisTick: {
+                        show: true,
+                    },
+                    axisLabel: {
+                        formatter: (value) => {
+                            return Math.floor(value).toLocaleString();
+                        },
+                    },
+                    splitLine: {
+                        show: false,
+                    },
+                    min: function (value) {
+                        return Math.floor(value.min - value.min * 0.1);
+                    },
+                    max: function (value) {
+                        return Math.ceil(value.max + value.max * 0.04);
+                    },
+                },
+                {
+                    type: "value",
+                    name: "Sites",
+                    position: "right",
+                    alignTicks: false,
+                    min: function (value) {
+                        return Math.floor(value.min - value.min * 0.1);
+                    },
+                    max: function (value) {
+                        return Math.ceil(value.max + value.max * 0.04);
+                    },
+                    axisLine: {
+                        show: true,
+                    },
+                    axisTick: {
+                        show: true,
+                    },
+                    axisLabel: {
+                        formatter: (value) => {
+                            return Math.floor(value).toLocaleString();
+                        },
+                    },
+                    splitLine: {
+                        show: false,
+                    },
+                },
+            ],
+            legend: {
+                data: [
+                    { name: "Habitants intra UE", icon: "roundRect" },
+                    { name: "Habitants toutes origines", icon: "roundRect" },
+                    {
+                        name: "Sites exclusivement intra UE",
+                        icon: "path://M 3 1 L 10 1 L 10 2 L 3 2 M 3 1 L 3 1",
+                    },
+                    {
+                        name: "Sites",
+                        icon: "path://M 3 1 L 10 1 L 10 2 L 3 2 M 3 1 L 3 1",
+                    },
+                ],
+            },
+        },
+    };
+});
+</script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartEurope.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartEurope.vue
@@ -12,14 +12,14 @@
                 :evolution="
                     formatStat(data.inhabitants.figures.european.evolution)
                 "
-                >Sites exclusivement intra UE</ChartBigFigure
+                >Habitants intra UE</ChartBigFigure
             >
 
             <ChartBigFigure
                 icon="location-dot"
-                :figure="formatStat(data.towns.figures.total.value)"
-                :evolution="formatStat(data.towns.figures.total.evolution)"
-                >Tous sites</ChartBigFigure
+                :figure="formatStat(data.towns.figures.european.value)"
+                :evolution="formatStat(data.towns.figures.european.evolution)"
+                >Sites exclusivement intra UE</ChartBigFigure
             >
         </div>
 
@@ -27,7 +27,7 @@
             class="mt-6"
             :chartOptions="options"
             :chartData="chartData.datasets"
-            :graphId="`evolution-inhabitants`"
+            :graphId="`evolution-europeans`"
         />
     </section>
 </template>
@@ -60,7 +60,7 @@ const chartData = computed(() => {
         generateDataset(
             "Sites exclusivement intra UE",
             "0, 0, 255",
-            data.towns.charts.total,
+            data.towns.charts.european,
             {
                 yAxisIndex: 1,
                 lineStyle: { width: 2, color: "rgba(0, 0, 255, 1)" },
@@ -74,24 +74,6 @@ const chartData = computed(() => {
         datasets,
     };
 });
-
-// const options = computed(() => {
-//     return {
-//         ...chartOptions.line,
-//         options: {
-//             ...chartOptions.line.options,
-//             xAxis: {
-//                 ...chartOptions.line.options.xAxis,
-//                 data: data.inhabitants.charts.labels,
-//                 axisTick: {
-//                     show: true,
-//                     alignWithLabel: false,
-//                     interval: 0,
-//                 },
-//             },
-//         },
-//     };
-// });
 
 const options = computed(() => {
     return {
@@ -164,13 +146,8 @@ const options = computed(() => {
             legend: {
                 data: [
                     { name: "Habitants intra UE", icon: "roundRect" },
-                    { name: "Habitants toutes origines", icon: "roundRect" },
                     {
                         name: "Sites exclusivement intra UE",
-                        icon: "path://M 3 1 L 10 1 L 10 2 L 3 2 M 3 1 L 3 1",
-                    },
-                    {
-                        name: "Sites",
                         icon: "path://M 3 1 L 10 1 L 10 2 L 3 2 M 3 1 L 3 1",
                     },
                 ],

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartForeigner.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartForeigner.vue
@@ -11,7 +11,7 @@
                 :evolution="
                     formatStat(data.inhabitants.figures.total.evolution)
                 "
-                >Toutes origines</ChartBigFigure
+                >Habitants toutes origines</ChartBigFigure
             >
 
             <ChartBigFigure
@@ -26,7 +26,7 @@
             class="mt-6"
             :chartOptions="options"
             :chartData="chartData.datasets"
-            :graphId="`evolution-towns`"
+            :graphId="`evolution-foreigners`"
         />
     </section>
 </template>
@@ -42,7 +42,7 @@ import generateDataset from "../../utils/GraphiquesDonneesStatistiques/generateD
 
 const departementMetricsStore = useDepartementMetricsStore();
 const data = departementMetricsStore.evolution.data.inhabitants;
-console.log(data);
+
 const chartData = computed(() => {
     const datasets = [
         generateDataset(
@@ -55,9 +55,12 @@ const chartData = computed(() => {
                 symbolSize: 1,
             }
         ),
-        generateDataset("Sites", "156, 102, 82", data.towns.charts.total, {
+        generateDataset("Tous sites", "156, 102, 82", data.towns.charts.total, {
             yAxisIndex: 1,
-            lineStyle: { width: 2, color: "rgba(156, 102, 82, 1)" },
+            lineStyle: {
+                width: 2,
+                color: "rgba(156, 102, 82, 1)",
+            },
             symbolSize: 1,
         }),
     ];
@@ -68,23 +71,6 @@ const chartData = computed(() => {
     };
 });
 
-// const options = computed(() => {
-//     return {
-//         ...chartOptions.line,
-//         options: {
-//             ...chartOptions.line.options,
-//             xAxis: {
-//                 ...chartOptions.line.options.xAxis,
-//                 data: data.charts.labels,
-//                 axisTick: {
-//                     show: true,
-//                     alignWithLabel: false,
-//                     interval: 0,
-//                 },
-//             },
-//         },
-//     };
-// });
 const options = computed(() => {
     return {
         ...chartOptions.line,
@@ -155,14 +141,9 @@ const options = computed(() => {
             ],
             legend: {
                 data: [
-                    { name: "Habitants intra UE", icon: "roundRect" },
                     { name: "Habitants toutes origines", icon: "roundRect" },
                     {
-                        name: "Sites exclusivement intra UE",
-                        icon: "path://M 3 1 L 10 1 L 10 2 L 3 2 M 3 1 L 3 1",
-                    },
-                    {
-                        name: "Sites",
+                        name: "Tous sites",
                         icon: "path://M 3 1 L 10 1 L 10 2 L 3 2 M 3 1 L 3 1",
                     },
                 ],

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartForeigner.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartForeigner.vue
@@ -1,0 +1,173 @@
+<template>
+    <section>
+        <h1 class="font-bold text-primary text-lg">
+            Nombre de sites et d'habitants (toutes origines)
+        </h1>
+
+        <div class="flex mt-4 space-x-6">
+            <ChartBigFigure
+                icon="people-group"
+                :figure="formatStat(data.inhabitants.figures.total.value)"
+                :evolution="
+                    formatStat(data.inhabitants.figures.total.evolution)
+                "
+                >Toutes origines</ChartBigFigure
+            >
+
+            <ChartBigFigure
+                icon="location-dot"
+                :figure="formatStat(data.towns.figures.total.value)"
+                :evolution="formatStat(data.towns.figures.total.evolution)"
+                >Tous sites</ChartBigFigure
+            >
+        </div>
+
+        <LineChart
+            class="mt-6"
+            :chartOptions="options"
+            :chartData="chartData.datasets"
+            :graphId="`evolution-towns`"
+        />
+    </section>
+</template>
+
+<script setup>
+import formatStat from "@/utils/formatStat";
+import { computed } from "vue";
+import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
+import LineChart from "@/components/Graphs/GraphBase.vue";
+import ChartBigFigure from "./ChartBigFigure.vue";
+import chartOptions from "../../utils/GraphiquesDonneesStatistiques/ChartOptions";
+import generateDataset from "../../utils/GraphiquesDonneesStatistiques/generateDataset";
+
+const departementMetricsStore = useDepartementMetricsStore();
+const data = departementMetricsStore.evolution.data.inhabitants;
+console.log(data);
+const chartData = computed(() => {
+    const datasets = [
+        generateDataset(
+            "Habitants toutes origines",
+            "204, 135, 59",
+            data.inhabitants.charts.total,
+            {
+                lineStyle: { opacity: 1 },
+                area: true,
+                symbolSize: 1,
+            }
+        ),
+        generateDataset("Sites", "156, 102, 82", data.towns.charts.total, {
+            yAxisIndex: 1,
+            lineStyle: { width: 2, color: "rgba(156, 102, 82, 1)" },
+            symbolSize: 1,
+        }),
+    ];
+
+    return {
+        labels: data.inhabitants.charts.labels,
+        datasets,
+    };
+});
+
+// const options = computed(() => {
+//     return {
+//         ...chartOptions.line,
+//         options: {
+//             ...chartOptions.line.options,
+//             xAxis: {
+//                 ...chartOptions.line.options.xAxis,
+//                 data: data.charts.labels,
+//                 axisTick: {
+//                     show: true,
+//                     alignWithLabel: false,
+//                     interval: 0,
+//                 },
+//             },
+//         },
+//     };
+// });
+const options = computed(() => {
+    return {
+        ...chartOptions.line,
+        options: {
+            ...chartOptions.line.options,
+            xAxis: {
+                ...chartOptions.line.options.xAxis,
+                data: data.inhabitants.charts.labels,
+                axisTick: {
+                    show: true,
+                    alignWithLabel: false,
+                    interval: 0,
+                },
+            },
+            yAxis: [
+                {
+                    type: "value",
+                    name: "Habitants",
+                    position: "left",
+                    alignTicks: true,
+                    axisLine: {
+                        show: true,
+                    },
+                    axisTick: {
+                        show: true,
+                    },
+                    axisLabel: {
+                        formatter: (value) => {
+                            return Math.floor(value).toLocaleString();
+                        },
+                    },
+                    splitLine: {
+                        show: false,
+                    },
+                    min: function (value) {
+                        return Math.floor(value.min - value.min * 0.1);
+                    },
+                    max: function (value) {
+                        return Math.ceil(value.max + value.max * 0.04);
+                    },
+                },
+                {
+                    type: "value",
+                    name: "Sites",
+                    position: "right",
+                    alignTicks: false,
+                    min: function (value) {
+                        return Math.floor(value.min - value.min * 0.1);
+                    },
+                    max: function (value) {
+                        return Math.ceil(value.max + value.max * 0.04);
+                    },
+                    axisLine: {
+                        show: true,
+                    },
+                    axisTick: {
+                        show: true,
+                    },
+                    axisLabel: {
+                        formatter: (value) => {
+                            return Math.floor(value).toLocaleString();
+                        },
+                    },
+                    splitLine: {
+                        show: false,
+                    },
+                },
+            ],
+            legend: {
+                data: [
+                    { name: "Habitants intra UE", icon: "roundRect" },
+                    { name: "Habitants toutes origines", icon: "roundRect" },
+                    {
+                        name: "Sites exclusivement intra UE",
+                        icon: "path://M 3 1 L 10 1 L 10 2 L 3 2 M 3 1 L 3 1",
+                    },
+                    {
+                        name: "Sites",
+                        icon: "path://M 3 1 L 10 1 L 10 2 L 3 2 M 3 1 L 3 1",
+                    },
+                ],
+            },
+        },
+    };
+});
+</script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartInhabitants.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartInhabitants.vue
@@ -4,13 +4,6 @@
 
         <div class="flex mt-4 space-x-6">
             <ChartBigFigure
-                icon="people-group"
-                :figure="formatStat(data.figures.total.value)"
-                :evolution="formatStat(data.figures.total.evolution)"
-                >Tous sites</ChartBigFigure
-            >
-
-            <ChartBigFigure
                 :img="flagEU"
                 alt="Estimation du nombre d'habitants intra UE"
                 :figure="formatStat(data.figures.european.value)"
@@ -19,11 +12,10 @@
             >
 
             <ChartBigFigure
-                :img="flagExtraCommunautaires"
-                alt="Estimation du nombre d'habitants extra UE"
-                :figure="formatStat(data.figures.foreign.value)"
-                :evolution="formatStat(data.figures.foreign.evolution)"
-                >Sites exclusivement extra UE</ChartBigFigure
+                icon="people-group"
+                :figure="formatStat(data.figures.total.value)"
+                :evolution="formatStat(data.figures.total.evolution)"
+                >Tous sites</ChartBigFigure
             >
         </div>
 
@@ -43,7 +35,6 @@ import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
 import LineChart from "@/components/Graphs/GraphBase.vue";
 import ChartBigFigure from "./ChartBigFigure.vue";
 import flagEU from "@/assets/img/flags/eu.png";
-import flagExtraCommunautaires from "@/assets/img/flags/extra-communautaires.png";
 import chartOptions from "../../utils/GraphiquesDonneesStatistiques/ChartOptions";
 import generateDataset from "../../utils/GraphiquesDonneesStatistiques/generateDataset";
 

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/ChartOptions.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/ChartOptions.js
@@ -79,9 +79,6 @@ export default {
                 bottom: "0",
                 containLabel: true,
             },
-            stroke: {
-                curve: "smooth",
-            },
             xAxis: {
                 type: "category",
                 axisLabel: {

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/generateDataset.js
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/utils/GraphiquesDonneesStatistiques/generateDataset.js
@@ -45,6 +45,7 @@ export default function generateDataset(label, color, data, options = {}) {
         itemStyle: {
             color: `rgba(${color}, .5)`,
         },
+        smooth: 0.2,
         ...options,
     };
 }

--- a/packages/frontend/webapp/src/components/Graphs/GraphBase.vue
+++ b/packages/frontend/webapp/src/components/Graphs/GraphBase.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-chart :option="options" :id="graphId" class="h-80 w-full" />
+    <v-chart :option="options" :id="graphId" class="h-32 md:h-80 w-full" />
 </template>
 
 <script setup>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/SYCPx46m/2218-visu-donn%C3%A9es-v1-onglet-synth%C3%A8se-vue-d%C3%A9partementale

## 🛠 Description de la PR
La PR apporte des modifications visuelles sur les "BigFigures" de l'onglet de synthèse en visualisation de données départementale ainsi qu'une modification des données affichées.
On harmonise donc l'onglet avec celui de l'évolution nationale pour présenter d'une part les données concernant les habitants et sites provenant de l'Union Européenne et les habitants et site toutes origines.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/bbaeb857-f3ce-4ab7-a425-33ae80f6ea22)

## 🚨 Notes pour la mise en production
RàS