### PR TITLE
#minor (2356) Anonymiser le propriétaire (si personne physique) pour les sites fermés ou résorbés

### DIFF
--- a/packages/api/db/migrations/30000088-01-anonymize-owners-of-closed-sites.js
+++ b/packages/api/db/migrations/30000088-01-anonymize-owners-of-closed-sites.js
@@ -7,7 +7,7 @@ module.exports = {
                 queryInterface.sequelize.query(
                     `UPDATE shantytowns SET owner = NULL WHERE shantytown_id IN
                         (
-                            SELECT shantytown_id FROM shantytowns WHERE status  NOT LIKE 'open' AND owner IS NOT NULL
+                            SELECT shantytown_id FROM shantytowns WHERE status NOT LIKE 'open' AND fk_owner_type = 3 AND owner IS NOT NULL
                         ) ;`,
                     {
                         type: queryInterface.sequelize.QueryTypes.UPDATE,
@@ -20,7 +20,7 @@ module.exports = {
                     WHERE 
                         shantytown_id IN 
                             (
-                                SELECT shantytown_id FROM shantytowns WHERE status  NOT LIKE 'open' AND owner IS NOT NULL
+                                SELECT shantytown_id FROM shantytowns WHERE status NOT LIKE 'open' AND fk_owner_type = 3 AND owner IS NOT NULL
                             )
                         AND
                             owner IS NOT NULL ;`,

--- a/packages/api/db/migrations/30000088-01-anonymize-owners-of-closed-sites.js
+++ b/packages/api/db/migrations/30000088-01-anonymize-owners-of-closed-sites.js
@@ -1,0 +1,41 @@
+module.exports = {
+    async up(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            await Promise.all([
+                queryInterface.sequelize.query(
+                    `UPDATE shantytowns SET owner = NULL WHERE shantytown_id IN
+                        (
+                            SELECT shantytown_id FROM shantytowns WHERE status  NOT LIKE 'open' AND owner IS NOT NULL
+                        ) ;`,
+                    {
+                        type: queryInterface.sequelize.QueryTypes.UPDATE,
+                        transaction,
+                    },
+                ),
+                queryInterface.sequelize.query(
+                    `UPDATE "ShantytownHistories" 
+                    SET owner = NULL
+                    WHERE 
+                        shantytown_id IN 
+                            (
+                                SELECT shantytown_id FROM shantytowns WHERE status  NOT LIKE 'open' AND owner IS NOT NULL
+                            )
+                        AND
+                            owner IS NOT NULL ;`,
+                    {
+                        type: queryInterface.sequelize.QueryTypes.UPDATE,
+                        transaction,
+                    },
+                ),
+            ]);
+            return transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+
+    down: () => Promise.resolve(),
+};

--- a/packages/api/server/controllers/shantytown/close/shantytown.close.ts
+++ b/packages/api/server/controllers/shantytown/close/shantytown.close.ts
@@ -1,14 +1,24 @@
 import shantytownService from '#server/services/shantytown';
 
+const ERROR_RESPONSES = {
+    closing_shantytown_not_allowed: { code: 403, message: 'Vous n\'êtes pas autorisé à fermer ce site' },
+    update_failed: { code: 400, message: 'Une mise à jour en base de données a échoué' },
+    anonymisation_failed: { code: 400, message: 'L\'anonymisation du nom du popriétaire a échoué' },
+    fetch_failed: { code: 400, message: 'Une lecture en base de données a échoué' },
+    undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
+};
+
 export default async (req, res, next) => {
     // close the town
     try {
         const updatedTown = await shantytownService.close(req.user, req.body);
         return res.status(200).send(updatedTown);
-    } catch (e) {
-        res.status(500).send({
-            user_message: 'Une erreur est survenue dans l\'enregistrement du site en base de données',
+    } catch (error) {
+        const { code, message } = ERROR_RESPONSES[error && error.code] || ERROR_RESPONSES.undefined;
+
+        res.status(code).send({
+            user_message: message,
         });
-        return next(e);
+        return next(error.nativeError || error);
     }
 };

--- a/packages/api/server/controllers/shantytown/close/shantytown.close.validator.ts
+++ b/packages/api/server/controllers/shantytown/close/shantytown.close.validator.ts
@@ -1,13 +1,15 @@
 /* eslint-disable newline-per-chained-call */
 import { body, param } from 'express-validator';
-import shantytownModel from '#server/models/shantytownModel';
 import closingSolutionModel from '#server/models/closingSolutionModel';
 
 export default [
     param('id')
+        .isInt({ min: 1 }).bail().withMessage('L\'identifiant du site est invalide')
+        .toInt(),
     (req, res, next) => {
         req.body.shantytown_id = req.params.id;
         next();
+    },
 
     body('closed_with_solutions')
         .isBoolean().bail().withMessage('Vous devez indiquer si le site a été résorbé définitivement')

--- a/packages/api/server/controllers/shantytown/close/shantytown.close.validator.ts
+++ b/packages/api/server/controllers/shantytown/close/shantytown.close.validator.ts
@@ -5,27 +5,9 @@ import closingSolutionModel from '#server/models/closingSolutionModel';
 
 export default [
     param('id')
-        .toInt()
-        .isInt().bail().withMessage('L\'identifiant du site est invalide')
-        .custom(async (value, { req }) => {
-            let shantytown;
-            try {
-                shantytown = await shantytownModel.findOne(req.user, value, 'close');
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la recherche du site en base de données');
-            }
-
-            if (shantytown === null) {
-                throw new Error('Le site à fermer est introuvable en base de données');
-            }
-
-            if (shantytown.status !== 'open') {
-                throw new Error('Ce site est déjà marqué comme fermé');
-            }
-
-            req.body.shantytown = shantytown;
-            return true;
-        }),
+    (req, res, next) => {
+        req.body.shantytown_id = req.params.id;
+        next();
 
     body('closed_with_solutions')
         .isBoolean().bail().withMessage('Vous devez indiquer si le site a été résorbé définitivement')

--- a/packages/api/server/models/shantytownModel/anonymizeOwner.ts
+++ b/packages/api/server/models/shantytownModel/anonymizeOwner.ts
@@ -1,5 +1,5 @@
 import { sequelize } from '#db/sequelize';
-import { Transaction } from 'sequelize';
+import { QueryTypes, Transaction } from 'sequelize';
 
 export default async (shantytownId: number, argTransaction: Transaction = undefined): Promise<void> => {
     let transaction: Transaction = argTransaction;
@@ -7,25 +7,22 @@ export default async (shantytownId: number, argTransaction: Transaction = undefi
         transaction = await sequelize.transaction();
     }
     try {
-        sequelize.query(`
-            UPDATE shantytowns SET owner = NULL WHERE shantytown_id WHERE fk_shantytown = :id
-        `,
+        sequelize.query(`UPDATE shantytowns SET owner = NULL 
+            WHERE shantytown_id = :id`,
         {
             replacements: {
                 id: shantytownId,
             },
+            type: QueryTypes.UPDATE,
             transaction,
         });
-        sequelize.query(`
-            UPDATE "ShantytownHistories" 
-                    SET owner = NULL
-                    WHERE 
-                        shantytown_id = :id
-        `,
+        sequelize.query(`UPDATE "ShantytownHistories"  SET owner = NULL
+            WHERE shantytown_id = :id`,
         {
             replacements: {
                 id: shantytownId,
             },
+            type: QueryTypes.UPDATE,
             transaction,
         });
         if (argTransaction === undefined) {

--- a/packages/api/server/models/shantytownModel/index.ts
+++ b/packages/api/server/models/shantytownModel/index.ts
@@ -1,3 +1,4 @@
+import anonymizeOwner from './anonymizeOwner';
 import create from './create';
 import findAll from './findAll';
 import findNearby from './findNearby';
@@ -13,6 +14,7 @@ import fixClosedStatus from './fixClosedStatus';
 import setHeatwaveStatus from './setHeatwaveStatus';
 
 export default {
+    anonymizeOwner,
     create,
     findAll,
     findNearby,

--- a/packages/api/server/services/shantytown/close.ts
+++ b/packages/api/server/services/shantytown/close.ts
@@ -1,33 +1,56 @@
+import { sequelize } from '#db/sequelize';
 import shantytownModel from '#server/models/shantytownModel';
 import mattermostUtils from '#server/utils/mattermost';
+import ServiceError from '#server/errors/ServiceError';
+import { AuthUser } from '#server/middlewares/authMiddleware';
+import can from '#server/utils/permission/can';
 import sendMailForClosedTown from './_common/sendMailForClosedTown';
 
+export default async (user: AuthUser, data) => {
     const shantytown = await shantytownModel.findOne(user, data.shantytown_id);
 
     if (!can(user).do('close', 'shantytown').on(shantytown)) {
         throw new ServiceError('closing_shantytown_not_allowed', new Error('Vous n\'êtes pas autorisé(e) à metttre à jour ce site'));
     }
-    // close the town
-    await shantytownModel.update(
-        user,
-        data.shantytown.id,
-        {
-            closed_at: data.closed_at,
-            closed_with_solutions: data.closed_with_solutions,
-            status: data.status,
-            closing_context: data.closing_context,
-            closing_solutions: data.solutions,
-            updated_at: new Date(),
-        },
-    );
-    const updatedTown = await shantytownModel.findOne(user, data.shantytown.id);
+
+    let updatedTown = null;
+    const transaction = await sequelize.transaction();
+    try {
+        // close the town
+        await shantytownModel.update(
+            user,
+            data.shantytown_id,
+            {
+                closed_at: data.closed_at,
+                closed_with_solutions: data.closed_with_solutions,
+                status: data.status,
+                closing_context: data.closing_context,
+                closing_solutions: data.solutions,
+                updated_at: new Date(),
+            },
+            transaction,
+        );
+    } catch (error) {
+        await transaction.rollback();
+        throw new ServiceError('update_failed', error);
+    }
+
+    try {
+        // Anonymise le nom du propriétaire du site fermé
+        await shantytownModel.anonymizeOwner(data.shantytown_id, transaction);
+        updatedTown = await shantytownModel.findOne(user, data.shantytown_id);
+    } catch (error) {
+        await transaction.rollback();
+        throw new ServiceError('anonymisation_failed', error);
+    }
+    await transaction.commit();
 
     // Send a mattermost alert, if it fails, do nothing
     try {
         await mattermostUtils.triggerShantytownCloseAlert(updatedTown, user);
     } catch (err) {
         // eslint-disable-next-line no-console
-        console.log(`Error with shantytown close mattermost webhook : ${err.message}`);
+        console.log(`L'envoi de la notification de fermeture du site a échoué: ${err.message}`);
     }
     // Send a notification to all users of the related departement, if it fails, do nothing
     try {

--- a/packages/api/server/services/shantytown/close.ts
+++ b/packages/api/server/services/shantytown/close.ts
@@ -2,7 +2,11 @@ import shantytownModel from '#server/models/shantytownModel';
 import mattermostUtils from '#server/utils/mattermost';
 import sendMailForClosedTown from './_common/sendMailForClosedTown';
 
-export default async (user, data) => {
+    const shantytown = await shantytownModel.findOne(user, data.shantytown_id);
+
+    if (!can(user).do('close', 'shantytown').on(shantytown)) {
+        throw new ServiceError('closing_shantytown_not_allowed', new Error('Vous n\'êtes pas autorisé(e) à metttre à jour ce site'));
+    }
     // close the town
     await shantytownModel.update(
         user,

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.schema.js
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.schema.js
@@ -11,13 +11,12 @@ export default (variant) => {
 
     if (variant === "declare") {
         const maxClosedAt = new Date();
-        maxClosedAt.setDate(maxClosedAt.getDate() + 1);
-        maxClosedAt.setHours(0, 0, 0, 0);
+        maxClosedAt.setHours(23, 59, 59, 999);
 
         schema.closed_at = date()
             .typeError(`${labels.closed_at} est obligatoire`)
             .required()
-            .max(new Date())
+            .max(maxClosedAt)
             .label(labels.closed_at);
         schema.status = string()
             .required()

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
@@ -164,7 +164,7 @@ const config = {
         },
         successTitle: "Fermeture du site",
         successWording:
-            "Le site a bien été déclaré comme fermé. Les acteurs concernés ont été prévenus par mail",
+            "Le site a bien été déclaré fermé et les éventuelles données du propriétaire anonymisées. Les acteurs concernés ont été prévenus par mail",
     },
     fix: {
         submit(values) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Do3PDf4K/2356

## 🛠 Description de la PR
- Ajoute le contrôle de permission côté backend pour la fermeture d'un site
- Déplace le contrôle de l'existence du site du validateur vers le service -  c'est une bonne pratique de déléguer les opérations telles que la vérification d'existence et l'assignation d'objets  au service plutôt qu'au middleware ou au validateur.
- Améliore la lisibilité et la remontée au frontend des messages d'erreurs générés par le service et remontés via le contrôleur
- Anonymise les données du propriétaire dans les informations du site et dans l'historique lors de la fermeture du site
- Anonymise les données des propriétaires des sites déjà fermés grâce à l'exécution d'une migration

## 📸 Captures d'écran
![notif_fermeture_anonymisation](https://github.com/user-attachments/assets/5b59f95c-7dc7-49a4-9066-292a432752b3)

## 🚨 Notes pour la mise en production
- Penser à exécuter la migrations `30000088-01-anonymize-owners-of-closed-sites.js` 