### PR TITLE
Wording: Ajout d'une légende pour le recensement de la population

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
@@ -93,6 +93,10 @@
             </tr>
         </tbody>
     </table>
+    <div class="flex mt-2 gap-2" v-if="closestEntryDate">
+        <div class="relative w-5 h-5 bg-sky-200"></div>
+        Recensement de la population au démarrage de la résorption
+    </div>
 </template>
 
 <script setup>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/y50WXA16/2308-exp%C3%A9-44-visualisation-de-la-date-douverture-dans-le-tableau-des-habitants

## 🛠 Description de la PR
La PR apporte une légende affichée uniquement si une date d'ouverture officielle est renseignée.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS