### PR TITLE
#patch: (2361) Correction de l'affichage des tuiles derrière le menu burger

### DIFF
--- a/packages/frontend/webapp/src/components/NavBar/NavBarMobile.vue
+++ b/packages/frontend/webapp/src/components/NavBar/NavBarMobile.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         v-show="!isMobileMenuHidden"
-        class="mobileMenu-transition fixed top-0 left-0 h-full w-full bg-white opacity-0 -z-10"
+        class="mobileMenu-transition top-0 left-0 h-full w-full bg-white opacity-0 -z-10"
         ref="mobileMenu"
     >
         <header @click="hideMobileMenu" class="mt-3 text-right">


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/AgDKdJT2/2361-bug-gestion-de-lindex-des-cartes-et-du-menu-burger-en-version-mobile

## 🛠 Description de la PR
En version mobile, les tuiles de la page d'accueil passaient au dessus du menu burger, le rendant difficilement utilisable. Cette PR apporte la correction afin de recouvrir la page avec le menu.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/6f2aa99a-85b4-40de-ae17-eb64c5f73273)

## 🚨 Notes pour la mise en production
RàS