### PR TITLE
#patch: (2351) Harmonisation des dates sur les graphiques de visualisation de données

### DIFF
--- a/packages/api/server/services/metrics/_utils/initializeListOfDates.ts
+++ b/packages/api/server/services/metrics/_utils/initializeListOfDates.ts
@@ -19,7 +19,7 @@ export default (argFrom: Date, argTo: Date): DateObject[] => {
 
     let diff = getMonthDiff(argFrom, argTo);
     let step = 'months';
-    let format = 'MMMM';
+    let format = 'MMMM YYYY';
 
 
     if (diff < 3) {
@@ -28,7 +28,7 @@ export default (argFrom: Date, argTo: Date): DateObject[] => {
         format = 'DD/MM/YYYY';
     }
 
-    const listOfDates = [{ date: from.toDate(), label: from.format(format) }];
+    const listOfDates = [{ date: from.toDate(), label: from.format(format).charAt(0).toUpperCase() + from.format(format).slice(1) }];
 
 
     // there is a special case for when from and to are the exact same day
@@ -39,11 +39,11 @@ export default (argFrom: Date, argTo: Date): DateObject[] => {
 
     for (let i = 1, d = moment(from).add(1, step === 'weeks' ? 'weeks' : 'months'); i < (step === 'months' ? diff : (diff + 1)); i += 1, d.add(1, step === 'weeks' ? 'weeks' : 'months')) {
         if (!moment(to).isSame(d)) {
-            listOfDates.push({ date: d.toDate(), label: d.format(format) });
+            listOfDates.push({ date: d.toDate(), label: d.format(format).charAt(0).toUpperCase() + d.format(format).slice(1) });
         }
     }
 
-    listOfDates.push({ date: to.toDate(), label: moment(argTo).format(format) });
+    listOfDates.push({ date: to.toDate(), label: moment(argTo).format(format).charAt(0).toUpperCase() + moment(argTo).format(format).slice(1) });
 
     return listOfDates;
 };

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartJustice.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartJustice.vue
@@ -18,11 +18,6 @@
             >
         </div>
 
-        <!-- <LineChart
-            class="mt-6"
-            :chartOptions="chartOptions"
-            :chartData="chartData"
-        /> -->
         <LineChart
             class="mt-6"
             :chartOptions="options"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QE5vfJGq/2351-visu-donn%C3%A9es-harmoniser-les-graphiques-%C3%A9volution-d%C3%A9partementale

## 🛠 Description de la PR
Cette PR apporte une correction de l'affichage des dates sur les graphiques de visualisation de données pour coller à celui de l'évolution nationale.
Le mois commence par une majuscule et l'année est présente, rendant l'axe X et les tooltips plus lisibles.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/02da8186-cfc7-4791-aac2-1ceda1cf76dc)

## 🚨 Notes pour la mise en production
RàS