### PR TITLE
#minor: (2369) Ajout d'un système de remontées de métriques via Prometheus

### DIFF
--- a/packages/api/server/app.ts
+++ b/packages/api/server/app.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 import loaders from '#server/loaders';
 import config from '#server/config';
+import PrometheusMetricsHandler from '#server/middlewares/prometheusMiddleware';
 
 const {
     port, sendActivitySummary, sendActionAlerts, checkInactiveUsers,
@@ -39,6 +40,8 @@ export default {
         const app = loaders.customRouteMethods(loaders.express());
 
         sentryContextHandlers(app);
+
+        app.use(PrometheusMetricsHandler);
 
         loaders.rateLimiter(app);
         await loaders.routes(app);

--- a/packages/api/server/controllers/metrics/prometheusMetrics/metrics.prom.route.ts
+++ b/packages/api/server/controllers/metrics/prometheusMetrics/metrics.prom.route.ts
@@ -1,0 +1,9 @@
+import { type ApplicationWithCustomRoutes } from '#server/loaders/customRouteMethodsLoader';
+import controller from './metrics.prom';
+
+export default (app: ApplicationWithCustomRoutes): void => {
+    app.customRoutes.get('/prom_metrics', controller, undefined, {
+        authenticate: true,
+        multipart: false,
+    });
+};

--- a/packages/api/server/controllers/metrics/prometheusMetrics/metrics.prom.ts
+++ b/packages/api/server/controllers/metrics/prometheusMetrics/metrics.prom.ts
@@ -1,0 +1,21 @@
+import { register } from 'prom-client';
+
+const ERROR_RESPONSES = {
+    fetch_failed: { code: 400, message: 'La lecture des métriques a échoué' },
+    undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
+};
+
+export default async (req, res, next) => {
+    let metrics;
+    try {
+        res.set('Content-Type', register.contentType);
+        metrics = await register.metrics();
+    } catch (error) {
+        const { code, message } = ERROR_RESPONSES[error && error.code] || ERROR_RESPONSES.undefined;
+        res.status(code).send({
+            user_message: message,
+        });
+        return next(error.nativeError || error);
+    }
+    return res.status(200).send(metrics);
+};

--- a/packages/api/server/middlewares/prometheusMiddleware.ts
+++ b/packages/api/server/middlewares/prometheusMiddleware.ts
@@ -1,0 +1,53 @@
+import { Request, Response, NextFunction } from 'express';
+import {
+    Counter, Gauge, collectDefaultMetrics, register,
+} from 'prom-client';
+
+register.setDefaultLabels({
+    app: 'api',
+});
+collectDefaultMetrics({ register });
+
+// Créer un nouveau compteur pour enregistrer le nombre total de requêtes
+const requestsCounter = new Counter({
+    name: 'total_requests',
+    help: 'Total numberof received requests',
+});
+
+const http_request_counter = new Counter({
+    name: 'http_request_count',
+    help: 'Count of HTTP requests made to API endpoints',
+    labelNames: ['method', 'route', 'statusCode'],
+});
+
+// Créer une nouvelle jauge pour enregistrer le nombre de connexions actives
+const activeConnectionsCounter = new Gauge({
+    name: 'active_connections',
+    help: 'Number of active connections',
+});
+
+const metricsHandler = (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+) => {
+    if (req.path !== '/prom_metrics') {
+        requestsCounter.inc();
+        activeConnectionsCounter.inc();
+        http_request_counter
+            .labels({
+                method: req.method,
+                route: req.originalUrl,
+                statusCode: res.statusCode,
+            })
+            .inc();
+
+        // On décrémente la jauge lorsque la réponse est terminée
+        res.on('finish', () => {
+            activeConnectionsCounter.dec();
+        });
+    }
+    next();
+};
+
+export default metricsHandler;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Wl6avvXk/2369-tech-tracking-des-erreurs-via-sentry-ou-prometheus-grafana

## 🛠 Description de la PR
Cette PR ajoute un middleware permettant de remonter des statistiques de l'API dans Prometheus.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/e4df632f-1f14-41b1-98dc-9a0209ca580b)

## 🚨 Notes pour la mise en production
RàS