### PR TITLE
#patch (2315) Renommer les valeurs du filtre "Origines"

### DIFF
--- a/packages/frontend/ui/src/components/Filter.vue
+++ b/packages/frontend/ui/src/components/Filter.vue
@@ -23,7 +23,8 @@
             <Menu containerClasses="py-0">
                 <div v-for="option in options" :key="option.value"
                     :class="['flex', 'items-center', 'whitespace-nowrap', 'text-sm', 'menuWidth', { 'border-b-1': option.displayBottomBorder }]">
-                    <Checkbox :disabled="disabled" v-model="checked[option.value]" variant="invisible" :label="option.label"
+                    <span v-if="option.type === 'label'" class="text-sm font-bold w-full pt-2 pb-0 pl-3 bg-white text-G600 cursor-pointer disabled" style="font-weight: bold;">{{ option.label }}</span>
+                    <Checkbox v-else :disabled="disabled" v-model="checked[option.value]" variant="invisible" :lineOffset="option.lineOffset" :label="option.label"
                         direction="col">
                     </Checkbox>
                 </div>
@@ -32,7 +33,7 @@
                     <Button 
                         size="sm"
                         variant="custom" 
-                        class="flex items-center whitespace-nowrap text-sm menuWidth hover:bg-blue200 hover:text-primary text-primary focusClasses.ring"
+                        class="flex items-center whitespace-nowrap text-sm menuWidth pl-3 hover:bg-blue200 hover:text-primary text-primary focusClasses.ring"
                         @click="clear">
                         Effacer
                     </Button>

--- a/packages/frontend/ui/src/components/Input/CheckboxUi.vue
+++ b/packages/frontend/ui/src/components/Input/CheckboxUi.vue
@@ -15,7 +15,7 @@
             <label class="flex items-center justify-between w-full hover:bg-blue200 py-2 pr-4 text-primary cursor-pointer">
                 <input :id="`variant-invisible-${randomId()}`" ref="checkbox" @click="onChange(value)" class="appearance-none"
                     type="checkbox" :checked="checked" :disabled="disabled" />
-                <div class="flex-1">
+                <div :class="['flex-1 ', lineOffset && 'pl-2']">
                     {{ label }}
                 </div>
                 <div class="ml-4">
@@ -62,7 +62,7 @@
     </template>
 
     <template v-else>
-        <label class="cursor-pointer inline-block px-2 py-1 border border-2 border-blue200" :class="[
+        <label class="cursor-pointer inline-block px-2 py-1 border-2 border-blue200" :class="[
             checked
                 ? 'bg-blue500 text-white border-blue500'
                 : 'bg-blue200 text-primary',
@@ -110,7 +110,12 @@ const props = defineProps({
         type: String,
         required: false,
         default: ''
-    }
+    },
+    lineOffset: {
+        type: Boolean,
+        required: false,
+        default: false,
+    },
 });
 
 const { label, variant, modelValue: checked, disabled, isSubmitting, active } = toRefs(props);

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.filtres.js
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.filtres.js
@@ -34,20 +34,28 @@ export default {
                 displayBottomBorder: true,
             },
             {
+                type: "label",
+                label: "Incluant...",
+            },
+            {
                 value: "1",
                 label: "Français",
+                lineOffset: true,
             },
             {
                 value: "2",
                 label: "Union européenne",
+                lineOffset: true,
             },
             {
                 value: "3",
                 label: "Hors Union européenne",
+                lineOffset: true,
             },
             {
                 value: "unknown",
                 label: "Inconnu",
+                lineOffset: true,
             },
         ],
     },

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesFiltres.vue
@@ -154,10 +154,26 @@ watch(isUeOnly, (newValue) => {
 
 watch(
     () => townsStore.filters.properties.origin,
-    (newValue) => {
+    (newValue, oldValue) => {
         if (!isProcessing.value) {
             isProcessing.value = true;
-            isUeOnly.value = newValue[0] === "0";
+            const hasOtherValues = newValue.some((value) => value !== "0");
+            if (
+                hasOtherValues &&
+                newValue.includes("0") &&
+                oldValue.includes("0")
+            ) {
+                const currentFilters = { ...townsStore.filters.properties };
+                const filteredOrigin = currentFilters.origin.filter(
+                    (value) => value !== "0"
+                );
+                townsStore.filters.properties = {
+                    ...currentFilters,
+                    origin: filteredOrigin,
+                };
+            } else {
+                isUeOnly.value = newValue[0] === "0";
+            }
             isProcessing.value = false;
         }
     },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Z5wI721S/2315

## 🛠 Description de la PR
- Corriger le bug suivant: quand on a sélectionné "Exclusivement UE" dans le filtre "Origine" de la liste des sites, si on sélectionne ensuite l'une des autres valeurs, "Exclusivement UE" reste actif.
- Corriger le décalage de l'option "Effacer" dans les listes de filtres
- Ajouter "Incluant" avant les options non exclusives de la liste du filtre "Origines"
- Décaler légèrement à droite les valeurs des options non exclusives de la liste du filtre "Origines"

## 📸 Captures d'écran
![{08908B6E-CB21-450E-A3AA-93B67EBB312B}](https://github.com/user-attachments/assets/bd095c93-0820-4ba1-9699-02ebce0bed10)

## 🚨 Notes pour la mise en production
- Ràs