### PR TITLE
#patch: (2378) Ajout de la courbe d'évolution du nombre de mineurs

### DIFF
--- a/packages/api/server/models/metricsModel/getDepartementEvolutionData.ts
+++ b/packages/api/server/models/metricsModel/getDepartementEvolutionData.ts
@@ -12,6 +12,7 @@ const { where: pWhere } = permissionUtils;
 export type DepartementEvolutionMetricsRawData = {
     shantytown_id: number,
     population_total: number,
+    population_minors: number,
     minors_in_school: number | null,
     input_date: Date,
     known_since: Date,
@@ -96,6 +97,7 @@ export default async (user, departementCode, from: Date, to: Date): Promise<Depa
                     0 as hid,
                 shantytowns.shantytown_id,
                 shantytowns.population_total,
+                shantytowns.population_minors,
                 shantytowns.minors_in_school,
                 COALESCE(shantytowns.updated_at, shantytowns.created_at) AS input_date,
                 shantytowns_today.known_since,
@@ -185,6 +187,7 @@ export default async (user, departementCode, from: Date, to: Date): Promise<Depa
                     shantytowns.hid,
                 shantytowns.shantytown_id,
                 shantytowns.population_total,
+                shantytowns.population_minors,
                 shantytowns.minors_in_school,
                 COALESCE(shantytowns.updated_at, shantytowns.created_at) AS input_date,
                 shantytowns_today.known_since,

--- a/packages/api/server/services/metrics/_utils/initializeDepartementEvolutionMetrics.ts
+++ b/packages/api/server/services/metrics/_utils/initializeDepartementEvolutionMetrics.ts
@@ -25,6 +25,10 @@ export default (listOfDateLabels: string[]):DepartementMetricsEvolution => {
                         value: 0,
                         evolution: 0,
                     },
+                    minors: {
+                        value: 0,
+                        evolution: 0,
+                    },
                     minors_in_school: {
                         value: 0,
                         evolution: 0,
@@ -36,6 +40,7 @@ export default (listOfDateLabels: string[]):DepartementMetricsEvolution => {
                     less_than_10: zeros(n),
                     between_10_and_99: zeros(n),
                     more_than_99: zeros(n),
+                    minors: zeros(n),
                     minors_in_school: zeros(n),
                 },
             },

--- a/packages/api/server/services/metrics/getDepartementEvolutionMetrics.ts
+++ b/packages/api/server/services/metrics/getDepartementEvolutionMetrics.ts
@@ -81,6 +81,9 @@ export default async (user: User, departementCode: string, argFrom: Date, argTo:
             if (row.population_total >= 100) {
                 metrics.inhabitants.towns.charts.more_than_99[i] += 1;
             }
+            if (row.population_minors !== null) {
+                metrics.inhabitants.towns.charts.minors[i] += row.population_minors;
+            }
             if (row.minors_in_school !== null) {
                 metrics.inhabitants.towns.charts.minors_in_school[i] += row.minors_in_school;
             }

--- a/packages/api/types/resources/DepartementMetricsEvolution.d.ts
+++ b/packages/api/types/resources/DepartementMetricsEvolution.d.ts
@@ -18,6 +18,10 @@ export type DepartementMetricsEvolution = {
                     value: number,
                     evolution: number,
                 },
+                minors: {
+                    value: number,
+                    evolution: number,
+                },
                 minors_in_school: {
                     value: number,
                     evolution: number,
@@ -29,6 +33,7 @@ export type DepartementMetricsEvolution = {
                 less_than_10: number[],
                 between_10_and_99: number[],
                 more_than_99: number[],
+                minors: number[],
                 minors_in_school: number[],
             },
         },

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/ChartBigFigure.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/ChartBigFigure.vue
@@ -47,8 +47,13 @@ const props = defineProps({
         required: false,
         default: false,
     },
+    neutral: {
+        type: Boolean,
+        required: false,
+        default: false,
+    },
 });
-const { icon, img, alt, figure, evolution, invert } = toRefs(props);
+const { icon, img, alt, figure, evolution, invert, neutral } = toRefs(props);
 
 const colors = {
     positive: {
@@ -67,7 +72,9 @@ const colors = {
 
 const background = computed(() => {
     return (
-        evolution.value == 0
+        neutral.value
+            ? colors.neutral
+            : evolution.value == 0
             ? colors.neutral
             : evolution.value < 0
             ? !invert.value
@@ -80,7 +87,9 @@ const background = computed(() => {
 });
 const color = computed(() => {
     return (
-        evolution.value == 0
+        neutral.value
+            ? colors.neutral
+            : evolution.value == 0
             ? colors.neutral
             : evolution.value < 0
             ? !invert.value

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartSchooling.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartSchooling.vue
@@ -4,6 +4,13 @@
 
         <div class="flex mt-4 space-x-6">
             <ChartBigFigure
+                icon="children"
+                :figure="formatStat(data.figures.minors.value)"
+                :evolution="formatStat(data.figures.minors.evolution)"
+                neutral
+                >Mineurs</ChartBigFigure
+            >
+            <ChartBigFigure
                 icon="school"
                 :figure="formatStat(data.figures.minors_in_school.value)"
                 :evolution="formatStat(data.figures.minors_in_school.evolution)"
@@ -35,9 +42,14 @@ const data = departementMetricsStore.evolution.data.inhabitants.towns;
 
 const chartData = computed(() => {
     const datasets = [
+        generateDataset("Nombre de mineurs", "0, 0, 255", data.charts.minors, {
+            lineStyle: { opacity: 1 },
+            area: true,
+            symbolSize: 1,
+        }),
         generateDataset(
             "Nombre de mineurs scolarisés",
-            "0, 0, 255",
+            "0, 255, 0",
             data.charts.minors_in_school,
             {
                 lineStyle: { opacity: 1 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4698,6 +4698,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api@npm:^1.4.0":
+  version: 1.9.0
+  resolution: "@opentelemetry/api@npm:1.9.0"
+  checksum: 9e88e59d53ced668f3daaecfd721071c5b85a67dd386f1c6f051d1be54375d850016c881f656ffbe9a03bedae85f7e89c2f2b635313f9c9b195ad033cdc31020
+  languageName: node
+  linkType: hard
+
 "@parcel/watcher-android-arm64@npm:2.4.1":
   version: 2.4.1
   resolution: "@parcel/watcher-android-arm64@npm:2.4.1"
@@ -5645,6 +5652,7 @@ __metadata:
     nodemon: ^2.0.7
     pg: ^8.7.3
     pg-hstore: ^2.3.2
+    prom-client: ^15.1.3
     proxyquire: ^2.1.0
     rewiremock: ^3.13.9
     rimraf: ^3.0.2
@@ -12497,6 +12505,13 @@ __metadata:
   dependencies:
     file-uri-to-path: 1.0.0
   checksum: 65b6b48095717c2e6105a021a7da4ea435aa8d3d3cd085cb9e85bcb6e5773cf318c4745c3f7c504412855940b585bdf9b918236612a1c7a7942491de176f1ae7
+  languageName: node
+  linkType: hard
+
+"bintrees@npm:1.0.2":
+  version: 1.0.2
+  resolution: "bintrees@npm:1.0.2"
+  checksum: 56a52b7d3634e30002b1eda740d2517a22fa8e9e2eb088e919f37c030a0ed86e364ab59e472fc770fc8751308054bb1c892979d150e11d9e11ac33bcc1b5d16e
   languageName: node
   linkType: hard
 
@@ -25568,6 +25583,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prom-client@npm:^15.1.3":
+  version: 15.1.3
+  resolution: "prom-client@npm:15.1.3"
+  dependencies:
+    "@opentelemetry/api": ^1.4.0
+    tdigest: ^0.1.1
+  checksum: 9a57f3c16f39aa9a03da021883a4231c0bb56fc9d02f6ef9c28f913379f275640a5a33b98d9946ebf53c71011a29b580e9d2d6e3806cb1c229a3f59c65993968
+  languageName: node
+  linkType: hard
+
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -28736,6 +28761,15 @@ __metadata:
     mkdirp: ^1.0.3
     yallist: ^4.0.0
   checksum: f1322768c9741a25356c11373bce918483f40fa9a25c69c59410c8a1247632487edef5fe76c5f12ac51a6356d2f1829e96d2bc34098668a2fc34d76050ac2b6c
+  languageName: node
+  linkType: hard
+
+"tdigest@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "tdigest@npm:0.1.2"
+  dependencies:
+    bintrees: 1.0.2
+  checksum: 44de8246752b6f8c2924685f969fd3d94c36949f22b0907e99bef2b2220726dd8467f4730ea96b06040b9aa2587c0866049640039d1b956952dfa962bc2075a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/5J31M5Wj/2378-visudonn%C3%A9es-scolarisation-ajout-de-la-courbe-d%C3%A9volution-du-nombre-de-mineurs

## 🛠 Description de la PR
La PR ajoute la courbe des mineurs à la visualisation de données départementales avec la courbe de scolarisation.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/b1642524-961c-420d-b7e5-66f84e6c874e)

## 🚨 Notes pour la mise en production
RàS