### PR TITLE
#patch (2328) Visualiser si un site ou une action dispose de PJ

### DIFF
--- a/packages/api/server/models/shantytownDecreeModel/findAll.ts
+++ b/packages/api/server/models/shantytownDecreeModel/findAll.ts
@@ -2,7 +2,7 @@ import { sequelize } from '#db/sequelize';
 import { QueryTypes, Transaction } from 'sequelize';
 import { ShantytownDecree } from './shantytownDecrees.d';
 
-export default (shantytownIds: number, transaction: Transaction = undefined): Promise<ShantytownDecree[]> => {
+export default (shantytownIds: number[], transaction: Transaction = undefined): Promise<ShantytownDecree[]> => {
     const ids: number[] = Array.isArray(shantytownIds) ? shantytownIds : [shantytownIds];
 
     return sequelize.query(

--- a/packages/api/server/models/shantytownDecreeModel/findAll.ts
+++ b/packages/api/server/models/shantytownDecreeModel/findAll.ts
@@ -2,7 +2,7 @@ import { sequelize } from '#db/sequelize';
 import { QueryTypes, Transaction } from 'sequelize';
 import { ShantytownDecree } from './shantytownDecrees.d';
 
-export default (shantytownIds: number[], transaction: Transaction = undefined): Promise<ShantytownDecree[]> => {
+export default (shantytownIds: number | number[], transaction: Transaction = undefined): Promise<ShantytownDecree[]> => {
     const ids: number[] = Array.isArray(shantytownIds) ? shantytownIds : [shantytownIds];
 
     return sequelize.query(

--- a/packages/api/server/models/shantytownDecreeModel/shantytownDecrees.d.ts
+++ b/packages/api/server/models/shantytownDecreeModel/shantytownDecrees.d.ts
@@ -1,6 +1,8 @@
 export type ShantytownDecree = {
     shantytownDecreeId: number,
+    attachmentId: number,
     shantytownId: number,
+    attachmentType: string,
     decreeType: string,
     fileKey: string,
     previewFileKey: string | null,

--- a/packages/api/server/services/shantytown/list.ts
+++ b/packages/api/server/services/shantytown/list.ts
@@ -3,6 +3,7 @@ import ServiceError from '#server/errors/ServiceError';
 import shantytownDecree from '#server/services/shantytownDecree/findAll';
 import { ShantytownDecree } from '#server/models/shantytownDecreeModel/shantytownDecrees.d';
 import serializeAttachment from '#server/services/attachment/serializeAttachment';
+import can from '#server/utils/permission/can';
 import { Attachment } from '../attachment/Attachment';
 
 export default async (user, search = undefined) => {
@@ -26,7 +27,7 @@ export default async (user, search = undefined) => {
             'list',
         );
 
-        if (user.permissions.shantytown_justice.access.allowed) {
+        if (can(user).do('access', 'shantytown_justice').on(shantytowns)) {
             const decrees: ShantytownDecree[] = await shantytownDecree(user, shantytowns.map(town => town.id));
 
             shantytowns = await Promise.all(shantytowns.map(async (shantytown) => {

--- a/packages/api/server/services/shantytown/list.ts
+++ b/packages/api/server/services/shantytown/list.ts
@@ -1,5 +1,9 @@
 import shantytownModel from '#server/models/shantytownModel';
 import ServiceError from '#server/errors/ServiceError';
+import shantytownDecree from '#server/services/shantytownDecree/findAll';
+import { ShantytownDecree } from '#server/models/shantytownDecreeModel/shantytownDecrees.d';
+import serializeAttachment from '#server/services/attachment/serializeAttachment';
+import { Attachment } from '../attachment/Attachment';
 
 export default async (user, search = undefined) => {
     const filters = search !== undefined ? [
@@ -21,6 +25,30 @@ export default async (user, search = undefined) => {
             filters,
             'list',
         );
+
+        if (user.permissions.shantytown_justice.access.allowed) {
+            const decrees: ShantytownDecree[] = await shantytownDecree(user, shantytowns.map(town => town.id));
+
+            shantytowns = await Promise.all(shantytowns.map(async (shantytown) => {
+                const updatedShantytown = { ...shantytown };
+                if (updatedShantytown.attachments === undefined) {
+                    updatedShantytown.attachments = [];
+                }
+
+                const filteredDecrees = decrees.filter(filteredDecree => filteredDecree.shantytownId === updatedShantytown.id);
+                if (filteredDecrees.length > 0) {
+                    const attachments: Attachment[] = await Promise.all(filteredDecrees.map(async attachment => ({
+                        ...await serializeAttachment([attachment.attachmentId, attachment.fileKey, attachment.previewFileKey, attachment.originalName, attachment.type, attachment.size, attachment.createdBy].join('@.;.@')),
+                        type: attachment.attachmentType,
+                        mimetype: attachment.type,
+                    })));
+
+                    updatedShantytown.attachments.push(...attachments);
+                }
+
+                return updatedShantytown;
+            }));
+        }
     } catch (error) {
         throw new ServiceError('fetch_failed', error);
     }

--- a/packages/api/server/services/shantytownDecree/findAll.ts
+++ b/packages/api/server/services/shantytownDecree/findAll.ts
@@ -1,16 +1,8 @@
-import shantytownModel from '#server/models/shantytownModel';
 import shantytownDecreeModel from '#server/models/shantytownDecreeModel';
-import ServiceError from '#server/errors/ServiceError';
 import { ShantytownDecree } from '#server/models/shantytownDecreeModel/shantytownDecrees.d';
 import { User } from '#root/types/resources/User.d';
 
-export default async (user: User, townId: number) => {
-    const town = await shantytownModel.findOne(user, townId);
-
-    if (town === null) {
-        throw new ServiceError('fetch_failed', new Error('Impossible de retrouver le site en base de données'));
-    }
-
+export default async (user: User, townId: number | number[]) => {
     const shantytownDecrees: ShantytownDecree[] = await shantytownDecreeModel.findAll(townId);
 
     return shantytownDecrees;

--- a/packages/frontend/webapp/src/components/ArrangementLeftMenu/ArrangementLeftMenuColumn.vue
+++ b/packages/frontend/webapp/src/components/ArrangementLeftMenu/ArrangementLeftMenuColumn.vue
@@ -28,9 +28,9 @@
                     focusClasses.ring,
                 ]"
                 replace
-                ><Icon v-if="tab.icon" :icon="tab.icon" />
-                {{ tab.label }}</RouterLink
-            >
+                ><Icon v-if="tab.icon" :icon="tab.icon" /> {{ tab.label }}
+                <Icon v-if="tab.postIcon" icon="paperclip"
+            /></RouterLink>
         </template>
     </nav>
 </template>
@@ -53,6 +53,7 @@ const props = defineProps({
 });
 
 const { tabs, activeTab } = toRefs(props);
+
 const classes = {
     primary: "text-primary",
     secondary: "text-secondary",

--- a/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
@@ -12,26 +12,46 @@
             @mouseenter="isHover = true"
             @mouseleave="isHover = false"
         >
-            <div class="mb-4 px-6 -mt-1 pt-px">
-                <Tag
-                    tabindex="0"
-                    :aria-label="actionPeriod"
-                    :class="[
-                        'text-xs uppercase text-primary',
-                        isHover ? 'shadow-md' : '',
-                    ]"
-                >
-                    <span aria-hidden="true" v-if="action.ended_at"
-                        >du
-                        {{ formatDate(action.started_at / 1000, "d/m/y") }}
-                        au
-                        {{ formatDate(action.ended_at / 1000, "d/m/y") }}</span
+            <div class="mb-4 px-6 -mt-1 pt-px flex gap-2">
+                <div>
+                    <Tag
+                        tabindex="0"
+                        :aria-label="actionPeriod"
+                        :class="[
+                            'text-xs uppercase text-primary',
+                            isHover ? 'shadow-md' : '',
+                        ]"
                     >
-                    <span aria-hidden="true" v-else>
-                        depuis le
-                        {{ formatDate(action.started_at / 1000, "d/m/y") }}
-                    </span>
-                </Tag>
+                        <span aria-hidden="true" v-if="action.ended_at"
+                            >du
+                            {{ formatDate(action.started_at / 1000, "d/m/y") }}
+                            au
+                            {{
+                                formatDate(action.ended_at / 1000, "d/m/y")
+                            }}</span
+                        >
+                        <span aria-hidden="true" v-else>
+                            depuis le
+                            {{ formatDate(action.started_at / 1000, "d/m/y") }}
+                        </span>
+                    </Tag>
+                </div>
+                <div
+                    class="flex sm:absolute sm:right-14 mt-[3px]"
+                    v-if="attachmentsLabel"
+                >
+                    <Tag
+                        tabindex="1"
+                        :aria-label="attachmentsLabel"
+                        variant="highlight"
+                        :class="[
+                            'text-xs uppercase text-primary justify-self-end items-center gap-2',
+                            isHover ? 'shadow-md' : '',
+                        ]"
+                        ><Icon icon="paperclip" class="text-xs md:text-md" />
+                        {{ attachmentsLabel }}</Tag
+                    >
+                </div>
             </div>
 
             <div class="px-6 text-primary text-display-md font-bold">
@@ -103,6 +123,18 @@ const actionPeriod = computed(() => {
             formatDate(action.value.started_at / 1000, "d/m/y")
         );
     }
+});
+
+const attachmentsLabel = computed(() => {
+    const commentsAttachments = action.value.comments.reduce((sum, comment) => {
+        return sum + (comment.attachments ? comment.attachments.length : 0);
+    }, 0);
+
+    return commentsAttachments > 1
+        ? `${commentsAttachments} Pièces jointes`
+        : commentsAttachments === 0
+        ? null
+        : `${commentsAttachments} Pièce jointe`;
 });
 </script>
 

--- a/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
@@ -131,10 +131,10 @@ const attachmentsLabel = computed(() => {
     }, 0);
 
     return commentsAttachments > 1
-        ? `${commentsAttachments} Pièces jointes`
+        ? `${commentsAttachments} Documents partagés`
         : commentsAttachments === 0
         ? null
-        : `${commentsAttachments} Pièce jointe`;
+        : `${commentsAttachments} Document partagé`;
 });
 </script>
 

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
@@ -1,28 +1,44 @@
 <template>
-    <header class="px-6">
-        <Tag
-            :variant="pinVariant"
-            :class="['text-xs uppercase', isHover ? 'shadow-md' : '']"
-            class="mt-1"
-        >
-            {{ lastUpdate }}
-        </Tag>
-        <Tag
-            v-if="heatwaveStatus === true"
-            variant="highlight"
-            :class="[
-                'ml-4 text-xs uppercase text-primary',
-                isHover ? 'shadow-md' : '',
-            ]"
-        >
-            Risque Canicule
-        </Tag>
-        <ResorptionTargetTag
-            class="ml-4"
-            v-if="shantytown.resorptionTarget"
-            :target="shantytown.resorptionTarget"
-            :isHover="isHover"
-        />
+    <header class="px-6 flex flex-col lg:flex-row justify-between">
+        <div class="flex-col sm:flex-row">
+            <Tag
+                :variant="pinVariant"
+                :class="['text-xs uppercase', isHover ? 'shadow-md' : '']"
+                class="mt-1 items-center py-2 mr-2"
+            >
+                {{ lastUpdate }}
+            </Tag>
+            <Tag
+                v-if="heatwaveStatus === true"
+                variant="highlight"
+                :class="[
+                    'mt-1 text-xs uppercase text-primary items-center py-2 mr-2',
+                    isHover ? 'shadow-md' : '',
+                ]"
+            >
+                Risque Canicule
+            </Tag>
+
+            <ResorptionTargetTag
+                v-if="shantytown.resorptionTarget"
+                :target="shantytown.resorptionTarget"
+                :isHover="isHover"
+                class="mt-1 items-center py-2"
+            />
+        </div>
+        <div class="flex lg:absolute lg:right-14" v-if="attachmentsLabel">
+            <Tag
+                variant="highlight"
+                :class="[
+                    'text-xs lg:text-xs uppercase text-primary',
+                    isHover ? 'shadow-md' : '',
+                ]"
+                class="mt-1 gap-2 lg:place-self-end items-center py-0"
+            >
+                <Icon icon="paperclip" class="text-sm lg:text-md" />
+                {{ attachmentsLabel }}
+            </Tag>
+        </div>
     </header>
 </template>
 
@@ -31,7 +47,7 @@ import { defineProps, toRefs, computed } from "vue";
 import getSince from "@/utils/getSince";
 import formatLastUpdatedAt from "@/utils/formatLastUpdatedAt";
 
-import { Tag } from "@resorptionbidonvilles/ui";
+import { Tag, Icon } from "@resorptionbidonvilles/ui";
 import ResorptionTargetTag from "@/components/TagObjectifResorption/TagObjectifResorption.vue";
 
 const props = defineProps({
@@ -52,5 +68,19 @@ const lastUpdate = computed(() => {
 });
 const heatwaveStatus = computed(() => {
     return shantytown.value.heatwaveStatus;
+});
+const attachmentsLabel = computed(() => {
+    const commentsAttachments = shantytown.value.comments.reduce(
+        (sum, comment) => {
+            return sum + (comment.attachments ? comment.attachments.length : 0);
+        },
+        0
+    );
+
+    return commentsAttachments > 1
+        ? `${commentsAttachments} Pièces jointes`
+        : commentsAttachments === 0
+        ? null
+        : `${commentsAttachments} Pièce jointe`;
 });
 </script>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
@@ -87,9 +87,9 @@ const attachmentsLabel = computed(() => {
     const totalAttachments = commentsAttachments + justiceAttachments;
 
     return totalAttachments > 1
-        ? `${totalAttachments} Pièces jointes`
+        ? `${totalAttachments} Documents partagés`
         : totalAttachments === 0
         ? null
-        : `${totalAttachments} Pièce jointe`;
+        : `${totalAttachments} Document partagé`;
 });
 </script>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
@@ -79,8 +79,10 @@ const attachmentsLabel = computed(() => {
         0
     );
 
-    const justiceAttachments = userStore.user.permissions.shantytown_justice
-        .access.allowed
+    const justiceAttachments = userStore.hasLocalizedPermission(
+        "shantytown_justice.access",
+        shantytown
+    )
         ? shantytown.value.attachments.length
         : 0;
 

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
@@ -49,6 +49,7 @@ import formatLastUpdatedAt from "@/utils/formatLastUpdatedAt";
 
 import { Tag, Icon } from "@resorptionbidonvilles/ui";
 import ResorptionTargetTag from "@/components/TagObjectifResorption/TagObjectifResorption.vue";
+import { useUserStore } from "@/stores/user.store";
 
 const props = defineProps({
     shantytown: Object,
@@ -58,6 +59,7 @@ const props = defineProps({
     },
 });
 const { shantytown, isHover } = toRefs(props);
+const userStore = useUserStore();
 
 const pinVariant = computed(() => {
     const { months } = getSince(shantytown.value.updatedAt);
@@ -77,10 +79,17 @@ const attachmentsLabel = computed(() => {
         0
     );
 
-    return commentsAttachments > 1
-        ? `${commentsAttachments} Pièces jointes`
-        : commentsAttachments === 0
+    const justiceAttachments = userStore.user.permissions.shantytown_justice
+        .access.allowed
+        ? shantytown.value.attachments.length
+        : 0;
+
+    const totalAttachments = commentsAttachments + justiceAttachments;
+
+    return totalAttachments > 1
+        ? `${totalAttachments} Pièces jointes`
+        : totalAttachments === 0
         ? null
-        : `${commentsAttachments} Pièce jointe`;
+        : `${totalAttachments} Pièce jointe`;
 });
 </script>

--- a/packages/frontend/webapp/src/components/FicheAction/FicheAction.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheAction.vue
@@ -62,6 +62,10 @@ const { action } = toRefs(props);
 const userStore = useUserStore();
 
 const tabs = computed(() => {
+    const commentsAttachments = action.value.comments.reduce((sum, comment) => {
+        return sum + (comment.attachments ? comment.attachments.length : 0);
+    }, 0);
+
     return menu
         .filter((item) => {
             if (!item.condition) {
@@ -74,6 +78,10 @@ const tabs = computed(() => {
             return {
                 ...item,
                 label: item.label(action.value),
+                postIcon:
+                    item.id === "journal_de_l_action" && commentsAttachments > 0
+                        ? true
+                        : false,
             };
         });
 });

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSite.menu.js
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSite.menu.js
@@ -34,8 +34,8 @@ export default [
         route: "#conditions_de_vie",
     },
     {
-        id: "procedure",
-        label: () => "Procédure",
+        id: "procedures",
+        label: () => "Procédures",
         route: "#procedure",
         condition() {
             const userStore = useUserStore();

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSite.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSite.vue
@@ -43,7 +43,6 @@
             />
         </ArrangementLeftMenu>
     </ContentWrapper>
-
     <FicheSiteJournal
         :town="town"
         v-if="userStore.hasLocalizedPermission('shantytown_comment.list', town)"
@@ -81,6 +80,11 @@ const { bus } = useEventBus();
 const historique = ref(null);
 
 const tabs = computed(() => {
+    const commentsAttachments = town.value.comments.reduce((sum, comment) => {
+        return sum + (comment.attachments ? comment.attachments.length : 0);
+    }, 0);
+    const proceduresAttachments = town.value.attachments?.length;
+
     return menu
         .filter((item) => {
             if (!item.condition) {
@@ -93,6 +97,12 @@ const tabs = computed(() => {
             return {
                 ...item,
                 label: item.label(town.value),
+                postIcon:
+                    (item.id === "journal_du_site" &&
+                        commentsAttachments > 0) ||
+                    (item.id === "procedures" && proceduresAttachments > 0)
+                        ? true
+                        : false,
             };
         });
 });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/HbCRB15L/2328-pj-visualiser-si-un-site-ou-une-action-dispose-de-pj

## 🛠 Description de la PR
Cette PR ajoute l'affichage d'un indicateur de présence de pièces jointes dans la liste des sites et des actions ainsi que sur les fiches de sites et d'action.
Dans le cas des sites, l'indicateur réagira également à la présence de pièces jointes liées aux procédures administratives ou judiciaire en fonction des droits de l'utilisateur.
Dans les liste de sites et d'actions, l'indicateur embarquera le cumul de documents du site ou de l'action en question.
Sur une fiche de site ou d'action, un indicateur (trombone) sera affiché sur le journal (du site ou de l'action) ainsi que sur les procédures sur la fiche site, en fonction des droits de l'utilisateur.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/c29b9b66-12a1-4c50-a3e9-17ba6d89a824)
![image](https://github.com/user-attachments/assets/d032a98f-dc39-4dbf-8491-febf8ca3f99b)

## 🚨 Notes pour la mise en production
RàS