### PR TITLE
fix: Correction d'une erreur de valeur non présente

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
@@ -204,7 +204,8 @@ const sections = [
 const closestEntryDate = ref(null);
 
 const updateClosestEntryDate = (entries, entriesAboveOfficialOpening) => {
-    closestEntryDate.value = entries[entriesAboveOfficialOpening].date * 1000;
+    closestEntryDate.value =
+        entries[entriesAboveOfficialOpening]?.date * 1000 || null;
 };
 
 const populationHistory = computed(() => {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/y50WXA16/2308-exp%C3%A9-44-visualisation-de-la-date-douverture-dans-le-tableau-des-habitants

## 🛠 Description de la PR
Correction d'une erreur empêchant l'affichage du tableau des habitants

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS_