### PR TITLE
tech: (2348) Passage de www en node:18

### DIFF
--- a/Dockerfile.www
+++ b/Dockerfile.www
@@ -39,7 +39,7 @@ RUN yarn build
 ###
 # PRODUCTION STAGE
 ###
-FROM node:16-alpine AS production
+FROM node:18-alpine AS production
 ENV NODE_ENV production
 ENV HOST=0.0.0.0
 

--- a/Dockerfile.www
+++ b/Dockerfile.www
@@ -1,7 +1,7 @@
 ###
 # BUILD STAGE
 ###
-FROM node:16-alpine AS build
+FROM node:18-alpine AS build
 ENV NODE_ENV production
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QgrljKuc/2348-fix-correctifs-li%C3%A9s-%C3%A0-la-mont%C3%A9e-de-version-des-actions

## 🛠 Description de la PR
Passage de node:16 à node:18 sur www pour corriger les potentielles incompatibilités de versions (intlify,...)

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS