### PR TITLE
fix: Correction de l'analyse de morceaux de formulaires non obligatoires générant une erreur à l'update d'un site

### DIFF
--- a/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
+++ b/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
@@ -365,17 +365,17 @@ export default mode => ([
                     {
                         key: 'pest_animals_presence',
                         submitedValue: valueMap[parseInt(req.body.pest_animals_presence, 10) + 1],
-                        storedValue: req.town.livingConditions.pest_animals.presence,
+                        storedValue: req.town.livingConditions.pest_animals ? req.town.livingConditions.pest_animals.presence : null,
                     },
                     {
                         key: 'pest_animals_details',
                         submitedValue: getStringOrNull(req.body.pest_animals_details),
-                        storedValue: getStringOrNull(req.town.livingConditions.pest_animals.details),
+                        storedValue: req.town.livingConditions.pest_animals ? getStringOrNull(req.town.livingConditions.pest_animals.details) : null,
                     },
                     {
                         key: 'fire_prevention_diagnostic',
                         submitedValue: valueMap[parseInt(req.body.fire_prevention_diagnostic, 10) + 1],
-                        storedValue: req.town.livingConditions.fire_prevention.diagnostic,
+                        storedValue: req.town.livingConditions.fire_prevention ? req.town.livingConditions.fire_prevention.diagnostic : null,
                     },
                     {
                         key: 'owner_complaint',


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/0vxngopq/2246-bug-fiche-site-en-modification-la-localisation-est-perdue

## 🛠 Description de la PR
Suite au correctif "bis", une nouvelle erreur est apparue à la validation des données car, dans certains cas, le formulaire ne renvoi pas le set complet de données. Ainsi, certaines data ne sont pas envoyées mais sont comparées malgré tout, générant le blocage.
Cette PR corrige la vérification de ces données.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS