### PR TITLE
#patch (2303) Permettre de filtrer les sites exclusivement intra UE

### DIFF
--- a/packages/frontend/ui/src/components/Filter.vue
+++ b/packages/frontend/ui/src/components/Filter.vue
@@ -21,8 +21,8 @@
         </template>
         <template v-slot:menu>
             <Menu containerClasses="py-0">
-                <div v-for="option in options" :key="option.id"
-                    class="flex items-center whitespace-nowrap text-sm menuWidth">
+                <div v-for="option in options" :key="option.value"
+                    :class="['flex', 'items-center', 'whitespace-nowrap', 'text-sm', 'menuWidth', { 'border-b-1': option.displayBottomBorder }]">
                     <Checkbox :disabled="disabled" v-model="checked[option.value]" variant="invisible" :label="option.label"
                         direction="col">
                     </Checkbox>

--- a/packages/frontend/ui/src/components/Filter.vue
+++ b/packages/frontend/ui/src/components/Filter.vue
@@ -28,8 +28,12 @@
                     </Checkbox>
                 </div>
 
-                <div class="px-1 py-1 border-t-1">
-                    <Button size="sm" variant="primaryText" @click="clear" class="hover:underline">
+                <div class="border-t-1">
+                    <Button 
+                        size="sm"
+                        variant="custom" 
+                        class="flex items-center whitespace-nowrap text-sm menuWidth hover:bg-blue200 hover:text-primary text-primary focusClasses.ring"
+                        @click="clear">
                         Effacer
                     </Button>
                 </div>

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.filtres.js
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.filtres.js
@@ -31,6 +31,7 @@ export default {
             {
                 value: "0",
                 label: "Exclusivement UE",
+                displayBottomBorder: true,
             },
             {
                 value: "1",

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.filtres.js
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.filtres.js
@@ -29,6 +29,10 @@ export default {
         id: "origin",
         options: [
             {
+                value: "0",
+                label: "Exclusivement UE",
+            },
+            {
                 value: "1",
                 label: "Français",
             },

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesFiltres.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useTownsStore } from "@/stores/towns.store";
 import { useUserStore } from "@/stores/user.store";
 import { trackEvent } from "@/helpers/matomo";
@@ -138,4 +138,29 @@ function trackFilter(eventAction, { label: eventName }) {
         eventName
     );
 }
+
+const isProcessing = ref(false);
+const isUeOnly = ref(false);
+
+watch(isUeOnly, (newValue) => {
+    if (newValue) {
+        const currentFilters = { ...townsStore.filters.properties };
+        townsStore.filters.properties = {
+            ...currentFilters,
+            origin: ["0"],
+        };
+    }
+});
+
+watch(
+    () => townsStore.filters.properties.origin,
+    (newValue) => {
+        if (!isProcessing.value) {
+            isProcessing.value = true;
+            isUeOnly.value = newValue[0] === "0";
+            isProcessing.value = false;
+        }
+    },
+    { immediate: true }
+);
 </script>

--- a/packages/frontend/webapp/src/utils/filterShantytowns.js
+++ b/packages/frontend/webapp/src/utils/filterShantytowns.js
@@ -144,6 +144,14 @@ function checkOrigin(shantytown, filters) {
         return true;
     }
 
+    // Cas spécifique où le site n'est occupé que par des ressortissants européens
+    if (filters.includes("0")) {
+        return (
+            shantytown.socialOrigins.length === 1 &&
+            shantytown.socialOrigins[0].id.toString() === "2"
+        );
+    }
+
     const origins = shantytown.socialOrigins.map((origin) => origin.id);
 
     const filteredArray = origins.filter((value) =>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/frNMOmDP/2303

## 🛠 Description de la PR
- Ajouter la valeur “Exclusivement intra UE” dans le filtre “Origine”, en haut de la liste et le séparer par une ligne car n’est pas cumulatif avec les autres filtres.
- Seuls les sites dont les habitants sont exclusivement des ressortissants de l'UE doivent être affichés
- La sélection de la valeur "Exclusivement UE" désactive toute autres options dans le filtre "Origines"

## 📸 Captures d'écran
![{B1622FDD-515E-4FF8-8CB7-7DA6B124A26E}](https://github.com/user-attachments/assets/da55bcbd-52d5-4080-a903-4e8aab0c1c3a)

## 🚨 Notes pour la mise en production
- ràs