### PR TITLE
fix: (2348) Test du passage en node:20 pour le build www

### DIFF
--- a/Dockerfile.www
+++ b/Dockerfile.www
@@ -1,7 +1,7 @@
 ###
 # BUILD STAGE
 ###
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 ENV NODE_ENV=production
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "checkout": "./scripts/checkout.sh"
   },
   "dependencies": {
-    "@intlify/core": "^11.1.0",
-    "@intlify/core-base": "^11.1.0",
-    "@intlify/message-compiler": "^11.1.0",
-    "@intlify/shared": "^11.1.0",
+    "@intlify/core": "^11.1.1",
+    "@intlify/core-base": "^11.1.1",
+    "@intlify/message-compiler": "^11.1.1",
+    "@intlify/shared": "^11.1.1",
     "echarts": "^5.5.0",
     "vue-echarts": "^6.7.3",
     "vue-i18n": "^11"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QgrljKuc/2348-fix-correctifs-li%C3%A9s-%C3%A0-la-mont%C3%A9e-de-version-des-actions

## 🛠 Description de la PR
La PR teste de build le package www en utilisant node:20. Elle pousse également les packages @intlify en v11.1.1.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS