### PR TITLE
#patch: (2247) Correction de la gestion du compteur d'erreurs à la connexion

### DIFF
--- a/packages/frontend/webapp/src/components/FormConnexion/FormConnexion.vue
+++ b/packages/frontend/webapp/src/components/FormConnexion/FormConnexion.vue
@@ -97,9 +97,7 @@ watch(isFormDisabled, (newVal) => {
     if (newVal === true) {
         timerReactivation();
     } else {
-        localStorage.removeItem("connexionCounter");
-        localStorage.removeItem("blockedTimer");
-        clearTimeout(timeoutReactivation.value);
+        resetConnexionAttempts();
     }
 });
 
@@ -155,7 +153,9 @@ const checkAttempt = () => {
 };
 
 const resetConnexionAttempts = () => {
-    isFormDisabled.value = false;
+    localStorage.removeItem("connexionCounter");
+    localStorage.removeItem("blockedTimer");
+    clearTimeout(timeoutReactivation.value);
 };
 
 onMounted(() => {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/hCsonw99/2247-bug-connexion-bloqu%C3%A9e-trop-rapidement-apr%C3%A8s-une-erreur

## 🛠 Description de la PR
La PR corrige la gestion du compteur d'erreur de compte/mot de passe qui n'était pas correctement remis à zéro dans certaines conditions.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS