### PR TITLE
#patch (2329) Modification de la requête SQL de récupération de l'évolution nationale

### DIFF
--- a/packages/api/server/models/metricsModel/getNationalEvolutionData.ts
+++ b/packages/api/server/models/metricsModel/getNationalEvolutionData.ts
@@ -19,73 +19,72 @@ export default async (user, from: Date, to: Date): Promise<NationalEvolutionMetr
 
     return sequelize.query(
         `WITH month_series AS (
-        SELECT generate_series(
+          SELECT generate_series(
             date_trunc('month', TIMESTAMP '${replacements.from}'),
             date_trunc('day', TIMESTAMP '${replacements.to}'),
             '1 month'::interval
-        ) AS month
+          ) AS month
         ), serie_ms AS (
             -- Evolution de la population d'un site par mois
             SELECT
-            ms.month
-            , max(sh.updated_at) as archives
-            , st.shantytown_id
-            , max(sh.hid) as archives_hid
+              ms.month
+             , max(sh.updated_at) as archives
+             , st.shantytown_id
+             , max(sh.hid) as archives_hid
             FROM
-            month_series ms
+              month_series ms
             JOIN shantytowns st ON
-            (date_trunc('month', st.built_at) <= ms.month AND
-            (st.closed_at IS NULL OR date_trunc('month', st.closed_at) > ms.month)) OR
-            (st.built_at IS NULL AND st.status = 'open')
+              (date_trunc('month', st.built_at) <= ms.month AND
+              (st.closed_at IS NULL OR date_trunc('month', st.closed_at) > ms.month)) OR
+              (st.built_at IS NULL AND st.status = 'open')
             LEFT JOIN "ShantytownHistories" sh ON st.shantytown_id=sh.shantytown_id AND date_trunc('month', sh.updated_at) <= ms.month
-            GROUP BY st.shantytown_id, ms.month 
+            GROUP BY st.shantytown_id, ms.month
             ORDER BY
-            ms.month DESC  
+              ms.month DESC
         ), aggregated_origins AS (
-        -- typologe de population
-        SELECT
+          -- typologe de population
+          SELECT
             month,
-            fk_shantytown,
-            SUM(CASE WHEN fk_social_origin = 1 THEN (CASE WHEN date_trunc('month', st.updated_at) <= month  THEN st.population_total ELSE sh.population_total END) ELSE 0 END) AS français_count, 
-            SUM(CASE WHEN fk_social_origin = 2 THEN (CASE WHEN date_trunc('month', st.updated_at) <= month  THEN st.population_total ELSE sh.population_total END) ELSE 0 END) AS intra_eu_count,
-            SUM(CASE WHEN fk_social_origin = 3 THEN (CASE WHEN date_trunc('month', st.updated_at) <= month  THEN st.population_total ELSE sh.population_total END) ELSE 0 END) AS extra_eu_count,
-            COUNT(fk_social_origin) as social_origin_count,
-            SUM((CASE WHEN date_trunc('month', st.updated_at) <= month  THEN st.population_total ELSE sh.population_total END))/count(fk_social_origin) AS total_population
-        FROM shantytown_origins
-        JOIN shantytowns st ON st.shantytown_id = shantytown_origins.fk_shantytown
-        INNER JOIN serie_ms ON serie_ms.shantytown_id=st.shantytown_id
-        LEFT JOIN "ShantytownHistories" sh ON serie_ms.archives_hid=sh.hid
-        GROUP BY month, fk_shantytown
+            st.shantytown_id,
+            SUM(CASE WHEN date_trunc('month', st.updated_at) <= month THEN (CASE WHEN shantytown_origins.fk_social_origin = 1 THEN st.population_total ELSE 0 END) ELSE (CASE WHEN soh.fk_social_origin = 1 THEN sh.population_total ELSE 0 END) END)  AS français_count
+            , SUM(CASE WHEN date_trunc('month', st.updated_at) <= month THEN (CASE WHEN shantytown_origins.fk_social_origin = 2 THEN st.population_total ELSE 0 END) ELSE (CASE WHEN soh.fk_social_origin = 2 THEN sh.population_total ELSE 0 END) END)  AS intra_eu_count
+            , SUM(CASE WHEN date_trunc('month', st.updated_at) <= month THEN (CASE WHEN shantytown_origins.fk_social_origin = 3 THEN st.population_total ELSE 0 END) ELSE (CASE WHEN soh.fk_social_origin = 3 THEN sh.population_total ELSE 0 END) END)  AS extra_eu_count
+            , SUM(CASE WHEN date_trunc('month', st.updated_at) <= month THEN st.population_total ELSE sh.population_total END) / COUNT(CASE WHEN date_trunc('month', st.updated_at) <= month  THEN shantytown_origins.fk_social_origin ELSE soh.fk_social_origin END) AS total_population
+            -- logs de debug
+            , string_agg(CAST(shantytown_origins.fk_social_origin AS text), ',' ORDER BY shantytown_origins.fk_social_origin ASC) AS origin_sites
+            , string_agg(CAST(soh.fk_social_origin AS text), ',' ORDER BY soh.fk_social_origin ASC) AS histori_origin_sites
+          FROM shantytowns st
+          INNER JOIN serie_ms ON serie_ms.shantytown_id=st.shantytown_id
+          LEFT JOIN shantytown_origins ON st.shantytown_id = shantytown_origins.fk_shantytown AND date_trunc('month', st.updated_at) <= month
+          LEFT JOIN "ShantytownHistories" sh ON serie_ms.archives_hid=sh.hid AND date_trunc('month', st.updated_at) > month
+          LEFT JOIN "ShantytownOriginHistories" soh ON soh.fk_shantytown=sh.hid AND date_trunc('month', st.updated_at) > month
+          GROUP BY month, st.shantytown_id
+        --  ORDER BY month DESC
         )
-        SELECT 
-        serie_ms.month
-        , COUNT(CASE WHEN st.shantytown_id IS NOT NULL THEN 1 END) AS toutes_origin_shantytowns_count
-        , SUM (CASE WHEN date_trunc('month', st.updated_at) <= serie_ms.month  THEN st.population_total ELSE sh.population_total END) as toutes_origin_count
-        , COUNT(CASE WHEN ao.extra_eu_count = 0 AND ao.français_count = 0 THEN 1 END) AS only_intra_eu_shantytowns_count
-        , SUM(CASE WHEN ao.extra_eu_count = 0 AND ao.français_count = 0 THEN ao.intra_eu_count END) AS intra_eu_count
-            -- log de debug
-        , string_agg(CAST(st.shantytown_id AS text), ',' ORDER BY st.shantytown_id ASC) AS toutes_origin_sites
-        , string_agg(CASE WHEN ao.extra_eu_count = 0 AND ao.français_count = 0 THEN CAST(st.shantytown_id AS text) END, ',' ORDER BY st.shantytown_id ASC) AS only_intra_eu_sites
-        , string_agg(CAST(CASE WHEN date_trunc('month', st.updated_at) <= serie_ms.month  THEN st.population_total ELSE sh.population_total END AS text), ',' ORDER BY st.shantytown_id ASC) AS population_total_site
-        , string_agg(CAST(CASE WHEN ao.extra_eu_count = 0 AND ao.français_count = 0 THEN ao.intra_eu_count END AS text), ',' ORDER BY st.shantytown_id ASC) as population_intra_ue_site
+        SELECT
+          serie_ms.month
+          , COUNT(CASE WHEN st.shantytown_id IS NOT NULL THEN 1 END) AS toutes_origin_shantytowns_count
+          , SUM (CASE WHEN date_trunc('month', st.updated_at) <= serie_ms.month  THEN st.population_total ELSE sh.population_total END) as toutes_origin_count
+          , COUNT(CASE WHEN ao.extra_eu_count = 0 AND ao.français_count = 0 AND ao.intra_eu_count > 0 THEN 1 END) AS only_intra_eu_shantytowns_count
+          , SUM(CASE WHEN ao.extra_eu_count = 0 AND ao.français_count = 0 THEN ao.intra_eu_count END) AS intra_eu_count
         FROM serie_ms
         LEFT JOIN "ShantytownHistories" sh ON serie_ms.archives_hid=sh.hid
         INNER JOIN shantytowns st ON serie_ms.shantytown_id=st.shantytown_id
-        LEFT JOIN aggregated_origins ao ON st.shantytown_id = ao.fk_shantytown AND ao.month=serie_ms.month
+        LEFT JOIN aggregated_origins ao ON st.shantytown_id = ao.shantytown_id AND ao.month=serie_ms.month
         JOIN
-        cities AS c ON st.fk_city = c.code
+          cities AS c ON st.fk_city = c.code
         JOIN
-        departements AS d ON c.fk_departement = d.code
+          departements AS d ON c.fk_departement = d.code
         WHERE
-        d.code NOT IN ('971', '972', '973', '974', '975', '976', '977', '978', '984', '986', '987', '988', '989') -- Exclure les départements d'outre-mer 
-        -- ne concerver que les sites de 10 et +, en fonction du mois
-        AND (CASE WHEN date_trunc('month', st.updated_at) <= serie_ms.month  THEN st.population_total ELSE sh.population_total END) >=10
-        -- on ne tient pas compte des variations de la typologie du site : on conserve la + à jour
-        AND st.fk_field_type IN (2,3) -- ne concerver que bati et terrain
+          d.code NOT IN ('971', '972', '973', '974', '975', '976', '977', '978', '984', '986', '987', '988', '989') -- Exclure les départements d'outre-mer
+        -- ne conserver que les sites de 10 et +, en fonction du mois
+         AND (CASE WHEN date_trunc('month', st.updated_at) <= serie_ms.month  THEN st.population_total ELSE sh.population_total END) >=10
+         -- on ne tient pas compte des variations de la typologie du site : on conserve la + à jour
+         AND st.fk_field_type IN (2,3) -- ne conserver que bati et terrain
         GROUP BY
         serie_ms.month
         ORDER BY
-        serie_ms.month ASC;`,
+         serie_ms.month DESC`,
         {
             type: QueryTypes.SELECT,
             replacements,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/cGFx2eV7/2329-visu-donn%C3%A9es-mise-%C3%A0-jour-du-calcul-pour-tenir-compte-de-la-variation-des-origines-de-population

## 🛠 Description de la PR
Cette PR modifie la requête de récupération des données utilisées dans la visualisation de l'évolution nationale.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/a8fcad3a-4092-46a4-8657-7f7111b86eab)

## 🚨 Notes pour la mise en production
RàS