### PR TITLE
fix: (2349) Activation de corepack en PROD sur API

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -46,4 +46,5 @@ COPY --from=build --chown=node:node /home/node/app/packages/api/dist ./packages/
 COPY --chown=node:node packages/api/package.json ./packages/api/
 
 WORKDIR /home/node/app/packages/api
+RUN corepack enable yarn
 ENTRYPOINT ["yarn", "serve"]


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/LgSC7ueH/2349-tech-mont%C3%A9e-de-version-des-images-node-utilis%C3%A9es-en-build-et-prod

## 🛠 Description de la PR
La PR active corepack pour la PROD de l'API.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS