### PR TITLE
#patch (2231) remplacer "de + de 10 personnes" par "de 10 personnes ou plus"

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/EvolutionNationale.vue
@@ -4,7 +4,7 @@
         <section class="mb-8">
             <h1 class="font-bold text-primary text-lg">
                 Nombre de sites et d'habitants en France métropolitaine
-                (exclusivement intra UE et + de 10 personnes)
+                (exclusivement intra UE et de 10 personnes ou plus)
             </h1>
             <LineChart
                 class="mt-6"
@@ -16,7 +16,7 @@
         <section>
             <h1 class="font-bold text-primary text-lg">
                 Nombre de sites et d'habitants en France métropolitaine (toutes
-                origines et + de 10 personnes)
+                origines et de 10 personnes ou plus)
             </h1>
             <LineChart
                 class="mt-6"

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/DonneesStatistiquesDepartementBigFigures.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/DonneesStatistiquesDepartementBigFigures.vue
@@ -10,7 +10,7 @@
             class="bg-G100 border border-G300 rounded py-4 px-6 flex md:flex-row flex-col items-stretch"
         >
             <div class="flex flex-col mb-2 md:mb-0">
-                <p class="font-bold w-full">Sites de + de 10 personnes</p>
+                <p class="font-bold w-full">Sites de 10 personnes ou plus</p>
                 <div class="flex flex-col xs:flex-row gap-2 xs:space-x-5">
                     <div
                         class="bg-G200 rounded-md p-2 flex flex-col flex-wrap items-center xl:items-start"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/x37H1D1v/2231

## 🛠 Description de la PR
- Le libellé des tableaux de visualisation de données est incorrect. On comptabilise les sites avec la condition ">=10", mais on indique "de plus de 10 personnes"
- La correction remplace le libellé "de plus de 10 personnes" par "de 10 personnes ou plus"

## 📸 Captures d'écran
![{96EF515F-2145-44D9-9265-53DDB05BABA9}](https://github.com/user-attachments/assets/6e2fc383-663d-4ceb-9ce8-f03ac98f9261)
![{8A475A2C-3F58-46CB-A2E0-0CFBCAB79739}](https://github.com/user-attachments/assets/64b2d0d2-42e7-40d8-b09d-e2dd5067ff82)

## 🚨 Notes pour la mise en production
- ràs