### PR TITLE
#patch (2345) [tech] Upgrade de actions/cache de la v2 à la v4

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get yarn cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
         id: yarn-cache
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/setup-buildx-action@master
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag }}
@@ -60,7 +60,7 @@ jobs:
         uses: docker/setup-buildx-action@master
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag }}
@@ -99,7 +99,7 @@ jobs:
         uses: docker/setup-buildx-action@master
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-www-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-webapp-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-api-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/AaGpMdyT/2345

## 🛠 Description de la PR
Mise à jour des scripts actions Github: passage de la v2 à la v4 de `actions/cache`
