### PR TITLE
#minor: (2349) Upgrade de version Node utilisées en BUILD et PROD

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,7 +1,7 @@
 ###
 # BUILD STAGE
 ###
-FROM node:16-alpine AS build
+FROM node:20-alpine AS build
 ENV NODE_ENV=production
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
@@ -31,7 +31,7 @@ RUN yarn build
 ###
 # PRODUCTION STAGE
 ###
-FROM node:16-alpine AS production
+FROM node:20-alpine AS production
 ENV NODE_ENV=production
 
 RUN mkdir -p \

--- a/Dockerfile.webapp
+++ b/Dockerfile.webapp
@@ -1,7 +1,7 @@
 ###
 # BUILD STAGE
 ###
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 ENV NODE_ENV=production
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.

--- a/Dockerfile.www
+++ b/Dockerfile.www
@@ -39,7 +39,7 @@ RUN yarn build
 ###
 # PRODUCTION STAGE
 ###
-FROM node:18-alpine AS production
+FROM node:20-alpine AS production
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/LgSC7ueH/2349-tech-mont%C3%A9e-de-version-des-images-node-utilis%C3%A9es-en-build-et-prod

## 🛠 Description de la PR
Cette PR fait passer les images Node utilisée en BUILD et PROD de la version v16 (ou v18 pour les tests déjà établis) à v20.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS