### PR TITLE
#patch (2231)  remplacer "de + de 10 personnes" par "de 10 personnes ou plus"

### DIFF
--- a/packages/api/server/models/questionModel/update.ts
+++ b/packages/api/server/models/questionModel/update.ts
@@ -13,6 +13,7 @@ export default async (data: UpdateQuestionInput): Promise<RawQuestion> => {
         await sequelize.query(
             `UPDATE questions SET
             details = :details,
+            people_affected = :people_affected,
             updated_at = NOW(),
             updated_by = :updated_by
         WHERE question_id = :question_id`,
@@ -22,6 +23,7 @@ export default async (data: UpdateQuestionInput): Promise<RawQuestion> => {
                 replacements: {
                     question_id: data.question_id,
                     details: data.details,
+                    people_affected: data.people_affected,
                     updated_by: data.updated_by,
                 },
             },

--- a/packages/api/server/services/question/findOne.ts
+++ b/packages/api/server/services/question/findOne.ts
@@ -10,7 +10,7 @@ export default async (questionId: number, transaction?: Transaction): Promise<En
         enrichedQuestion = await enrichQuestion(questionId, transaction);
 
         if (enrichedQuestion === null) {
-                throw new ServiceError('fetch_failed', new Error('Impossible de retrouver la question en base de données'));
+            throw new ServiceError('fetch_failed', new Error('Impossible de retrouver la question en base de données'));
         }
     } catch (error) {
         throw new ServiceError('fetch_failed', error);

--- a/packages/api/server/services/question/update.ts
+++ b/packages/api/server/services/question/update.ts
@@ -10,10 +10,10 @@ export default async (questionId: number, question: UpdateQuestionInput, author:
             {
                 question_id: questionId,
                 question: question.question,
+                details: question.details,
                 tags: question.tags,
                 other_tag: question.other_tag,
                 people_affected: question.people_affected,
-                details: question.details,
                 updated_by: author,
             },
         );

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
@@ -4,7 +4,7 @@
         <section class="mb-8">
             <h1 class="font-bold text-primary text-lg">
                 Nombre de sites et d'habitants en France métropolitaine
-                (exclusivement intra UE et + de 10 personnes)
+                (exclusivement intra UE et de 10 personnes ou plus)
             </h1>
             <LineChart
                 class="mt-6"
@@ -16,7 +16,7 @@
         <section>
             <h1 class="font-bold text-primary text-lg">
                 Nombre de sites et d'habitants en France métropolitaine (toutes
-                origines et + de 10 personnes)
+                origines et de 10 personnes ou plus)
             </h1>
             <LineChart
                 class="mt-6"

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/DonneesStatistiquesDepartementBigFigures.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/DonneesStatistiquesDepartementBigFigures.vue
@@ -10,7 +10,7 @@
             class="bg-G100 border border-G300 rounded py-4 px-6 flex md:flex-row flex-col items-stretch"
         >
             <div class="flex flex-col mb-2 md:mb-0">
-                <p class="font-bold w-full">Sites de + de 10 personnes</p>
+                <p class="font-bold w-full">Sites de 10 personnes ou plus</p>
                 <div class="flex flex-col xs:flex-row gap-2 xs:space-x-5">
                     <div
                         class="bg-G200 rounded-md p-2 flex flex-col flex-wrap items-center xl:items-start"

--- a/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
+++ b/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
@@ -153,8 +153,8 @@ const config = {
 };
 
 const otherTag = computed(() => {
-    const otherTag = question.value?.tags.find((tag) => tag.uid === "other");
-    const otherTagName = otherTag ? otherTag.name : "";
+    const tagFound = question.value?.tags.find((tag) => tag.uid === "other");
+    const otherTagName = tagFound ? tagFound.name : "";
     return otherTagName;
 });
 

--- a/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
+++ b/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
@@ -14,11 +14,14 @@
             /></FormParagraph>
             <FormParagraph :title="labels.other_tag" v-if="showOtherTag">
                 <FormNouvelleQuestionInputOtherTag
