### PR TITLE
#patch (2314) Ajout d'une entête Phases pour les sites en cours de résorption

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeLivingConditions.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeLivingConditions.vue
@@ -2,7 +2,7 @@
     <span class="sr-only">Statut des conditions de vie</span>
     <ul v-if="shantytown.livingConditions.version === 2" class="pl-5">
         <div class="mb-1 font-bold -ml-5 whitespace-nowrap">
-            Conditions de Vie
+            Conditions de vie
         </div>
         <CarteSiteDetailleeLivingConditionIcon
             :status="shantytown.livingConditions.water.status.status"

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleePhasesPreparatoiresResorption.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleePhasesPreparatoiresResorption.vue
@@ -1,6 +1,9 @@
 <template>
     <span class="sr-only">Phases préparatoires à la résorption du site</span>
     <ul v-if="shantytown.livingConditions.version === 2">
+        <div class="mb-1 font-bold -ml-5 whitespace-nowrap">
+            Phases préparatoires
+        </div>
         <li
             v-for="phase in shantytown.preparatoryPhasesTowardResorption"
             :key="phase.preparatoryPhaseId"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/dLiYp6YJ/2314-exe-44-ajout-dune-ent%C3%AAte-phases-pour-les-sites-en-cours-de-r%C3%A9sorption

## 🛠 Description de la PR
Cette PR ajoute une entête à la nouvelle colonne des "phases de la résorption" liée à l'EXPE 44

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/c4f48974-e22e-4fca-8391-99f290a75cc7)

## 🚨 Notes pour la mise en production
Merge dans develop après avoir mergé #1061 