### PR TITLE
[patch] (2297) Design: Affichage d'un titre de colonne et harmonisation des espacements

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
@@ -45,10 +45,7 @@
                         v-if="userStore.hasJusticePermission"
                         :shantytown="shantytown"
                     />
-                    <CarteSiteDetailleeActors
-                        :shantytown="shantytown"
-                        class="border-2 border-red"
-                    />
+                    <CarteSiteDetailleeActors :shantytown="shantytown" />
                 </div>
 
                 <CarteSiteDetailleeFooter

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
@@ -26,10 +26,13 @@
                 <CarteSiteDetailleeName :shantytown="shantytown" />
 
                 <div
-                    class="flex flex-col space-y-5 lg:flex-none lg:grid cardGridTemplateColumns print:grid lg:gap-10 px-6 py-4"
+                    class="flex flex-col lg:flex-none lg:grid cardGridTemplateColumns print:grid lg:gap-10 px-6 py-4 items-start"
                 >
                     <CarteSiteDetailleeFieldType :shantytown="shantytown" />
-                    <CarteSiteDetailleeOrigins :shantytown="shantytown" />
+                    <CarteSiteDetailleeOrigins
+                        :shantytown="shantytown"
+                        class="pl-5"
+                    />
                     <CarteSiteDetailleeLivingConditions
                         v-if="isOpen"
                         :shantytown="shantytown"
@@ -42,7 +45,10 @@
                         v-if="userStore.hasJusticePermission"
                         :shantytown="shantytown"
                     />
-                    <CarteSiteDetailleeActors :shantytown="shantytown" />
+                    <CarteSiteDetailleeActors
+                        :shantytown="shantytown"
+                        class="border-2 border-red"
+                    />
                 </div>
 
                 <CarteSiteDetailleeFooter

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFieldType.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFieldType.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <TypeDeSite :fieldType="shantytown.fieldType" />
-        <div class="ml-5">
+        <div class="ml-5 -mt-1">
             <div>
                 {{ shantytown.statusName }} depuis <br />
                 <span class="font-bold">{{ shantytown.statusSince }}</span>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeJustice.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeJustice.vue
@@ -1,8 +1,9 @@
 <template>
     <div
         v-if="!shantytown.justiceStatuses || !shantytown.justiceStatuses.length"
-        class="text-G700"
+        class="pl-5 text-G700"
     >
+        <div class="mb-0 font-bold -ml-5 whitespace-nowrap">Procédures</div>
         <Icon icon="ban" />&nbsp;
         <template
             v-if="
@@ -20,7 +21,8 @@
         <span class="sr-only"
             >Statut des procédures judiciaires ou administratives</span
         >
-        <ul>
+        <ul class="pl-5">
+            <div class="mb-0 font-bold -ml-5 whitespace-nowrap">Procédures</div>
             <li
                 class="flex items-center"
                 v-for="status in shantytown.justiceStatuses"

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeLivingConditionIcon.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeLivingConditionIcon.vue
@@ -1,8 +1,8 @@
 <template>
-    <li class="flex items-center">
+    <li class="flex items-center mb-1">
         <span
             :class="[
-                'flex rounded-full text-xs border-2 mr-3 mb-1 h-6 w-6 items-center justify-center',
+                'flex rounded-full text-xs border-2 mr-3 mb-0 h-6 w-6 items-center justify-center',
                 colorClass,
             ]"
             style="padding: 0.2em"

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeLivingConditions.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeLivingConditions.vue
@@ -1,6 +1,9 @@
 <template>
     <span class="sr-only">Statut des conditions de vie</span>
-    <ul v-if="shantytown.livingConditions.version === 2">
+    <ul v-if="shantytown.livingConditions.version === 2" class="pl-5">
+        <div class="mb-0 font-bold -ml-5 whitespace-nowrap">
+            Conditions de Vie
+        </div>
         <CarteSiteDetailleeLivingConditionIcon
             :status="shantytown.livingConditions.water.status.status"
             :audio="

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeOrigins.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeOrigins.vue
@@ -1,5 +1,6 @@
 <template>
     <div>
+        <div class="-mb-1 font-bold -ml-5 whitespace-nowrap">Habitants</div>
         <div v-if="shantytown.populationTotal === null" class="font-bold">
             Population : inconnu
         </div>

--- a/packages/frontend/webapp/src/components/TypeDeSite/TypeDeSite.vue
+++ b/packages/frontend/webapp/src/components/TypeDeSite/TypeDeSite.vue
@@ -6,7 +6,7 @@
             :style="`color: ${fieldType.color}`"
         />
         <span class="sr-only">Type de site</span>
-        <div class="font-bold ml-2 whitespace-nowrap">
+        <div class="font-bold ml-1 whitespace-nowrap">
             {{ fieldType.label }}
         </div>
     </div>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/gwKZor0B/2297-liste-des-sites-ajouter-une-ent%C3%AAte-de-colonne-sur-les-diff%C3%A9rentes-colonnes

## 🛠 Description de la PR
Cette PR ajoute des titres aux colonnes de détails des sites lors de l'affichage de la liste des sites. Elle corrige et harmonise les espacements et l'affichages des détails.

## 📸 Captures d'écran
Colonnes sans titres : 
![image](https://github.com/user-attachments/assets/fcd02ce1-6441-4473-92cd-741bc6086353)
Colonnes avec titres : 
![image](https://github.com/user-attachments/assets/679d2c6b-2cd4-4703-97de-e1bc448fa6d3)

## 🚨 Notes pour la mise en production
La colonne liée à l'EXPE44 n'a pas encore été prise en compte car non disponible dans `develop` actuellement. Il faudra intégrer un titre par la suite.