### PR TITLE
#minor (2352) Améliorer le courriel informant de la déclaration d'un site

### DIFF
--- a/packages/api/server/mails/dist/user_shantytown_declared.html
+++ b/packages/api/server/mails/dist/user_shantytown_declared.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
   <head>
-    <title>[Résorption-bidonvilles] {{var:departementName}} - Un nouveau site a été déclaré</title>
+    <title>[Résorption-bidonvilles] Site déclaré - {{var:title}}</title>
     <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!--<![endif]-->
@@ -135,7 +135,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">{{var:departementName}} - Un nouveau site a été déclaré</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Nouveau site déclaré - {{var:title}}</div>
     
                 </td>
               </tr>
@@ -149,17 +149,12 @@
               </tr>
             
               <tr>
-                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                  
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Un nouveau site a été déclaré aujourd’hui à {{var:hour}} sur la plateforme <a href="{{var:webappUrl}}?{{var:utm}}" class="link font-italic" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none; font-style: italic;">Résorption-bidonvilles</a> par {{var:creatorName}} :</div>
-    
-                </td>
-              </tr>
-            
-              <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a href="{{var:townUrl}}" class="link" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none;">{{var:townFullAddress}}</a></div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Un nouveau site a été déclaré le {{var:hour}} sur la plateforme 
+                    <a href="{{var:webappUrl}}?{{var:utm}}" class="link font-italic" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none; font-style: italic;">Résorption-bidonvilles</a>
+                    par {{var:creatorName}} à l'adresse suivante:
+                    <a href="{{var:townUrl}}" class="link" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none;">{{var:townAddress}}</a></div>
     
                 </td>
               </tr>
@@ -187,7 +182,7 @@
         <tbody>
           <tr>
             <td align="center" bgcolor="#000091" role="presentation" style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#000091;" valign="middle">
-              <a href="{{var:connexionUrl}}" rel="noopener noreferrer" style="display:inline-block;background:#000091;color:#FFFFFF;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
+              <a href="{{var:townUrl}}?{{var:utm}}" rel="noopener noreferrer" style="display:inline-block;background:#000091;color:#FFFFFF;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
                 Me connecter et voir le site
               </a>
             </td>

--- a/packages/api/server/mails/dist/user_shantytown_declared.subject.text
+++ b/packages/api/server/mails/dist/user_shantytown_declared.subject.text
@@ -1,1 +1,1 @@
-[Résorption-bidonvilles] {{var:departementName}} - Un nouveau site a été déclaré
+[Résorption-bidonvilles] Site déclaré - {{var:title}}

--- a/packages/api/server/mails/dist/user_shantytown_declared.text
+++ b/packages/api/server/mails/dist/user_shantytown_declared.text
@@ -1,13 +1,13 @@
-{{var:departementName}} - Un nouveau site a été déclaré
+Nouveau site déclaré - {{var:title}}
 Bonjour {{var:recipientName}},
-Un nouveau site a été déclaré aujourd’hui à {{var:hour}} sur la plateforme
-Résorption-bidonvilles [{{var:webappUrl}}?{{var:utm}}] par {{var:creatorName}} :
-{{var:townFullAddress}} [{{var:townUrl}}]
+Un nouveau site a été déclaré le {{var:hour}} sur la plateforme
+Résorption-bidonvilles [{{var:webappUrl}}?{{var:utm}}] par {{var:creatorName}} à
+l'adresse suivante: {{var:townAddress}} [{{var:townUrl}}]
 Connaissez-vous ce site ? Avez-vous effectué des actions sur ce site ?
 Connectez-vous dès maintenant à la plateforme et participez à la résorption des
 bidonvilles en partageant les changements dont vous auriez eu connaissance.
 
-Me connecter et voir le site [{{var:connexionUrl}}]
+Me connecter et voir le site [{{var:townUrl}}?{{var:utm}}]
 
 Le partage d’information entre tous les partenaires est essentiel pour accélérer
 la résorption des bidonvilles.

