### PR TITLE
#patch: (2247) Correction de la suppression du cookie de tentatives de connexion

### DIFF
--- a/packages/frontend/webapp/src/components/FormConnexion/FormConnexion.vue
+++ b/packages/frontend/webapp/src/components/FormConnexion/FormConnexion.vue
@@ -21,11 +21,11 @@
                 :delayBeforeReactivation="delayBeforeReactivation"
             />
             <FormConnexionInputEmail
-                :disabled="isFormDisabled"
+                :disabled="isFormDisabled || isLoading"
                 aria-label="Veuillez saisir l'adresse de messagerie correspondant à votre identifiant sur la plateforme"
             />
             <FormConnexionInputPassword
-                :disabled="isFormDisabled"
+                :disabled="isFormDisabled || isLoading"
                 aria-label="Veuillez saisir votre mot de passe"
             />
         </template>
@@ -35,7 +35,7 @@
                 <Button
                     type="submit"
                     aria-label="Valider les informations saisies,"
-                    :disabled="isFormDisabled"
+                    :disabled="isFormDisabled || isLoading"
                     >Me connecter</Button
                 >
             </p>
@@ -88,6 +88,7 @@ const props = defineProps({
 const { reason } = toRefs(props);
 const blockedTimer = ref(localStorage.getItem("blockedTimer"));
 const isFormDisabled = ref(false);
+const isLoading = ref(false);
 const delayBeforeReactivation = ref(null);
 const timeoutReactivation = ref(null);
 
@@ -107,6 +108,7 @@ const timerReactivation = () => {
 
 // methods
 async function submit({ email, password }) {
+    isLoading.value = true;
     try {
         await userStore.signin(email, password);
     } catch (error) {
@@ -115,7 +117,9 @@ async function submit({ email, password }) {
     }
     resetConnexionAttempts();
     trackEvent("Login", "Connection");
-    router.push("/chargement");
+    setTimeout(() => {
+        router.push("/chargement");
+    }, 1000);
 }
 
 const message = computed(() => {
@@ -147,6 +151,7 @@ const checkAttempt = () => {
             return false;
         }
     }
+    isLoading.value = false;
     return false;
 };
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/hCsonw99/2247-bug-connexion-bloqu%C3%A9e-trop-rapidement-apr%C3%A8s-une-erreur

## 🛠 Description de la PR
Le correctif n'est pas toujours pris en compte correctement en PROD et PREPROD. Cette PR corrige cela en ajoutant un délai d'1 seconde à la validation pour laisser le temps au site de supprimer l'élément générant l'erreur. Pendant cette seconde, le formulaire de connexion est bloqué.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS