### PR TITLE
feat: Ajout des information femmes et filles dans l'export des sites

### DIFF
--- a/packages/api/server/services/shantytown/_common/createExportSections.ts
+++ b/packages/api/server/services/shantytown/_common/createExportSections.ts
@@ -75,8 +75,10 @@ export default async (
         title: 'Habitants',
         properties: [
             properties.populationTotal,
+            properties.populationTotalFemales,
             properties.populationCouples,
             properties.populationMinors,
+            properties.populationMinorsGirls,
             properties.populationMinors0To3,
             properties.populationMinors3To6,
             properties.populationMinors6To12,

--- a/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
+++ b/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
@@ -173,6 +173,12 @@ export default (closingSolutions: ClosingSolution[]) => {
             width: COLUMN_WIDTHS.SMALL,
             sum: true,
         },
+        populationTotalFemales: {
+            title: 'dont femmes et filles',
+            data: ({ populationTotalFemales }: ShantytownWithFinancedAction) => populationTotalFemales,
+            width: COLUMN_WIDTHS.SMALL,
+            sum: true,
+        },
         populationCouples: {
             title: 'Nombre de ménages',
             data: ({ populationCouples }: ShantytownWithFinancedAction) => populationCouples,
@@ -182,6 +188,12 @@ export default (closingSolutions: ClosingSolution[]) => {
         populationMinors: {
             title: 'Nombre de mineurs',
             data: ({ populationMinors }: ShantytownWithFinancedAction) => populationMinors,
+            width: COLUMN_WIDTHS.SMALL,
+            sum: true,
+        },
+        populationMinorsGirls: {
+            title: 'dont filles',
+            data: ({ populationMinorsGirls }: ShantytownWithFinancedAction) => populationMinorsGirls,
             width: COLUMN_WIDTHS.SMALL,
             sum: true,
         },

--- a/packages/api/server/services/shantytown/export/section_people/populationHistory.ts
+++ b/packages/api/server/services/shantytown/export/section_people/populationHistory.ts
@@ -12,8 +12,10 @@ const intToStr = (int, nullValue = 'NC') => {
 type TownExportPopulationHistoryRow = {
     date: string,
     populationTotal: number,
+    populationTotalFemales: number,
     populationCouples: number,
     populationMinors: number,
+    populationMinorsGirls: number,
     populationMinors0To3: number,
     populationMinors3To6: number,
     populationMinors6To12: number,
@@ -31,12 +33,17 @@ export default (town: Shantytown): TownExportPopulationHistoryRow[] => {
     // valeurs présentes
     const ref = {
         populationTotal: intToStr(town.populationTotal, '-'),
+        populationTotalFemales: intToStr(town.populationTotalFemales, '-'),
         populationCouples: intToStr(
             town.populationCouples,
             '-',
         ),
         populationMinors: intToStr(
             town.populationMinors,
+            '-',
+        ),
+        populationMinorsGirls: intToStr(
+            town.populationMinorsGirls,
             '-',
         ),
         populationMinors0To3: intToStr(

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
@@ -231,8 +231,6 @@ const populationHistory = computed(() => {
 
     // on traite le changelog pour n'y conserver que les étapes qui contiennent au moins un
     // changement sur les champs de population
-    console.log("Changelog: ", town.value.changelog);
-
     const entries = town.value.changelog
         .map((entry) => {
             return {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/E43u1P44/2309-sites-mise-%C3%A0-jour-de-lexport-suite-%C3%A0-lint%C3%A9gration-des-mineures

## 🛠 Description de la PR
Ajout des nouvelles données "dont femmes et filles" dans l'export des sites .

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/66ba49eb-551f-4eae-a72c-4921690f83d1)

## 🚨 Notes pour la mise en production
RàS