--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -851,6 +851,8 @@ export default {
             connexion: generateTrackingUTM(USER_CAMPAIGN, `dep${variables.departement.code}-nouveau-site-connexion`),
         };
 
+        const title = () => `${variables.shantytown.usename} ${variables.shantytown.city.name} (${variables.shantytown.departement.code})`;
+
         return mailService.send('user_shantytown_declared', {
             recipient,
             variables: {
@@ -858,7 +860,8 @@ export default {
                 departementName: variables.departement.name,
                 hour: moment(variables.shantytown.createdAt).utcOffset(2).format('HH:mm'),
                 creatorName: formatName(variables.creator),
-                townFullAddress: variables.shantytown.address,
+                townAddress: variables.shantytown.address,
+                title: title(),
                 webappUrl,
                 utm: utm.regular,
                 connexionUrl: `${connexionUrl}?${utm.connexion}`,

--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -4,6 +4,7 @@ import mailService from '#server/services/mailService';
 import config from '#server/config';
 
 import { QuestionSummary } from '#server/models/activityModel/types/QuestionNationalSummary';
+import formatDate from '#server/utils/formatDate';
 import generateTrackingUTM from './generateTrackingUTM';
 
 const { formatName } = userModel;

--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -858,7 +858,7 @@ export default {
             variables: {
                 recipientName: formatName(recipient),
                 departementName: variables.departement.name,
-                hour: moment(variables.shantytown.createdAt).utcOffset(2).format('HH:mm'),
+                hour: formatDate(variables.shantytown.createdAt, 'd M y à h:i'),
                 creatorName: formatName(variables.creator),
                 townAddress: variables.shantytown.address,
                 title: title(),

--- a/packages/api/server/mails/src/user_shantytown_declared.mjml
+++ b/packages/api/server/mails/src/user_shantytown_declared.mjml
@@ -1,6 +1,6 @@
 <mjml>
     <mj-head>
-        <mj-title>[Résorption-bidonvilles] {{var:departementName}} - Un nouveau site a été déclaré</mj-title>
+        <mj-title>[Résorption-bidonvilles] Site déclaré - {{var:title}}</mj-title>
         <mj-include path='common/attributes.mjml' />
         <mj-include path='common/styles.mjml' />
     </mj-head>
@@ -10,16 +10,18 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class='text-primary text-display pb-4'>
-                    {{var:departementName}} - Un nouveau site a été déclaré
+                    Nouveau site déclaré - {{var:title}}
                 </mj-text>
                 <mj-include path='common/hello.mjml' />
-                <mj-text>
-                    Un nouveau site a été déclaré aujourd’hui à {{var:hour}} sur la plateforme <a href="{{var:webappUrl}}?{{var:utm}}" class="link font-italic" target="_blank" rel="noopener noreferrer">Résorption-bidonvilles</a> par {{var:creatorName}} :
+                <mj-text mj-class="pb-4">
+                    Un nouveau site a été déclaré le {{var:hour}} sur la plateforme 
+                    <a href="{{var:webappUrl}}?{{var:utm}}" class="link font-italic" target="_blank" rel="noopener noreferrer">Résorption-bidonvilles</a>
+                    par {{var:creatorName}} à l'adresse suivante:
+                    <a href="{{var:townUrl}}" class="link" target="_blank" rel="noopener noreferrer">{{var:townAddress}}</a>
                 </mj-text>
-                <mj-text mj-class="pb-4"><a href="{{var:townUrl}}" class="link" target="_blank" rel="noopener noreferrer">{{var:townFullAddress}}</a></mj-text>
                 <mj-text mj-class="font-bold">Connaissez-vous ce site ? Avez-vous effectué des actions sur ce site ?</mj-text>
                 <mj-text mj-class="pb-4">Connectez-vous dès maintenant à la plateforme et participez à la résorption des bidonvilles en partageant les changements dont vous auriez eu connaissance.</mj-text>
-                <mj-button mj-class="button-primary" href="{{var:connexionUrl}}" rel="noopener noreferrer">
+                <mj-button mj-class="button-primary" href="{{var:townUrl}}?{{var:utm}}" rel="noopener noreferrer">
                     Me connecter et voir le site
                 </mj-button>
                 <mj-text mj-class="pb-4">Le partage d’information entre tous les partenaires est essentiel pour accélérer la résorption des bidonvilles.</mj-text>

--- a/packages/api/server/models/shantytownModel/_common/getUsenameOf.ts
+++ b/packages/api/server/models/shantytownModel/_common/getUsenameOf.ts
@@ -13,12 +13,12 @@ export default (shantytown: Shantytown): string => {
     if (shantytown.name) {
         let aka;
         if (!shantytown.addressSimple) {
-            aka = `site dit ${shantytown.name}`;
+            aka = `site dit « ${shantytown.name} »`;
         } else {
             aka = shantytown.name;
         }
 
-        return `${addressSimple} « ${aka} »`;
+        return `${addressSimple} ${aka}`;
     }
 
     return addressSimple;

--- a/packages/api/server/utils/formatDate.ts
+++ b/packages/api/server/utils/formatDate.ts
@@ -1,0 +1,37 @@
+const DAYS = [
+    'Dimanche',
+    'Lundi',
+    'Mardi',
+    'Mercredi',
+    'Jeudi',
+    'Vendredi',
+    'Samedi',
+];
+
+const MONTHS = [
+    { long: 'Janvier', short: 'jan.' },
+    { long: 'Février', short: 'fév.' },
+    { long: 'Mars', short: 'mars' },
+    { long: 'Avril', short: 'avr.' },
+    { long: 'Mai', short: 'mai' },
+    { long: 'Juin', short: 'juin' },
+    { long: 'Juillet', short: 'juil.' },
+    { long: 'Août', short: 'août' },
+    { long: 'Septembre', short: 'sep.' },
+    { long: 'Octobre', short: 'oct.' },
+    { long: 'Novembre', short: 'nov.' },
+    { long: 'Décembre', short: 'déc.' },
+];
+
+export default (timestamp: number, format = 'd/m/y') => {
+    const date = new Date(timestamp * 1000);
+    return format
+        .replace('d', `0${date.getDate()}`.slice(-2))
+        .replace('m', `0${date.getMonth() + 1}`.slice(-2))
+        .replace('y', date.getFullYear().toString())
+        .replace('h', `0${date.getHours()}`.slice(-2))
+        .replace('i', `0${date.getMinutes()}`.slice(-2))
+        .replace('M', MONTHS[date.getMonth()].long)
+        .replace('B', MONTHS[date.getMonth()].short)
+        .replace('U', DAYS[date.getDay()]);
+};

--- a/packages/api/server/utils/mail.ts
+++ b/packages/api/server/utils/mail.ts
@@ -21,7 +21,7 @@ export default {
                 Messages: [
                     Object.assign({
                         From: {
-                            Email: ' contact-resorption-bidonvilles@dihal.gouv.fr',
+                            Email: 'contact-resorption-bidonvilles@dihal.gouv.fr',
                             Name: 'Résorption Bidonvilles',
                         },
                         ReplyTo: replyTo !== null ? {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/9VwVkGKB/2352

## 🛠 Description de la PR
- Corrige l'heure affichée dans le texte du courriel grâce à une nouvelle fonction `formatDate` copie de la version utilisée cpôté front
- Corrige le placement des double-chevrons dans la formule « site dit ... » => site dit « nom du site »
- Modifie le lien derrière le bouton "Me connecter et voir le site" et redirige directement vers la fiche du site et non vers la page de connexion. Si l'utilisateur n'est pas authentifié, il est redirigé vers le portail de connexion puis est routé automatiquement vers la fiche du site.
- Simplifie l'objet et le titre du mail en reprenant  la valeur du champ `shantytown.usename` concaténé avec le nom de la commune et le code du département affiché sur deux ou trois caractères

## 📸 Captures d'écran
![{1E14DF94-0109-4012-9230-12A230072D17}](https://github.com/user-attachments/assets/1e2aead0-d4db-4f43-87bb-bf1c5b9a54de)

## 🚨 Notes pour la mise en production
- ràs