### PR TITLE
[patch] (2298) - Mauvaise couleur sur le libellé évacuation des déchets

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVieRubrique.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVieRubrique.vue
@@ -161,7 +161,7 @@ const realStatus = computed(() => {
     return s;
 });
 const colorClass = computed(() => {
-    return COLORS[realStatus.value] || "text-red";
+    return COLORS[realStatus.value] || "text-secondary";
 });
 const icon = computed(() => {
     return ICONS[realStatus.value] || "question";

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVieRubrique.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVieRubrique.vue
@@ -131,10 +131,10 @@ const { title, status, info, showStatus, answers, inverted } = toRefs(props);
 const collapsed = ref(true);
 
 const COLORS = {
-    good: "text-green500",
+    good: "text-tertiaryA11Y",
     toImprove: "text-secondary",
-    bad: "text-red",
-    unknown: "text-red",
+    bad: "text-secondary",
+    unknown: "text-secondary",
 };
 const ICONS = {
     good: "check",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/OLz0NnSc/2298-site-mauvaise-couleur-sur-le-libell%C3%A9-%C3%A9vacuation-des-d%C3%A9chets

## 🛠 Description de la PR
Correction des couleurs utilisées sur les conditions de vie pour homogénéiser en respectant les préconisations d'accessibilité:
- utilisation du même rouge sur tous les points
- utilisation du même rouge si la couleur n'a pas pu être déterminée en fonction de la valeur
- modification du vert pour utiliser celui préconisé pour l'accessibilité

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/d0fa6f34-cd56-459d-a16d-f51cee9aa00c)

## 🚨 Notes pour la mise en production
RàS