### PR TITLE
feat: Colorisation de la colonne à partir de l'ouverture officielle

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
@@ -22,7 +22,7 @@
                     :class="{
                         'font-bold': colIndex === 0,
                         'bg-blue200': colIndex === 0,
-                        'bg-sky-300': closestEntryDate === col.fullDate,
+                        'bg-sky-200': closestEntryDate === col.fullDate,
                     }"
                 >
                     {{ col.date }}<br />{{ col.year }}
@@ -85,7 +85,7 @@
                         'border-b border-b-black':
                             sections[index + 1]?.icon !== undefined,
                         'bg-blue100': colIndex === 0,
-                        'bg-sky-300': closestEntryDate === col.fullDate,
+                        'bg-sky-200': closestEntryDate === col.fullDate,
                     }"
                 >
                     {{ col[section.data] }}
@@ -203,6 +203,10 @@ const sections = [
 ];
 const closestEntryDate = ref(null);
 
+const updateClosestEntryDate = (entries, entriesAboveOfficialOpening) => {
+    closestEntryDate.value = entries[entriesAboveOfficialOpening].date * 1000;
+};
+
 const populationHistory = computed(() => {
     let ref = {
         populationTotal: formatInt(town.value.populationTotal, "-"),
@@ -290,8 +294,7 @@ const populationHistory = computed(() => {
                     );
                 }).length - 1;
 
-            closestEntryDate.value =
-                entries[entriesAboveOfficialOpening].date * 1000;
+            updateClosestEntryDate(entries, entriesAboveOfficialOpening);
         }
     }
     // s'il y a eu au moins une modification

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
@@ -274,7 +274,6 @@ const populationHistory = computed(() => {
     }
 
     let officialOpeningDate = null;
-    // let closestEntryDate = null;
     if (town.value.preparatoryPhasesTowardResorption?.length > 0) {
         officialOpeningDate = town.value.preparatoryPhasesTowardResorption.find(
             (phase) => phase.preparatoryPhaseId === "official_opening"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/y50WXA16/2308-exp%C3%A9-44-visualisation-de-la-date-douverture-dans-le-tableau-des-habitants

## 🛠 Description de la PR
La PR intègre une visualisation de la colonne du tableau des habitants à partir de laquelle l'ouverture officielle a été faite.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/ff57a06c-d998-4626-8c4f-ef3c26f042c7)

## 🚨 Notes pour la mise en production
RàS