### PR TITLE
#minor (2337) Harmoniser le calcul de la date de dernière MAJ pour le TAG

### DIFF
--- a/packages/frontend/ui/src/components/Tag.vue
+++ b/packages/frontend/ui/src/components/Tag.vue
@@ -46,7 +46,7 @@ export default {
                     } px-2 py-1 text-sm`,
                 pin: `px-2 py-1 bg-blue100 text-primary ${this.uppercase ? "uppercase" : ""
                     } text-xs`,
-                pin_green: `px-2 py-1 bg-green100 text-tertiaryA11Y ${this.uppercase ? "uppercase" : ""
+                pin_green: `px-2 py-1 bg-green100 text-black ${this.uppercase ? "uppercase" : ""
                     } text-xs`,
                 pin_orange: `px-2 py-1 bg-warningOrange text-black ${this.uppercase ? "uppercase" : ""
                     } text-xs`,

--- a/packages/frontend/ui/src/components/Tag.vue
+++ b/packages/frontend/ui/src/components/Tag.vue
@@ -46,6 +46,10 @@ export default {
                     } px-2 py-1 text-sm`,
                 pin: `px-2 py-1 bg-blue100 text-primary ${this.uppercase ? "uppercase" : ""
                     } text-xs`,
+                pin_green: `px-2 py-1 bg-green100 text-tertiaryA11Y ${this.uppercase ? "uppercase" : ""
+                    } text-xs`,
+                pin_orange: `px-2 py-1 bg-warningOrange text-black ${this.uppercase ? "uppercase" : ""
+                    } text-xs`,
                 pin_red: `px-2 py-1 bg-red600 text-white ${this.uppercase ? "uppercase" : ""
                     } text-xs`,
                 info: "bg-blue100 text-primary px-2 py-1 text-xs",

--- a/packages/frontend/ui/tailwind.config.js
+++ b/packages/frontend/ui/tailwind.config.js
@@ -171,6 +171,7 @@ module.exports = {
                 green: "#169B62",
                 red: "#D63626",
                 cardBorder: "rgba(0,0,145,0.2)",
+                warningOrange: "#FCB316",
 
                 // Deprecated values : TO DELETE
                 primaryDark: "#00006c",

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
@@ -72,7 +72,12 @@ const userStore = useUserStore();
 
 const pinVariant = computed(() => {
     const { months } = getSince(shantytown.value.lastUpdatedAt);
-    return months > 6 ? "pin_red" : months >= 3 ? "pin_orange" : "pin_green";
+    if (months > 6) {
+        return "pin_red";
+    } else if (months >= 3) {
+        return "pin_orange";
+    }
+    return "pin_green";
 });
 
 const heatwaveStatus = computed(() => {

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
@@ -3,10 +3,14 @@
         <div class="flex-col sm:flex-row">
             <Tag
                 :variant="pinVariant"
-                :class="['text-xs uppercase', isHover ? 'shadow-md' : '']"
+                :class="[
+                    'text-xs uppercase',
+                    isHover ? 'shadow-md' : '',
+                    'lastUpdatedAtDotColor',
+                ]"
                 class="mt-1 items-center py-2 mr-2"
             >
-                {{ lastUpdate }}
+                {{ formatLastUpdatedAt(townForLastUpdate) }}
             </Tag>
             <Tag
                 v-if="heatwaveStatus === true"
@@ -51,6 +55,8 @@ import { Tag, Icon } from "@resorptionbidonvilles/ui";
 import ResorptionTargetTag from "@/components/TagObjectifResorption/TagObjectifResorption.vue";
 import { useUserStore } from "@/stores/user.store";
 
+import useLastUpdated from "@/composables/useLastUpdated";
+
 const props = defineProps({
     shantytown: Object,
     isHover: {
@@ -59,15 +65,16 @@ const props = defineProps({
     },
 });
 const { shantytown, isHover } = toRefs(props);
+
+const { townForLastUpdate } = useLastUpdated(shantytown);
+
 const userStore = useUserStore();
 
 const pinVariant = computed(() => {
-    const { months } = getSince(shantytown.value.updatedAt);
-    return months >= 3 ? "pin_red" : "pin";
+    const { months } = getSince(shantytown.value.lastUpdatedAt);
+    return months > 6 ? "pin_red" : months >= 3 ? "pin_orange" : "pin_green";
 });
-const lastUpdate = computed(() => {
-    return `${formatLastUpdatedAt(shantytown.value)}`;
-});
+
 const heatwaveStatus = computed(() => {
     return shantytown.value.heatwaveStatus;
 });

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatus.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatus.vue
@@ -1,22 +1,9 @@
 <template>
     <div class="flex items-center uppercase text-sm">
-        <div
-            class="rounded-full h-3 w-3 mr-2"
-            :class="isClosed || isSolved ? 'bg-red' : 'bg-corail'"
-        />
+        <div class="rounded-full h-3 w-3 mr-2" :class="lastUpdatedAtDotColor" />
 
-        <p v-if="isClosed || isSolved" class="mr-4">
-            <template v-if="isClosed">
-                Fermé le
-                {{ formatDate(town.closedAt, "d/m/y") }}
-            </template>
-            <template v-else-if="isSolved">
-                Résorbé le
-                {{ formatDate(town.closedAt, "d/m/y") }}
-            </template>
-        </p>
-        <p class="mr-4" v-else>
-            {{ formatLastUpdatedAt(town) }}
+        <p class="mr-4">
+            {{ townStatus }}
         </p>
         <TagObjectifResorption
             v-if="town.resorptionTarget"
@@ -26,9 +13,8 @@
 </template>
 
 <script setup>
-import { toRefs, computed } from "vue";
-import formatDate from "@common/utils/formatDate.js";
-import formatLastUpdatedAt from "@/utils/formatLastUpdatedAt";
+import { toRefs } from "vue";
+import useLastUpdated from "@/composables/useLastUpdated";
 
 import TagObjectifResorption from "@/components/TagObjectifResorption/TagObjectifResorption.vue";
 
@@ -37,10 +23,5 @@ const props = defineProps({
 });
 const { town } = toRefs(props);
 
-const isClosed = computed(() => {
-    return town.value.closedAt && town.value.closedWithSolutions !== "yes";
-});
-const isSolved = computed(() => {
-    return town.value.closedAt && town.value.closedWithSolutions === "yes";
-});
+const { townStatus, lastUpdatedAtDotColor } = useLastUpdated(town);
 </script>

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.tris.js
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.tris.js
@@ -8,7 +8,11 @@ export default {
         label: "Date d'installation",
     },
     updatedAt: {
-        value: "updatedAt",
+        value: "lastUpdatedAt",
+        label: "Date d'actualisation",
+    },
+    lastUpdatedAt: {
+        value: "lastUpdatedAt",
         label: "Date d'actualisation",
     },
     declaredAt: {

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.vue
@@ -63,7 +63,7 @@ watch(currentTab, () => {
     if (currentTab.value === "close") {
         townsStore.sort = "closedAt";
     } else {
-        townsStore.sort = "updatedAt";
+        townsStore.sort = "lastUpdatedAt";
     }
 });
 </script>

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesFiltres.vue
@@ -111,7 +111,12 @@ const groupedFilters = {
     },
 };
 const groupedSorts = {
-    open: [sorts.cityName, sorts.builtAt, sorts.updatedAt, sorts.declaredAt],
+    open: [
+        sorts.cityName,
+        sorts.builtAt,
+        sorts.lastUpdatedAt,
+        sorts.declaredAt,
+    ],
     close: [sorts.cityName, sorts.closedAt, sorts.updatedAt],
 };
 

--- a/packages/frontend/webapp/src/composables/useLastUpdated.js
+++ b/packages/frontend/webapp/src/composables/useLastUpdated.js
@@ -1,0 +1,68 @@
+import { ref, computed, watch } from "vue";
+import coloreUpdatedSince from "@/utils/coloreUpdatedSince";
+import formatDate from "@common/utils/formatDate.js";
+import formatLastUpdatedAt from "@/utils/formatLastUpdatedAt";
+
+export default function useLastUpdated(town) {
+    const townForLastUpdate = ref({
+        createdAt: town.value.createdAt,
+        updatedAt: town.value.lastUpdatedAt,
+    });
+
+    function updateTownStatus() {
+        let townStatusReturned = null;
+        if (town.value.closedAt && town.value.closedWithSolutions !== "yes") {
+            townStatusReturned = `Fermé le ${formatDate(
+                town.value.closedAt,
+                "d/m/y"
+            )}`;
+        } else if (
+            town.value.closedAt &&
+            town.value.closedWithSolutions === "yes"
+        ) {
+            townStatusReturned = `Résorbé le ${formatDate(
+                town.value.closedAt,
+                "d/m/y"
+            )}`;
+        } else {
+            townStatusReturned = formatLastUpdatedAt(townForLastUpdate.value);
+        }
+        return townStatusReturned;
+    }
+
+    const lastUpdatedAtDotColor = computed(() => {
+        if (town.value.closedAt && town.value.closedWithSolutions !== "yes") {
+            return "bg-red";
+        } else if (
+            town.value.closedAt &&
+            town.value.closedWithSolutions === "yes"
+        ) {
+            return "bg-green";
+        }
+        return coloreUpdatedSince(town.value.lastUpdatedAt);
+    });
+
+    const lastUpdatedAt = computed(() => {
+        return town.value.lastUpdatedAt;
+    });
+
+    const townStatus = computed(() => {
+        return updateTownStatus();
+    });
+
+    watch(
+        lastUpdatedAt,
+        (newValue) => {
+            if (newValue) {
+                townForLastUpdate.value.updatedAt = newValue;
+            }
+        },
+        { immediate: true }
+    );
+
+    return {
+        townStatus,
+        townForLastUpdate,
+        lastUpdatedAtDotColor,
+    };
+}

--- a/packages/frontend/webapp/src/utils/coloreUpdatedSince.js
+++ b/packages/frontend/webapp/src/utils/coloreUpdatedSince.js
@@ -1,0 +1,14 @@
+import getSince from "@/utils/getSince";
+
+export default function (lastUpdatedAt) {
+    let bgColor = "bg-green";
+    const { months } = getSince(lastUpdatedAt);
+
+    if (months >= 6) {
+        bgColor = "bg-red600";
+    }
+    if (months >= 3 && months < 6) {
+        bgColor = "bg-warningOrange";
+    }
+    return bgColor;
+}

--- a/packages/frontend/webapp/src/utils/enrichShantytown.js
+++ b/packages/frontend/webapp/src/utils/enrichShantytown.js
@@ -8,6 +8,7 @@
 
 import formatDateSince from "./formatDateSince";
 import getLabelForLivingConditionDetail from "./getLabelForLivingConditionDetail";
+import setTownLastUpdatedAt from "@/utils/setTownLastUpdatedAt";
 
 export default function (shantytown, fieldTypes) {
     const fieldTypeColors = fieldTypes.reduce(
@@ -225,6 +226,8 @@ export default function (shantytown, fieldTypes) {
         );
     });
 
+    const lastUpdatedAt = setTownLastUpdatedAt(shantytown);
+
     return {
         ...shantytown,
         statusName,
@@ -238,6 +241,7 @@ export default function (shantytown, fieldTypes) {
         livingConditions,
         justiceStatuses,
         totalSolutions,
+        lastUpdatedAt,
     };
 }
 

--- a/packages/frontend/webapp/src/utils/enrichShantytown.js
+++ b/packages/frontend/webapp/src/utils/enrichShantytown.js
@@ -8,7 +8,7 @@
 
 import formatDateSince from "./formatDateSince";
 import getLabelForLivingConditionDetail from "./getLabelForLivingConditionDetail";
-import setTownLastUpdatedAt from "@/utils/setTownLastUpdatedAt";
+import { getTownLastUpdatedAt } from "@/utils/townLastUpdateManager";
 
 export default function (shantytown, fieldTypes) {
     const fieldTypeColors = fieldTypes.reduce(
@@ -226,7 +226,7 @@ export default function (shantytown, fieldTypes) {
         );
     });
 
-    const lastUpdatedAt = setTownLastUpdatedAt(shantytown);
+    const lastUpdatedAt = getTownLastUpdatedAt(shantytown);
 
     return {
         ...shantytown,

--- a/packages/frontend/webapp/src/utils/townLastUpdateManager.js
+++ b/packages/frontend/webapp/src/utils/townLastUpdateManager.js
@@ -1,0 +1,21 @@
+function getMostRecentComment(comments) {
+    return comments.reduce((newest, current) => {
+        return current.createdAt > newest.createdAt ? current : newest;
+    }, comments[0]);
+}
+
+function getMostRecentUpdateOnTown(mostRecentComment, townUpdatedAt) {
+    return mostRecentComment.createdAt > townUpdatedAt
+        ? mostRecentComment.createdAt
+        : townUpdatedAt;
+}
+
+function getTownLastUpdatedAt(town) {
+    if (!town.comments.length) {
+        return town.updatedAt;
+    }
+    const mostRecentComment = getMostRecentComment(town.comments);
+    return getMostRecentUpdateOnTown(mostRecentComment, town.updatedAt);
+}
+
+export { getMostRecentComment, getTownLastUpdatedAt };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/hXp85LUr/2337

## 🛠 Description de la PR
- Inclure la date du dernier commentaire dans le calcul du statut d'un site ("Mis à jour depuis"..., etc)
- Gérer la date de dernière mise à jour d'un site en cas de création ou de suppression d'un commentaire
- Afficher un tag TAG “Pas d’activité depuis X mois” en rouge, si dernière mise à jour ou dernier commentaire posté il y a  6 mois ou plus,
- Afficher un tag TAG "Pas de mise mise à jour depuis xx mois" en orange, si dernière mise à jour ou dernier commentaire posté
il y a plus de 3 mois mais moins de 6 mois,
- Afficher un tag TAG "Mise à jour ['aujourd'hui', 'il y a x jours', 'il y a x mois'] si dernière mise à jour ou dernier commentaire posté
il y a moins 3 mois ou moins.

## 📸 Captures d'écran
![{3CD22A73-2D1A-4374-B093-AB5D052F9A82}](https://github.com/user-attachments/assets/63f618ec-8152-4a1e-a781-7059f28d414b)
![{118CF7C7-7F74-4B11-AB53-B437223AD364}](https://github.com/user-attachments/assets/24e977d8-439e-47a6-92e9-0126e6d7ba78)
![{9817E9EA-AF24-44FC-BD8A-063803240397}](https://github.com/user-attachments/assets/45201de7-9233-4b35-a438-6e5d3df48a44)
![{F41DB000-236D-4919-B274-305982A6A787}](https://github.com/user-attachments/assets/f7d3eebb-a7b2-4772-9edd-4f859b249733)
![{AFCF5816-7E25-43C1-B7D3-4620C2A3CF8F}](https://github.com/user-attachments/assets/ad7106ec-a658-4603-a96a-ecac15453c10)
![{CD1811CC-0FA2-45DB-B33D-B3A5F8127058}](https://github.com/user-attachments/assets/8e7a7074-ad02-4e89-8e0c-8a01ededfb42)

## 🚨 Notes pour la mise en production
- ràs