### PR TITLE
patch: (2269) Correction de l'affichage de la structure dans les éléments des emails automatiques

### DIFF
--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -325,7 +325,7 @@ export default {
                 blogUrl,
                 webappUrl,
                 utm,
-                created_by: `${formatName(variables.question.createdBy)} (${variables.question.createdBy.organization})`,
+                created_by: `${formatName(variables.question.createdBy)} (${variables.question.createdBy.organization.name})`,
                 question: variables.question.question,
                 questionId: variables.question.id,
             },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/E81rjDkT/2269-mel-pushbug-la-structure-nest-pas-r%C3%A9cup%C3%A9r%C3%A9e-dans-le-push-mel-de-lespace-entraide

## 🛠 Description de la PR
La PR corrige l'affichage de la structure des utilisateurs dans les emails automatiques.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/26d04729-f796-49d2-89de-6f1aa1bb97d4)

## 🚨 Notes pour la mise en production
RàS