+                    :tag="otherTag"
                     :disabled="mode === 'edit'"
                 />
             </FormParagraph>
             <FormParagraph :title="labels.people_affected" info="(optionnel)">
-                <FormNouvelleQuestionInputPeopleAffected />
+                <FormNouvelleQuestionInputPeopleAffected
+                    :peopleAffected="peopleAffected"
+                />
             </FormParagraph>
             <FormParagraph :title="labels.details" showMandatoryStar>
                 <FormNouvelleQuestionInputDetails @paste="onPaste" />
@@ -148,6 +151,16 @@ const config = {
         },
     },
 };
+
+const otherTag = computed(() => {
+    const otherTag = question.value?.tags.find((tag) => tag.uid === "other");
+    const otherTagName = otherTag ? otherTag.name : "";
+    return otherTagName;
+});
+
+const peopleAffected = computed(() => {
+    return question.value?.peopleAffected;
+});
 
 defineExpose({
     submit: handleSubmit(async (sentValues) => {

--- a/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
+++ b/packages/frontend/webapp/src/components/FormNouvelleQuestion/FormNouvelleQuestion.vue
@@ -14,9 +14,9 @@
             /></FormParagraph>
             <FormParagraph :title="labels.other_tag" v-if="showOtherTag">
                 <FormNouvelleQuestionInputOtherTag
-                    :tag="question.tags[0].name"
                     :disabled="mode === 'edit'"
-            /></FormParagraph>
+                />
+            </FormParagraph>
             <FormParagraph :title="labels.people_affected" info="(optionnel)">
                 <FormNouvelleQuestionInputPeopleAffected />
             </FormParagraph>

--- a/packages/frontend/webapp/src/components/FormNouvelleQuestion/inputs/FormNouvelleQuestionInputOtherTag.vue
+++ b/packages/frontend/webapp/src/components/FormNouvelleQuestion/inputs/FormNouvelleQuestionInputOtherTag.vue
@@ -1,5 +1,5 @@
 <template>
-    <TextInput name="other_tag" id="other_tag" :value="tag" maxlength="255" />
+    <TextInput name="other_tag" id="other_tag" :value="tag" maxlength="35" />
 </template>
 <script setup>
 import { TextInput } from "@resorptionbidonvilles/ui";

--- a/packages/frontend/webapp/src/components/FormNouvelleQuestion/inputs/FormNouvelleQuestionInputPeopleAffected.vue
+++ b/packages/frontend/webapp/src/components/FormNouvelleQuestion/inputs/FormNouvelleQuestionInputPeopleAffected.vue
@@ -4,9 +4,20 @@
         id="people_affected"
         info="Incitez les autres membres de la communauté à vous répondre rapidement en indiquant le nombre de personnes qui ont besoin d'aide"
         width="w-28"
+        :value="peopleAffected"
     />
 </template>
 
 <script setup>
+import { toRefs } from "vue";
 import { TextInput } from "@resorptionbidonvilles/ui";
+
+const props = defineProps({
+    peopleAffected: {
+        type: String,
+        required: false,
+        default: "",
+    },
+});
+const { peopleAffected } = toRefs(props);
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/x37H1D1v/2231

## 🛠 Description de la PR
- Le libellé des tableaux de visualisation de données est incorrect. On comptabilise les sites avec la condition ">=10", mais on indique "de plus de 10 personnes"
- La correction remplace le libellé "de plus de 10 personnes" par "de 10 personnes ou plus"

## 📸 Captures d'écran
![{96EF515F-2145-44D9-9265-53DDB05BABA9}](https://github.com/user-attachments/assets/6e2fc383-663d-4ceb-9ce8-f03ac98f9261)
![{8A475A2C-3F58-46CB-A2E0-0CFBCAB79739}](https://github.com/user-attachments/assets/64b2d0d2-42e7-40d8-b09d-e2dd5067ff82)

## 🚨 Notes pour la mise en production
- ràs