### PR TITLE
fix: (2349) Rollback node v16 sur API

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -31,7 +31,7 @@ RUN yarn build
 ###
 # PRODUCTION STAGE
 ###
-FROM node:20-alpine AS production
+FROM node:16-alpine AS production
 ENV NODE_ENV=production
 
 RUN mkdir -p \
@@ -46,5 +46,4 @@ COPY --from=build --chown=node:node /home/node/app/packages/api/dist ./packages/
 COPY --chown=node:node packages/api/package.json ./packages/api/
 
 WORKDIR /home/node/app/packages/api
-RUN corepack enable
 ENTRYPOINT ["yarn", "serve"]


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/LgSC7ueH/2349-tech-mont%C3%A9e-de-version-des-images-node-utilis%C3%A9es-en-build-et-prod

## 🛠 Description de la PR
Cette PR fait un rollback de version node v16. Vérifications nécessaires pour corepack en v20.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS