### PR TITLE
fix: (2348) Passage de @nuxtjs/i18n de v8 à v9

### DIFF
--- a/packages/frontend/www/package.json
+++ b/packages/frontend/www/package.json
@@ -9,33 +9,14 @@
   "dependencies": {
     "@fortawesome/free-brands-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
-    "@nuxtjs/i18n": "^8.0.0",
+    "@nuxtjs/i18n": "^9.2.0",
     "@nuxtjs/tailwindcss": "^6.8.0",
     "nuxt": "^3.12.4",
-    "vue-i18n": "^11.1.1",
-    "@intlify/core": "^11.1.1",
-    "@intlify/core-base": "^11.1.1",
-    "@intlify/shared": "^9.14.0",
-    "@intlify/message-compiler": "^11.1.1",
-    "@intlify/vue-i18n-core": "^11.1.1",
-    "@intlify/message-resolver": "^9.1.10",
-    "@intlify/utils": "^0.13.0",
-    "@intlify/vue-devtools": "^9.14.1"
+    "vue-i18n": "^11.1.1"
   },
   "devDependencies": {
     "postcss-custom-properties": "^13.3.2",
     "vue-matomo": "^4.1.0"
-  },
-  "resolutions": {
-    "vue-i18n": "^11.1.1",
-    "@intlify/core": "^11.1.1",
-    "@intlify/core-base": "^11.1.1",
-    "@intlify/shared": "^9.14.0",
-    "@intlify/message-compiler": "^11.1.1",
-    "@intlify/vue-i18n-core": "^11.1.1",
-    "@intlify/message-resolver": "^9.1.10",
-    "@intlify/utils": "^0.13.0",
-    "@intlify/vue-devtools": "^9.14.1"
   },
   "version": "2.26.10"
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QgrljKuc/2348-fix-correctifs-li%C3%A9s-%C3%A0-la-mont%C3%A9e-de-version-des-actions

## 🛠 Description de la PR
La PR change la version attendue pour @nuxtjs/i18n pour passer de v8 à v9.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS