### PR TITLE
#patch (2291) Ajout de l'affichage du cadastre lors de la mise à jour d'un site

### DIFF
--- a/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
+++ b/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
@@ -9,20 +9,24 @@
     >
         <div
             ref="cadastreToggler"
-            class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded leaflet-control print:hidden"
+            class="bg-white ml-3 my-3 border-2 border-primary text-primary hover:bg-primary hover:text-white py-1 px-2 leaflet-control print:hidden"
             :class="{
                 'opacity-50': cadastreIsLoading,
-                'opacity-100 !bg-primary text-white border-primary':
-                    showCadastre,
             }"
             v-show="cadastre"
         >
             <label
-                class="flex items-center space-x-2 cursor-pointer"
+                class="flex gap-2 items-center space-x-2 cursor-pointer"
                 @click.prevent.stop="showCadastre = !showCadastre"
             >
                 <input type="checkbox" v-model="showCadastre" class="hidden" />
-                <span class="p-0 !ml-0">Voir le cadastre</span>
+                <Icon
+                    :icon="showCadastre ? 'eye' : 'eye-slash'"
+                    class="p-0 !ml-0"
+                />
+                <span class="p-0 !ml-0"
+                    >{{ showCadastre ? "Masquer" : "Voir" }} le cadastre</span
+                >
             </label>
         </div>
     </Carto>
@@ -31,6 +35,7 @@
 <script setup>
 import { ref, toRefs, watch } from "vue";
 import L from "leaflet";
+import { Icon } from "@resorptionbidonvilles/ui";
 import { useNotificationStore } from "@/stores/notification.store";
 import copyToClipboard from "@/utils/copyToClipboard";
 import Carto from "@/components/Carto/Carto.vue";

--- a/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
+++ b/packages/frontend/webapp/src/components/CartoFicheSite/CartoFicheSite.vue
@@ -9,12 +9,20 @@
     >
         <div
             ref="cadastreToggler"
-            class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden"
+            class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded leaflet-control print:hidden"
+            :class="{
+                'opacity-50': cadastreIsLoading,
+                'opacity-100 !bg-primary text-white border-primary':
+                    showCadastre,
+            }"
             v-show="cadastre"
         >
-            <label class="flex items-center space-x-2">
-                <input type="checkbox" v-model="showCadastre" />
-                <span>Voir le cadastre</span>
+            <label
+                class="flex items-center space-x-2 cursor-pointer"
+                @click.prevent.stop="showCadastre = !showCadastre"
+            >
+                <input type="checkbox" v-model="showCadastre" class="hidden" />
+                <span class="p-0 !ml-0">Voir le cadastre</span>
             </label>
         </div>
     </Carto>

--- a/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
+++ b/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
@@ -12,16 +12,14 @@
             <div class="leaflet-bottom leaflet-left mb-4">
                 <div
                     ref="cadastreToggler"
-                    class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded leaflet-control print:hidden"
+                    class="bg-white ml-3 my-3 border-2 border-primary text-primary hover:bg-primary hover:text-white py-1 px-2 leaflet-control print:hidden"
                     :class="{
                         'opacity-50': cadastreIsLoading,
-                        'opacity-100 !bg-primary text-white border-primary':
-                            showCadastre,
                     }"
                     v-show="cadastre"
                 >
                     <label
-                        class="flex items-center space-x-2 cursor-pointer"
+                        class="flex gap-2 items-center space-x-2 cursor-pointer"
                         @click.prevent.stop="showCadastre = !showCadastre"
                     >
                         <input
@@ -30,7 +28,14 @@
                             :disabled="cadastreIsLoading"
                             class="hidden"
                         />
-                        <span class="p-0 !ml-0">Voir le cadastre</span>
+                        <Icon
+                            :icon="showCadastre ? 'eye' : 'eye-slash'"
+                            class="p-0 !ml-0"
+                        />
+                        <span class="p-0 !ml-0"
+                            >{{ showCadastre ? "Masquer" : "Voir" }} le
+                            cadastre</span
+                        >
                     </label>
                 </div>
             </div>
@@ -49,6 +54,7 @@ import { useNotificationStore } from "@/stores/notification.store";
 import copyToClipboard from "@/utils/copyToClipboard";
 import { getCadastre } from "@/api/ign.api";
 import generateSquare from "@/utils/generateSquare";
+import { Icon } from "@resorptionbidonvilles/ui";
 
 const DEFAULT_ZOOM = 14;
 const carto = ref(null);
@@ -86,6 +92,7 @@ const view = computed(() => {
 });
 
 const inputMarker = marqueurInput(value.value);
+
 let clickTimeout = null;
 
 function createCadastreControl() {

--- a/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
+++ b/packages/frontend/webapp/src/components/InputCoordinates/InputCoordinates.vue
@@ -8,19 +8,51 @@
             defaultLayer="Dessin"
             :isLoading="isSubmitting"
             displaySkipMapLinks
-        />
+        >
+            <div class="leaflet-bottom leaflet-left mb-4">
+                <div
+                    ref="cadastreToggler"
+                    class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded leaflet-control print:hidden"
+                    :class="{
+                        'opacity-50': cadastreIsLoading,
+                        'opacity-100 !bg-primary text-white border-primary':
+                            showCadastre,
+                    }"
+                    v-show="cadastre"
+                >
+                    <label
+                        class="flex items-center space-x-2 cursor-pointer"
+                        @click.prevent.stop="showCadastre = !showCadastre"
+                    >
+                        <input
+                            type="checkbox"
+                            v-model="showCadastre"
+                            :disabled="cadastreIsLoading"
+                            class="hidden"
+                        />
+                        <span class="p-0 !ml-0">Voir le cadastre</span>
+                    </label>
+                </div>
+            </div>
+        </Carto>
     </div>
 </template>
 
 <script setup>
-import { defineProps, toRefs, computed, watch, ref } from "vue";
+import { defineProps, toRefs, computed, watch, ref, onMounted } from "vue";
 import { useField, useIsSubmitting } from "vee-validate";
 import Carto from "@/components/Carto/Carto.vue";
+import L from "leaflet";
 import marqueurInput from "@/utils/marqueurInput";
 import InputCoordinatesTooltip from "./InputCoordinatesTooltip.vue";
+import { useNotificationStore } from "@/stores/notification.store";
+import copyToClipboard from "@/utils/copyToClipboard";
+import { getCadastre } from "@/api/ign.api";
+import generateSquare from "@/utils/generateSquare";
 
 const DEFAULT_ZOOM = 14;
 const carto = ref(null);
+const cadastreToggler = ref(null);
 const props = defineProps({
     name: {
         type: String,
@@ -28,7 +60,16 @@ const props = defineProps({
     },
 });
 const { name } = toRefs(props);
+const showCadastre = ref(false);
+const cadastre = ref(null);
+const cadastreIsLoading = ref(null);
+const notificationStore = useNotificationStore();
 const isSubmitting = useIsSubmitting();
+const markersGroup = ref(
+    L.geoJSON([], {
+        onEachFeature: handleParcelle,
+    })
+);
 const { value, handleChange } = useField(name.value);
 
 watch(value, () => {
@@ -41,12 +82,66 @@ const view = computed(() => {
     if (!value.value) {
         return;
     }
-
     return value.value;
 });
 
 const inputMarker = marqueurInput(value.value);
 let clickTimeout = null;
+
+function createCadastreControl() {
+    const CadastreToggler = L.Control.extend({
+        options: {
+            position: "bottomleft",
+        },
+
+        onAdd() {
+            return cadastreToggler.value;
+        },
+    });
+
+    return new CadastreToggler();
+}
+
+function handleParcelle(feature, layer) {
+    const { numero, feuille, section, code_insee } = feature.properties;
+    layer.bindTooltip(
+        `N°${numero}<br/>Feuille ${feuille}<br/>Section ${section}<br/>N°INSEE ${code_insee}`
+    );
+
+    layer.on("click", () => {
+        copyToClipboard(
+            `N°${numero}\nFeuille ${feuille}\nSection ${section}\nN°INSEE ${code_insee}`
+        );
+        notificationStore.success(
+            "Copie de la parcelle cadastrale",
+            "Les données de cette parcelle cadastrale ont bien été copiées dans votre presse-papier"
+        );
+    });
+}
+
+async function loadCadastre() {
+    if (cadastreIsLoading.value === true) {
+        return;
+    }
+
+    cadastreIsLoading.value = true;
+    try {
+        const response = await getCadastre(
+            generateSquare([view.value[1], view.value[0]], 0.06)
+        );
+
+        if (
+            Number.isInteger(response.totalFeatures) &&
+            response.totalFeatures > 0
+        ) {
+            cadastre.value = response;
+        }
+    } catch (error) {
+        // ignore
+    }
+
+    cadastreIsLoading.value = false;
+}
 
 function refreshInput(center, emitInput = true) {
     if (isSubmitting.value === true) {
@@ -67,10 +162,15 @@ function handleClick({ latlng: { lat, lng } }) {
     clickTimeout = null;
 }
 
+watch(view, () => {
+    loadCadastre();
+});
+
 watch(carto, () => {
     if (carto.value) {
         const { map } = carto.value;
         inputMarker.addTo(map);
+        carto.value.addControl("cadastreToggler", createCadastreControl());
         inputMarker.addEventListener("dragend", () => {
             const { lat, lng } = inputMarker.getLatLng();
             refreshInput([lat, lng]);
@@ -85,5 +185,27 @@ watch(carto, () => {
             clickTimeout = null;
         });
     }
+});
+
+watch(showCadastre, () => {
+    const { map } = carto.value;
+
+    if (showCadastre.value === false) {
+        if (map.hasLayer(markersGroup.value)) {
+            map.removeLayer(markersGroup.value);
+        }
+    } else if (!map.hasLayer(markersGroup.value)) {
+        map.addLayer(markersGroup.value);
+        map.setView(view.value, 15);
+    }
+});
+
+watch(cadastre, () => {
+    markersGroup.value.clearLayers();
+    markersGroup.value.addData(cadastre.value);
+});
+
+onMounted(() => {
+    loadCadastre();
 });
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/tcNN98MA/2291-maj-site-permettre-laffichage-de-la-couche-cadastrale-lors-de-maj-dun-site

## 🛠 Description de la PR
Cette PR ajoute de la couche "cadastre" sur la carte lors de la mise à jour d'un site. Elle améliore également la visibilité et l'expérience utilisateur avec le bouton d'activation/désactivation de la couche.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/aae18aa0-adc3-4e10-ad7a-b52fe3873ed5)
![image](https://github.com/user-attachments/assets/3c984158-bc46-43a1-ad21-0626fcebdce3)
![image](https://github.com/user-attachments/assets/23b863d2-2353-48f7-990e-511f12bf31d0)

## 🚨 Notes pour la mise en production
RàS