### PR TITLE
#patch (2326) Afficher la structure des pilotes et opérateurs

### DIFF
--- a/packages/api/server/models/actionModel/fetch/mergeManagers.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeManagers.ts
@@ -16,6 +16,8 @@ export default function mergeManagers(hash: ActionHash, managers: ActionUserRow[
             is_admin: row.admin_role_name !== null,
             organization: {
                 id: row.organization_id,
+                name: row.organization_name,
+                abbreviation: row.organization_abbreviation,
             },
         };
 

--- a/packages/api/server/models/actionModel/fetch/mergeOperators.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeOperators.ts
@@ -16,6 +16,8 @@ export default function mergeOperators(hash: ActionHash, operators: ActionUserRo
             is_admin: row.admin_role_name !== null,
             organization: {
                 id: row.organization_id,
+                name: row.organization_name,
+                abbreviation: row.organization_abbreviation,
             },
         };
 

--- a/packages/api/server/models/actionModel/fetchByShantytown/mergeOperators.ts
+++ b/packages/api/server/models/actionModel/fetchByShantytown/mergeOperators.ts
@@ -16,6 +16,8 @@ export default (hash: ActionHash, operators: ActionUserRow[]): void => {
             is_admin: row.admin_role_name !== null,
             organization: {
                 id: row.organization_id,
+                name: row.organization_name,
+                abbreviation: row.organization_abbreviation,
             },
         };
 

--- a/packages/api/types/resources/Action.d.ts
+++ b/packages/api/types/resources/Action.d.ts
@@ -125,7 +125,9 @@ export type ActionOrganizationMember = {
     role: string,
     is_admin: boolean,
     organization: {
-        id: number
+        id: number,
+        name: string,
+        abbreviation: string,
     }
 };
 type ActionOrganization = {

--- a/packages/frontend/webapp/src/components/CarteUtilisateur/CarteUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/CarteUtilisateur/CarteUtilisateur.vue
@@ -10,8 +10,15 @@
     >
         <div>
             <h2 class="font-bold" :class="user.is_admin ? 'text-info' : ''">
-                {{ user.last_name.toUpperCase() }}
-                {{ user.first_name }}
+                <p>
+                    {{ user.last_name.toUpperCase() }}
+                    {{ user.first_name }}
+                </p>
+                <p v-if="includeOrganization" class="text-black">
+                    {{
+                        user.organization.abbreviation || user.organization.name
+                    }}
+                </p>
             </h2>
             <p>{{ user.position }}</p>
             <p class="mt-2">
@@ -85,6 +92,11 @@ const props = defineProps({
         type: Boolean,
         required: false,
         default: true,
+    },
+    includeOrganization: {
+        type: Boolean,
+        required: false,
+        default: false,
     },
 });
 const { user, linkToUser } = toRefs(props);

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionOperateur.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionOperateur.vue
@@ -7,6 +7,7 @@
             :key="user.id"
             :user="user"
             :linkToUser="false"
+            includeOrganization
         />
     </FicheSousRubrique>
 </template>

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionPilotes.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionPilotes.vue
@@ -7,6 +7,7 @@
             :key="user.id"
             :user="user"
             :linkToUser="false"
+            includeOrganization
         />
     </FicheSousRubrique>
 </template>

--- a/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
+++ b/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
@@ -2,7 +2,7 @@
     <ContentWrapper>
         <ViewHeader icon="building">
             <template v-slot:title
-                >Fiche structure —
+                >Fiche structure -
                 <span class="text-primary">{{
                     organization.name
                 }}</span></template


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/39DDcWfS/2326

## 🛠 Description de la PR
- Affiche la l'abréviation ou le nom de la structure de l'utilisateur dans les parties "pilotes" et "opérateurs" de la fiche action
- Comme la carte affichant ces infos est commune avec celle utilisée dans l'annuaire et qu'il n'est pas nécessaire de repréciser ces informations dans l'annuaire affichant déjà les contacts par organisation, ces informations sont rendues facultatives par défaut

## 📸 Captures d'écran
![{C9DBF673-EACB-4F7A-8C13-E5BECEAFFBE0}](https://github.com/user-attachments/assets/7e384eb1-bd48-4fc2-a74f-9458da0c3086)

## 🚨 Notes pour la mise en production
- ràs