### PR TITLE
#patch (2296) Corriger les marges basses des fieldset

### DIFF
--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteProcedure.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteProcedure.vue
@@ -62,7 +62,10 @@
         <Fieldset
             :legend="labels.evacuation_under_time_limit"
             showMandatoryStar
-            class="mb-12"
+            :class="[
+                { 'mb-4': values.evacuation_under_time_limit !== 1 },
+                { 'mb-12': values.evacuation_under_time_limit === 1 },
+            ]"
         >
             <InputCheckableGroup
                 name="evacuation_under_time_limit"
@@ -100,7 +103,10 @@
         <Fieldset
             :legend="labels.insalubrity_order"
             showMandatoryStar
-            class="mb-12"
+            :class="[
+                { 'mb-4': values.insalubrity_order !== 1 },
+                { 'mb-12': values.insalubrity_order === 1 },
+            ]"
         >
             <InputCheckableGroup
                 name="insalubrity_order"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/3XIpCQ1q/2296
## 🛠 Description de la PR
Les marges basses sont trop importantes lorsqu’on n’affiche pas le composant de sélection de fichier (fileUpload)

## 📸 Captures d'écran
![{45BF9325-5AF1-465A-8428-16B7EC0EE3FD}](https://github.com/user-attachments/assets/6908bd58-63c0-44dd-9b04-0c3da319bd45)

## 🚨 Notes pour la mise en production
- ràs