### PR TITLE
fix: Correction du champ adresse lors de la mise à jour d'un site

### DIFF
--- a/packages/frontend/ui/src/components/Input/BasicAutocomplete.vue
+++ b/packages/frontend/ui/src/components/Input/BasicAutocomplete.vue
@@ -229,7 +229,7 @@ function sendEvent(data) {
 }
 
 onMounted(() => {
-    input.value.setValue("");
+    input.value.setValue(modelValue.value?.search || "");
 });
 
 onBeforeUnmount(() => {

--- a/packages/frontend/webapp/src/components/InputAddress/InputAddress.vue
+++ b/packages/frontend/webapp/src/components/InputAddress/InputAddress.vue
@@ -4,6 +4,7 @@
             name="address"
             id="address"
             v-bind="$attrs"
+            v-model="address"
             :fn="searchAddress"
             ref="address"
         />
@@ -33,19 +34,8 @@ const props = defineProps({
     },
 });
 const { modelValue, withoutMargin } = toRefs(props);
-
-const { handleChange, errors } = useField("address");
-const address = computed({
-    get() {
-        if (modelValue.value) {
-            handleChange(modelValue.value, false);
-        }
-        return modelValue.value;
-    },
-    set(value) {
-        if (value?.data) {
-            handleChange(value, true);
-        }
-    },
+const { errors } = useField("address");
+const address = computed(() => {
+    return modelValue.value;
 });
 </script>

--- a/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
+++ b/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
@@ -54,7 +54,7 @@ function refreshInput(center, emitInput = true) {
     }
 
     inputMarker.setLatLng(center);
-    carto.value.setView({ center });
+    carto.value && carto.value.setView({ center });
 
     if (emitInput === true) {
         handleChange(center);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/0vxngopq/2246-bug-fiche-site-en-modification-la-localisation-est-perdue

## 🛠 Description de la PR
Cette PR corrige un bug où le champ `adresse` du formulaire de mise à jour d'un site était vide et ne validait pas l'entrée lors de la soumission.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
Un bug subséquent demeure lors du changement d'adresse d'un site et est consigné dans le [backlog Trello](https://trello.com/c/vsvG6bM6/1124-bug-champs-des-proc%C3%A9dures-raz-lors-dun-changement-dadresse-de-site)