### PR TITLE
#patch: (2369) Désactivation de l'auth sur la route des métrics prometheus

### DIFF
--- a/packages/api/server/controllers/metrics/prometheusMetrics/metrics.prom.route.ts
+++ b/packages/api/server/controllers/metrics/prometheusMetrics/metrics.prom.route.ts
@@ -3,7 +3,7 @@ import controller from './metrics.prom';
 
 export default (app: ApplicationWithCustomRoutes): void => {
     app.customRoutes.get('/prom_metrics', controller, undefined, {
-        authenticate: true,
+        authenticate: false,
         multipart: false,
     });
 };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Wl6avvXk/2369-tech-tracking-des-erreurs-via-sentry-ou-prometheus-grafana

## 🛠 Description de la PR
La PR supprime le besoin d'authentification pour la route des métriques Prometheus

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS