### PR TITLE
#minor (2278) Supprimer le contrôle de date future pour la date de l'évacuation

### DIFF
--- a/packages/api/server/controllers/shantytown/close/shantytown.close.validator.ts
+++ b/packages/api/server/controllers/shantytown/close/shantytown.close.validator.ts
@@ -40,13 +40,6 @@ export default [
             return value;
         })
         .custom((value, { req }) => {
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
-
-            if (value > today) {
-                throw new Error('La date de la fermeture du site ne peut pas être future');
-            }
-
             if (req.body.shantytown && req.body.shantytown.declaredAt) {
                 const declaredDate = new Date(req.body.shantytown.declaredAt * 1000);
                 declaredDate.setHours(0, 0, 0, 0);

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedAt.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedAt.vue
@@ -4,7 +4,6 @@
         width="w-64"
         name="closed_at"
         :label="labels.closed_at"
-        :maxDate="new Date()"
         :clearable="false"
         v-bind="$attrs"
         v-model="values.closed_at"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/YaYgH0as/2278

## 🛠 Description de la PR
Supprimer côté front et côté back, le contrôle empêchant la saisie d'une date de fermeture du site postérieure à la date du jour

## 🚨 Notes pour la mise en production
- ràs