### PR TITLE
#patch: (2376) Ouverture du formulaire newsletter dans un nouvel onglet

### DIFF
--- a/packages/frontend/ui/src/components/FooterBar/FooterBarNewsletter.vue
+++ b/packages/frontend/ui/src/components/FooterBar/FooterBarNewsletter.vue
@@ -3,7 +3,7 @@
         <h2 class="font-bold text-lg">{{ $t('footer.newsletterTitle') }}</h2>
         <p class="text-sm">{{ $t('footer.newsletterBody') }}</p>
 
-        <Button href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" class="mt-3 hover:!bg-primaryDark" size="sm"
+        <Button href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" target="_blank" class="mt-3 hover:!bg-primaryDark" size="sm"
             icon="arrow-up-right-from-square">{{ $t('footer.newsletterCta') }}</Button>
     </section>
 </template>
@@ -11,3 +11,9 @@
 <script setup>
 import Button from "../Button.vue";
 </script>
+
+<style scoped>
+[target=_blank]:after {
+    content: none !important;
+}
+</style>

--- a/packages/frontend/www/components/LandingPage/ThirdSection/LandingPageNewsletter.vue
+++ b/packages/frontend/www/components/LandingPage/ThirdSection/LandingPageNewsletter.vue
@@ -6,7 +6,7 @@
         <p class="mb-4 max-w-screen-sm mx-auto">
             {{ $t("landingPage.newsletter.text") }}
         </p>
-        <Button variant="primary" href=" https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=">{{
+        <Button variant="primary" href=" https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" icon="arrow-up-right-from-square" target="_blank">{{
             $t("landingPage.newsletter.cta") }}</Button>
     </div>
 </template>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/mYGRaN9v/2376-accueil-ouvrir-le-lien-dinscription-%C3%A0-la-newsletter-dans-un-nouvel-onglet

## 🛠 Description de la PR
Cette PR permet aux utilisateurs d'ouvrir le lien externe d'inscription à la newsletter de le faire directement dans un nouvel onglet. L'onglet initial reste inchangé et l'utilisateur ne quitte pas la plateforme.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/646d06fc-55d5-44d9-88c2-8445a2b18a98)
Depuis le footer du site, disponible partout.
![image](https://github.com/user-attachments/assets/3d85da5e-dd7a-4e5c-8881-fc0a04e4a6d6)
Depuis la page d'accueil des utilisateurs déconnectés.

## 🚨 Notes pour la mise en production
RàS