### PR TITLE
#minor (2275) Permettre de téléverser la décision du tribunal

### DIFF
--- a/packages/api/server/services/attachment/upload.ts
+++ b/packages/api/server/services/attachment/upload.ts
@@ -21,7 +21,7 @@ export default async (entityType: AttachmentEntityType, entityId: number, create
             }
         }
     }
-  
+
     const previews: Buffer[] = await Promise.all(
         files.map((f) => {
             if (!f.mimetype.startsWith('image/')) {

--- a/packages/frontend/webapp/src/components/Common/FormEtFicheSite.labels.js
+++ b/packages/frontend/webapp/src/components/Common/FormEtFicheSite.labels.js
@@ -39,6 +39,7 @@ export default {
     justice_rendered: "Décision de justice rendue",
     justice_rendered_at: "Date de la décision",
     justice_rendered_by: "Origine de la décision",
+    justice_rendered_upload: "Téléverser la décision de justice",
     justice_challenged: "Y a-t-il un appel en cours ?",
     police_status: "Statut du concours de la force publique",
     police_requested_at: "Date de la demande du CFP",
@@ -51,7 +52,7 @@ export default {
     administrative_order_decision_at: "Date de l'arrêté",
     administrative_order_decision_rendered_by: "Qui a pris l'arrêté ?",
     administrative_order_evacuation_at: "Date de l'évacuation",
-    evacuation_upload: "Télécharger l'arrêté d'évacuation",
+    evacuation_upload: "Téléverser l'arrêté d'évacuation",
     evacuation_decrees: "Arrêté d'évacuation",
     // Arrêté d'insalubrité
     insalubrity_order:
@@ -63,7 +64,7 @@ export default {
     insalubrity_order_at: "Date de l'arrêté",
     insalubrity_parcels:
         "Parcelles concernées par l'arrêté (numéros de parcelles)",
-    insalubrity_upload: "Télécharger l'arrêté d'insalubrité",
+    insalubrity_upload: "Téléverser l'arrêté d'insalubrité",
     insalubrity_decrees: "Arrêté d'insalubrité",
     living_conditions_version:
         "Souhaitez-vous remplir le nouveau formulaire des conditions de vie ?",

--- a/packages/frontend/webapp/src/components/Common/FormEtFicheSite.labels.js
+++ b/packages/frontend/webapp/src/components/Common/FormEtFicheSite.labels.js
@@ -40,6 +40,7 @@ export default {
     justice_rendered_at: "Date de la décision",
     justice_rendered_by: "Origine de la décision",
     justice_rendered_upload: "Téléverser la décision de justice",
+    justice_rendered_decrees: "Décision de justice",
     justice_challenged: "Y a-t-il un appel en cours ?",
     police_status: "Statut du concours de la force publique",
     police_requested_at: "Date de la demande du CFP",

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteProcedures/FicheSiteProcedures.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteProcedures/FicheSiteProcedures.vue
@@ -13,6 +13,16 @@
             >
                 {{ procedure.value }}
             </FicheSiteProceduresLigne>
+            <FicheSiteProceduresLigne
+                v-if="filteredDecreesAttachments('justice_rendered').length > 0"
+                icon="paperclip"
+                :label="labels.justice_rendered_decrees"
+            >
+                <FilePreviewGrid
+                    class="mb-3"
+                    :files="filteredDecreesAttachments('justice_rendered')"
+                />
+            </FicheSiteProceduresLigne>
         </FicheSiteProceduresRubrique>
 
         <FicheSiteProceduresRubrique>

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -318,22 +318,20 @@ function formatValuesForApi(v) {
     ];
 
     const completeAttachments = [];
-    if (v.insalubrity_attachments && v.insalubrity_attachments.length > 0) {
-        completeAttachments.push(
-            ...formatAttachments(
-                Array.from(v.insalubrity_attachments),
-                "insalubrity"
-            )
-        );
-    }
-    if (v.evacuation_attachments && v.evacuation_attachments.length > 0) {
-        completeAttachments.push(
-            ...formatAttachments(
-                Array.from(v.evacuation_attachments),
-                "evacuation"
-            )
-        );
-    }
+
+    const attachmentTypes = [
+        { key: "justice_rendered_attachments", type: "justice_rendered" },
+        { key: "insalubrity_attachments", type: "insalubrity" },
+        { key: "evacuation_attachments", type: "evacuation" },
+    ];
+
+    attachmentTypes.forEach(({ key, type }) => {
+        if (v[key] && v[key].length > 0) {
+            completeAttachments.push(
+                ...formatAttachments(Array.from(v[key]), type)
+            );
+        }
+    });
 
     return {
         ...Object.keys(validationSchema.value.fields).reduce((acc, key) => {

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteUploadArrete.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteUploadArrete.vue
@@ -7,6 +7,7 @@
             :multiple="true"
             ref="input"
             @change="updateAttachments"
+            class="!mb-2"
         />
         <FilePreviewGrid
             class="mb-3"

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteProcedure.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteProcedure.vue
@@ -36,6 +36,15 @@
                 v-model="values.justice_rendered_at"
             />
             <InputJusticeRenderedBy v-if="values.justice_rendered === 1" />
+            <UploadArrete
+                type="justice_rendered"
+                v-if="values.justice_rendered === 1"
+                v-model="values"
+                :townId="townId"
+                @update:attachments="updateAttachments"
+                @delete:OriginalAttachment="deleteOriginalAttachment"
+                class="mb-4"
+            />
             <InputJusticeChallenged v-if="values.justice_rendered === 1" />
         </Fieldset>
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/rINmoaVc/2275

## 🛠 Description de la PR
- Ajoute une occurrence du composant de téléversement de pièces jointes sur le formulaire de gestion d'un site
- Permet la suppression et la consultation des décisions de justice (pièces jointes) depuis la fiche et le formulaire "Site"

## 📸 Captures d'écran
![{4AC9244D-A8BE-4DB6-8CD6-65E6663B7BEC}](https://github.com/user-attachments/assets/332502f9-08eb-4291-a146-50e24cc48d3a)

## 🚨 Notes pour la mise en production
Ràs