### PR TITLE
#patch: (2359) Remplacement du lien erroné d'inscription à la newsletter

### DIFF
--- a/packages/api/server/mails/dist/action_alert_postshot.html
+++ b/packages/api/server/mails/dist/action_alert_postshot.html
@@ -287,7 +287,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/action_alert_postshot.text
+++ b/packages/api/server/mails/dist/action_alert_postshot.text
@@ -27,5 +27,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/action_alert_preshot.html
+++ b/packages/api/server/mails/dist/action_alert_preshot.html
@@ -287,7 +287,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/action_alert_preshot.text
+++ b/packages/api/server/mails/dist/action_alert_preshot.text
@@ -27,5 +27,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/activity_summary.html
+++ b/packages/api/server/mails/dist/activity_summary.html
@@ -811,7 +811,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/activity_summary.text
+++ b/packages/api/server/mails/dist/activity_summary.text
@@ -156,7 +156,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]
 
 Pour ne plus recevoir les courriels envoyés automatiquement, veuillez le

--- a/packages/api/server/mails/dist/admin_access_activated.html
+++ b/packages/api/server/mails/dist/admin_access_activated.html
@@ -303,7 +303,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_access_activated.text
+++ b/packages/api/server/mails/dist/admin_access_activated.text
@@ -27,5 +27,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/admin_access_expired.html
+++ b/packages/api/server/mails/dist/admin_access_expired.html
@@ -289,7 +289,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_access_expired.text
+++ b/packages/api/server/mails/dist/admin_access_expired.text
@@ -26,5 +26,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/admin_contact_message.html
+++ b/packages/api/server/mails/dist/admin_contact_message.html
@@ -319,7 +319,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_contact_message.text
+++ b/packages/api/server/mails/dist/admin_contact_message.text
@@ -26,5 +26,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/admin_new_request_notification.html
+++ b/packages/api/server/mails/dist/admin_new_request_notification.html
@@ -329,7 +329,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_new_request_notification.text
+++ b/packages/api/server/mails/dist/admin_new_request_notification.text
@@ -35,5 +35,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/admin_request_pending_reminder_1.html
+++ b/packages/api/server/mails/dist/admin_request_pending_reminder_1.html
@@ -313,7 +313,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_request_pending_reminder_1.text
+++ b/packages/api/server/mails/dist/admin_request_pending_reminder_1.text
@@ -31,5 +31,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/admin_request_pending_reminder_2.html
+++ b/packages/api/server/mails/dist/admin_request_pending_reminder_2.html
@@ -313,7 +313,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_request_pending_reminder_2.text
+++ b/packages/api/server/mails/dist/admin_request_pending_reminder_2.text
@@ -31,5 +31,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/admin_shantytown_reporting.html
+++ b/packages/api/server/mails/dist/admin_shantytown_reporting.html
@@ -284,7 +284,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_shantytown_reporting.text
+++ b/packages/api/server/mails/dist/admin_shantytown_reporting.text
@@ -26,5 +26,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/admin_welcome.html
+++ b/packages/api/server/mails/dist/admin_welcome.html
@@ -323,7 +323,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_welcome.text
+++ b/packages/api/server/mails/dist/admin_welcome.text
@@ -29,5 +29,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/answer_deletion_notification.html
+++ b/packages/api/server/mails/dist/answer_deletion_notification.html
@@ -389,7 +389,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/answer_deletion_notification.text
+++ b/packages/api/server/mails/dist/answer_deletion_notification.text
@@ -27,5 +27,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/community_new_answer_for_author.html
+++ b/packages/api/server/mails/dist/community_new_answer_for_author.html
@@ -281,7 +281,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/community_new_answer_for_author.text
+++ b/packages/api/server/mails/dist/community_new_answer_for_author.text
@@ -22,7 +22,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]
 
 Pour ne plus recevoir les courriels envoyés automatiquement, veuillez le

--- a/packages/api/server/mails/dist/community_new_answer_for_observers.html
+++ b/packages/api/server/mails/dist/community_new_answer_for_observers.html
@@ -281,7 +281,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/community_new_answer_for_observers.text
+++ b/packages/api/server/mails/dist/community_new_answer_for_observers.text
@@ -22,7 +22,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]
 
 Pour ne plus recevoir les courriels envoyés automatiquement, veuillez le

--- a/packages/api/server/mails/dist/community_new_question.html
+++ b/packages/api/server/mails/dist/community_new_question.html
@@ -341,7 +341,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/community_new_question.text
+++ b/packages/api/server/mails/dist/community_new_question.text
@@ -21,7 +21,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]
 
 Pour ne plus recevoir les courriels envoyés automatiquement, veuillez le

--- a/packages/api/server/mails/dist/contact_newsletter_registration.html
+++ b/packages/api/server/mails/dist/contact_newsletter_registration.html
@@ -247,7 +247,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/contact_newsletter_registration.text
+++ b/packages/api/server/mails/dist/contact_newsletter_registration.text
@@ -14,5 +14,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/demo_invitation.html
+++ b/packages/api/server/mails/dist/demo_invitation.html
@@ -300,7 +300,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/demo_invitation.text
+++ b/packages/api/server/mails/dist/demo_invitation.text
@@ -28,5 +28,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/inactive_user_alert.html
+++ b/packages/api/server/mails/dist/inactive_user_alert.html
@@ -289,7 +289,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/inactive_user_alert.text
+++ b/packages/api/server/mails/dist/inactive_user_alert.text
@@ -21,5 +21,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/inactive_user_deactivation_alert.html
+++ b/packages/api/server/mails/dist/inactive_user_deactivation_alert.html
@@ -279,7 +279,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/inactive_user_deactivation_alert.text
+++ b/packages/api/server/mails/dist/inactive_user_deactivation_alert.text
@@ -20,5 +20,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/platform_invitation.html
+++ b/packages/api/server/mails/dist/platform_invitation.html
@@ -323,7 +323,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/platform_invitation.text
+++ b/packages/api/server/mails/dist/platform_invitation.text
@@ -31,5 +31,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/shantytown_actor_invitation.html
+++ b/packages/api/server/mails/dist/shantytown_actor_invitation.html
@@ -345,7 +345,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/shantytown_actor_invitation.text
+++ b/packages/api/server/mails/dist/shantytown_actor_invitation.text
@@ -38,5 +38,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/shantytown_actor_notification.html
+++ b/packages/api/server/mails/dist/shantytown_actor_notification.html
@@ -289,7 +289,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/shantytown_actor_notification.text
+++ b/packages/api/server/mails/dist/shantytown_actor_notification.text
@@ -26,5 +26,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_access_activated_welcome.html
+++ b/packages/api/server/mails/dist/user_access_activated_welcome.html
@@ -245,7 +245,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" class="link" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a> pour rester informés des nouveautés et activités du pôle !</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" class="link" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a> pour rester informés des nouveautés et activités du pôle !</div>
     
                 </td>
               </tr>
@@ -349,7 +349,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_activated_welcome.text
+++ b/packages/api/server/mails/dist/user_access_activated_welcome.text
@@ -20,7 +20,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr].
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 pour rester informés des nouveautés et activités du pôle !
 
 Cordialement,
@@ -35,5 +35,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_access_denied.html
+++ b/packages/api/server/mails/dist/user_access_denied.html
@@ -263,7 +263,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_denied.text
+++ b/packages/api/server/mails/dist/user_access_denied.text
@@ -18,5 +18,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_access_expired.html
+++ b/packages/api/server/mails/dist/user_access_expired.html
@@ -279,7 +279,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_expired.text
+++ b/packages/api/server/mails/dist/user_access_expired.text
@@ -20,5 +20,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_access_granted.html
+++ b/packages/api/server/mails/dist/user_access_granted.html
@@ -323,7 +323,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_granted.text
+++ b/packages/api/server/mails/dist/user_access_granted.text
@@ -30,5 +30,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_access_pending.html
+++ b/packages/api/server/mails/dist/user_access_pending.html
@@ -353,7 +353,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_pending.text
+++ b/packages/api/server/mails/dist/user_access_pending.text
@@ -29,5 +29,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_access_request_confirmation.html
+++ b/packages/api/server/mails/dist/user_access_request_confirmation.html
@@ -255,7 +255,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_request_confirmation.text
+++ b/packages/api/server/mails/dist/user_access_request_confirmation.text
@@ -16,5 +16,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_comment_deletion.html
+++ b/packages/api/server/mails/dist/user_comment_deletion.html
@@ -389,7 +389,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_comment_deletion.text
+++ b/packages/api/server/mails/dist/user_comment_deletion.text
@@ -28,5 +28,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_deactivation_by_admin_alert.html
+++ b/packages/api/server/mails/dist/user_deactivation_by_admin_alert.html
@@ -341,7 +341,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_deactivation_by_admin_alert.text
+++ b/packages/api/server/mails/dist/user_deactivation_by_admin_alert.text
@@ -22,5 +22,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_deactivation_confirmation.html
+++ b/packages/api/server/mails/dist/user_deactivation_confirmation.html
@@ -255,7 +255,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_deactivation_confirmation.text
+++ b/packages/api/server/mails/dist/user_deactivation_confirmation.text
@@ -19,5 +19,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_entraide_invitation.html
+++ b/packages/api/server/mails/dist/user_entraide_invitation.html
@@ -281,7 +281,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_entraide_invitation.text
+++ b/packages/api/server/mails/dist/user_entraide_invitation.text
@@ -21,5 +21,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_features.html
+++ b/packages/api/server/mails/dist/user_features.html
@@ -347,7 +347,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_features.text
+++ b/packages/api/server/mails/dist/user_features.text
@@ -37,5 +37,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_new_action_comment.html
+++ b/packages/api/server/mails/dist/user_new_action_comment.html
@@ -407,7 +407,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_new_action_comment.text
+++ b/packages/api/server/mails/dist/user_new_action_comment.text
@@ -27,7 +27,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]
 
 Pour ne plus recevoir les courriels envoyés automatiquement, veuillez le

--- a/packages/api/server/mails/dist/user_new_comment.html
+++ b/packages/api/server/mails/dist/user_new_comment.html
@@ -468,7 +468,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_new_comment.text
+++ b/packages/api/server/mails/dist/user_new_comment.text
@@ -39,7 +39,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]
 
 Pour ne plus recevoir les courriels envoyés automatiquement, veuillez le

--- a/packages/api/server/mails/dist/user_new_password.html
+++ b/packages/api/server/mails/dist/user_new_password.html
@@ -281,7 +281,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_new_password.text
+++ b/packages/api/server/mails/dist/user_new_password.text
@@ -19,5 +19,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_reactivation_alert.html
+++ b/packages/api/server/mails/dist/user_reactivation_alert.html
@@ -255,7 +255,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_reactivation_alert.text
+++ b/packages/api/server/mails/dist/user_reactivation_alert.text
@@ -18,5 +18,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_review.html
+++ b/packages/api/server/mails/dist/user_review.html
@@ -307,7 +307,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_review.text
+++ b/packages/api/server/mails/dist/user_review.text
@@ -27,5 +27,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_shantytown_closed.html
+++ b/packages/api/server/mails/dist/user_shantytown_closed.html
@@ -305,7 +305,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_shantytown_closed.text
+++ b/packages/api/server/mails/dist/user_shantytown_closed.text
@@ -25,7 +25,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]
 
 Pour ne plus recevoir les courriels envoyés automatiquement, veuillez le

--- a/packages/api/server/mails/dist/user_shantytown_declared.html
+++ b/packages/api/server/mails/dist/user_shantytown_declared.html
@@ -313,7 +313,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_shantytown_declared.text
+++ b/packages/api/server/mails/dist/user_shantytown_declared.text
@@ -26,7 +26,7 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]
 
 Pour ne plus recevoir les courriels envoyés automatiquement, veuillez le

--- a/packages/api/server/mails/dist/user_shantytown_reporting.html
+++ b/packages/api/server/mails/dist/user_shantytown_reporting.html
@@ -263,7 +263,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_shantytown_reporting.text
+++ b/packages/api/server/mails/dist/user_shantytown_reporting.text
@@ -19,5 +19,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/user_share.html
+++ b/packages/api/server/mails/dist/user_share.html
@@ -305,7 +305,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_share.text
+++ b/packages/api/server/mails/dist/user_share.text
@@ -28,5 +28,5 @@ contact-resorption-bidonvilles@dihal.gouv.fr]
 Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
 outils méthodologiques sur votre blog [{{var:blogUrl}}]
 Abonnez-vous à la lettre d'info
-[https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3]
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
 Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/src/common/footer.mjml
+++ b/packages/api/server/mails/src/common/footer.mjml
@@ -21,7 +21,7 @@
             Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos outils méthodologiques sur votre <a class="link" href="{{var:blogUrl}}">blog</a>
         </mj-text>
         <mj-text mj-class="pb-4">
-            <a class="link" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3">Abonnez-vous à la lettre d'info</a>
+            <a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=">Abonnez-vous à la lettre d'info</a>
         </mj-text>
         <mj-text>
             Développé par la <a href="https://www.gouvernement.fr/resorption-des-bidonvilles" class="link" target="_blank" rel="noopener noreferrer">Dihal</a>

--- a/packages/api/server/mails/src/common/subscribe_newsletter-cta.mjml
+++ b/packages/api/server/mails/src/common/subscribe_newsletter-cta.mjml
@@ -1,3 +1,3 @@
 <mj-text>
-     <a href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" class="link" target="_blank" rel="noopener noreferrer">Abonnez-vous à la lettre d'info</a> pour rester informés des nouveautés et activités du pôle !
+     <a href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" class="link" target="_blank" rel="noopener noreferrer">Abonnez-vous à la lettre d'info</a> pour rester informés des nouveautés et activités du pôle !
 </mj-text>

--- a/packages/frontend/ui/src/components/FooterBar/FooterBarNewsletter.vue
+++ b/packages/frontend/ui/src/components/FooterBar/FooterBarNewsletter.vue
@@ -3,7 +3,7 @@
         <h2 class="font-bold text-lg">{{ $t('footer.newsletterTitle') }}</h2>
         <p class="text-sm">{{ $t('footer.newsletterBody') }}</p>
 
-        <Button href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3" class="mt-3 hover:!bg-primaryDark" size="sm"
+        <Button href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" class="mt-3 hover:!bg-primaryDark" size="sm"
             icon="arrow-up-right-from-square">{{ $t('footer.newsletterCta') }}</Button>
     </section>
 </template>

--- a/packages/frontend/www/components/LandingPage/ThirdSection/LandingPageNewsletter.vue
+++ b/packages/frontend/www/components/LandingPage/ThirdSection/LandingPageNewsletter.vue
@@ -6,12 +6,8 @@
         <p class="mb-4 max-w-screen-sm mx-auto">
             {{ $t("landingPage.newsletter.text") }}
         </p>
-        <Button variant="primary" href="https://email.developpement-durable.gouv.fr/users/subscribe/js_id/5n4i/id/3">{{
+        <Button variant="primary" href=" https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=">{{
             $t("landingPage.newsletter.cta") }}</Button>
-        <p class="mt-6">
-            <a class="link" href="https://www.gouvernement.fr/resorption-des-bidonvilles">{{
-                $t("landingPage.newsletter.viewAll") }}</a>
-        </p>
     </div>
 </template>
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/FVek0Br2/2359-page-accueil-d%C3%A9connect%C3%A9e-mise-%C3%A0-jour-du-lien-de-la-newsletter

## 🛠 Description de la PR
Cette PR remplace le lien erroné de l'inscription à la newsletter sur la page d'accueil déconnecté, le footer des pages connectées et les push mels.
Elle supprime également le bouton d'accès aux anciennes newsletter, le lien n'étant également plus fonctionnel.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS