### PR TITLE
#patch: (2360) Correction du filtrage dans l'historique des mise à jour de site

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSite.filter.js
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSite.filter.js
@@ -4,6 +4,7 @@ export default {
         { value: "people", label: "Habitants" },
         { value: "living_conditions", label: "Conditions de vie" },
         { value: "procedure", label: "Procédures" },
+        { value: "localisation", label: "Localisation" },
     ],
     fields: {
         caracteristics: [
@@ -13,6 +14,7 @@ export default {
             "addressSimple",
             "fieldType",
             "owner_type",
+            "owner",
         ],
         people: [
             "isReinstallation",
@@ -122,5 +124,7 @@ export default {
             "insalubrityOrderAt",
             "insalubrityParcels",
         ],
+
+        localisation: ["latitude", "longitude"],
     },
 };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/MooUIhyD/2360-bugsite-le-filtre-caract%C3%A9ristiques-des-modifications-ne-filtre-pas-bien

## 🛠 Description de la PR
La PR ajoute le filtrage de localisation permettant de n'afficher que les mise à jour du point de localisation du site et ajoute la caractéristique manquante "Propriétaire".

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/d63bef73-c24c-4c60-ab52-56e3c4a84303)

## 🚨 Notes pour la mise en production
RàS