### PR TITLE
#patch (2290) Ouverture automatique des PJ dans un nouvel onglet

### DIFF
--- a/packages/frontend/ui/src/components/FilePreview/FilePreview.vue
+++ b/packages/frontend/ui/src/components/FilePreview/FilePreview.vue
@@ -1,7 +1,7 @@
 <template>
     <div @mousemove="isHovered = true" @mouseleave="isHovered = false">
         <a class="flex border rounded p-1 space-x-2 items-center cursor-pointer hover:bg-blue100 bg-white"
-        :title="`Consulter la pièce jointe, ${file.name}`" :href="file.urls.original">
+        :title="`Consulter la pièce jointe, ${file.name}`" :href="file.urls.original" target="_blank">
             <FilePreviewIcon aria-hidden="true" class="flex-shrink-0" :file="file" />
             <div class="text-sm overflow-hidden flex-1">
                 <p class="truncate" aria-hidden="true">{{ file.name }}</p>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/HuKFUikh/2290-pj-gestion-de-laffichage

## 🛠 Description de la PR
La PR permet d'ouvrir automatiquement les PJ du journal de sites dans un nouvel onglet plutôt qu'à la place de la page RB.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS