### PR TITLE
fix: (2348) Désactivation temporaire du fail on cache miss et ajout de intlify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           key: ${{ runner.os }}-www-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}
           restore-keys: |
             ${{ runner.os }}-www-buildx
-          fail-on-cache-miss: true
+          fail-on-cache-miss: false
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -118,7 +118,7 @@ jobs:
           key: ${{ runner.os }}-webapp-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}
           restore-keys: |
             ${{ runner.os }}-webapp-buildx
-          fail-on-cache-miss: true
+          fail-on-cache-miss: false
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -154,7 +154,7 @@ jobs:
           key: ${{ runner.os }}-api-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}
           restore-keys: |
             ${{ runner.os }}-api-buildx
-          fail-on-cache-miss: true
+          fail-on-cache-miss: false
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.32.0",
     "@aws-sdk/s3-request-presigner": "^3.598.0",
+    "@intlify/core-base": "latest",
+    "@intlify/shared": "latest",
     "@sentry/node": "^7.54.0",
     "@sentry/tracing": "^7.54.0",
     "@supercharge/promise-pool": "^2.4.0",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QgrljKuc/2348-fix-correctifs-li%C3%A9s-%C3%A0-la-mont%C3%A9e-de-version-des-actions

## 🛠 Description de la PR
La PR désactive temporairement le `fail on cache miss` et ajoute intlify shared et core.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS