### PR TITLE
patch: (2270) Activation du déplacement du marquer de localisation de site

### DIFF
--- a/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
+++ b/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
@@ -113,8 +113,11 @@ export default mode => ([
                         submitedValue: getStringOrNull(req.body.name),
                         storedValue: getStringOrNull(req.town.name),
                     },
-                    // Mis en commentaire le temps de résoudre l'incohérence des coordonnées géographiques du site toujours initialisée à celle de la commune
-                    // { key: 'coordinates', submitedValue: req.body['coordinates'], storedValue: `${req.town.city.latitude},${req.town.city.longitude}` },
+                    {
+                        key: 'coordinates',
+                        submitedValue: req.body.coordinates,
+                        storedValue: `${req.town.latitude},${req.town.longitude}`,
+                    },
                     {
                         key: 'built_at',
                         submitedValue: getStringOrNull(req.body.built_at),

--- a/packages/api/server/models/shantytownModel/_common/getDiff.ts
+++ b/packages/api/server/models/shantytownModel/_common/getDiff.ts
@@ -262,6 +262,12 @@ export default (oldVersion, newVersion): Diff[] => {
         insalubrityParcels: {
             label: "Parcelles concernées par l'arrêté d'insalubrité (numéros de parcelles)",
         },
+        latitude: {
+            label: 'Coordonnées GPS : Latitude',
+        },
+        longitude: {
+            label: 'Coordonnées GPS : Longitude',
+        },
     };
 
     const finalDiff = [];

--- a/packages/frontend/webapp/src/components/ArrangementLeftMenu/ArrangementLeftMenu.vue
+++ b/packages/frontend/webapp/src/components/ArrangementLeftMenu/ArrangementLeftMenu.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="flex flex-col sm:flex-row space-x-8">
+    <div class="flex flex-col md:flex-row space-x-8">
         <ArrangementLeftMenuColumn
             :tabs="tabs"
             :activeTab="computedActiveTab"
             class="print:hidden mb-12 shrink-0"
             :class="{
                 columnWidthClass: true,
-                'hidden sm:flex': autohide === true,
+                'hidden md:flex': autohide === true,
             }"
         >
             <template v-slot:title v-if="$slots.menuTitle"

--- a/packages/frontend/webapp/src/components/ButtonGPS/ButtonGPS.vue
+++ b/packages/frontend/webapp/src/components/ButtonGPS/ButtonGPS.vue
@@ -1,5 +1,6 @@
 <template>
-    <p>Lat {{ town.latitude }}, Long {{ town.longitude }}</p>
+    <p>Latitude : {{ town.latitude }}</p>
+    <p>Longitude : {{ town.longitude }}</p>
     <ButtonCopy
         :value="`${town.latitude},${town.longitude}`"
         @copied="notifyCopy"

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteAdresse.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteAdresse.vue
@@ -63,7 +63,7 @@
                             <Icon class="text-sm" icon="triangle-exclamation" />
                             Vous avez déplacé le marqueur de l'emplacement du
                             site. N'oubliez pas de cliquer sur "Mettre à jour"
-                            pour valider ce changement
+                            pour valider ce changement de localisation.
                         </div>
                     </div>
                 </FormParagraph>

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteAdresse.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteAdresse.vue
@@ -8,7 +8,10 @@
                     showMandatoryStar
                     id="addressParagraph"
                 >
-                    <InputAddress v-model="values.address" />
+                    <InputAddress
+                        v-model="values.address"
+                        :disabled="isSubmitting"
+                    />
                 </FormParagraph>
 
                 <div class="text-sm mb-4" v-if="nearbyShantytowns.length">
@@ -44,6 +47,24 @@
                 <FormParagraph title="Appellation du site" id="name">
                     <InputName />
                 </FormParagraph>
+
+                <FormParagraph title="Coordonnées GPS" id="coordinates">
+                    <div class="flex flex-col gap-2">
+                        <div>
+                            <p><b>Latitude</b>: {{ coordinates[0] }}</p>
+                            <p><b>Longitude</b>: {{ coordinates[1] }}</p>
+                        </div>
+                        <div
+                            v-if="initialCoordinates !== coordinates"
+                            class="text-redA11Y text-sm"
+                        >
+                            <Icon class="text-sm" icon="triangle-exclamation" />
+                            Vous avez déplacé le marqueur de l'emplacement du
+                            site. N'oubliez pas de cliquer sur "Mettre à jour"
+                            pour valider ce changement
+                        </div>
+                    </div>
+                </FormParagraph>
             </section>
 
             <section class="h-96 bg-G500 lg:w-96 ml-4 my-3" v-if="address">
@@ -55,11 +76,11 @@
 
 <script setup>
 import { findNearby } from "@/api/towns.api";
-import { useFieldValue, useFormValues } from "vee-validate";
+import { useFieldValue, useFormValues, useIsSubmitting } from "vee-validate";
 import { defineProps, ref, toRefs, watch } from "vue";
 
 import FormSection from "@/components/FormSection/FormSection.vue";
-import { FormParagraph, Link } from "@resorptionbidonvilles/ui";
+import { FormParagraph, Link, Icon } from "@resorptionbidonvilles/ui";
 import InputAddress from "@/components/InputAddress/InputAddress.vue";
 import InputCoordinates from "../inputs/FormDeclarationDeSiteInputCoordinates.vue";
 import InputName from "../inputs/FormDeclarationDeSiteInputName.vue";
@@ -76,6 +97,8 @@ const values = useFormValues();
 const address = useFieldValue("address");
 const coordinates = useFieldValue("coordinates");
 const nearbyShantytowns = ref([]);
+const initialCoordinates = ref(coordinates.value);
+const isSubmitting = useIsSubmitting();
 
 watch(address, () => {
     nearbyShantytowns.value = [];

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteAdresse.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteAdresse.vue
@@ -50,10 +50,12 @@
 
                 <FormParagraph title="Coordonnées GPS" id="coordinates">
                     <div class="flex flex-col gap-2">
-                        <div>
-                            <p><b>Latitude</b>: {{ coordinates[0] }}</p>
-                            <p><b>Longitude</b>: {{ coordinates[1] }}</p>
-                        </div>
+                        <ButtonGPS
+                            :town="{
+                                latitude: coordinates[0],
+                                longitude: coordinates[1],
+                            }"
+                        />
                         <div
                             v-if="initialCoordinates !== coordinates"
                             class="text-redA11Y text-sm"
@@ -80,6 +82,7 @@ import { useFieldValue, useFormValues, useIsSubmitting } from "vee-validate";
 import { defineProps, ref, toRefs, watch } from "vue";
 
 import FormSection from "@/components/FormSection/FormSection.vue";
+import ButtonGPS from "@/components/ButtonGPS/ButtonGPS.vue";
 import { FormParagraph, Link, Icon } from "@resorptionbidonvilles/ui";
 import InputAddress from "@/components/InputAddress/InputAddress.vue";
 import InputCoordinates from "../inputs/FormDeclarationDeSiteInputCoordinates.vue";

--- a/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinatesTooltip.vue
+++ b/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinatesTooltip.vue
@@ -8,7 +8,7 @@
             <div class="mx-auto mt-8 w-8/12 text-sm bg-white p-3">
                 <p>
                     Si besoin, préciser la localisation en déplaçant le pointeur
-                    bleu sur la carte.
+                    marron sur la carte.
                 </p>
                 <p
                     class="font-bold text-right cursor-pointer text-primary"

--- a/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinatesTooltip.vue
+++ b/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinatesTooltip.vue
@@ -8,7 +8,7 @@
             <div class="mx-auto mt-8 w-8/12 text-sm bg-white p-3">
                 <p>
                     Si besoin, préciser la localisation en déplaçant le pointeur
-                    marron sur la carte.
+                    sur la carte.
                 </p>
                 <p
                     class="font-bold text-right cursor-pointer text-primary"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ZckDzXvU/2270-sitebug-impossible-de-mettre-%C3%A0-jour-la-localisation-pr%C3%A9cise-du-point-vis-%C3%A0-vis-du-cadastre

## 🛠 Description de la PR
Cette PR permet aux utilisateurs ayant accès en modification aux site de déplacer le marqueur de localisation d'un site afin d'être plus précis sur son emplacement réel.

## 📸 Captures d'écran
Modification du composant de coordonnées GPS:
![image](https://github.com/user-attachments/assets/707c2165-aaf6-4c6b-acd4-28ddd3d73c80)
Utilisation du même composant de coordonnées GPS dans la mise à jour de site:
![image](https://github.com/user-attachments/assets/c79688db-dedd-43da-aabd-4e2166587b3a)
Message affiché lors d'une modification d'emplacement du marqueur:
![image](https://github.com/user-attachments/assets/5d2c0cc3-781d-473f-a0fa-022c89511ab6)

## 🚨 Notes pour la mise en production
RàS