### PR TITLE
fix: (2349) Modification de l'appel corepack

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -46,5 +46,5 @@ COPY --from=build --chown=node:node /home/node/app/packages/api/dist ./packages/
 COPY --chown=node:node packages/api/package.json ./packages/api/
 
 WORKDIR /home/node/app/packages/api
-RUN corepack enable yarn
+RUN corepack enable
 ENTRYPOINT ["yarn", "serve"]


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/LgSC7ueH/2349-tech-mont%C3%A9e-de-version-des-images-node-utilis%C3%A9es-en-build-et-prod

## 🛠 Description de la PR
La PR corrige l'appel à corepack pour l'API.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS