### PR TITLE
#patch (2384) Normaliser l'icône "Site" sur les dernières activités

### DIFF
--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordActivites/TableauDeBordActivite.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordActivites/TableauDeBordActivite.vue
@@ -237,7 +237,7 @@ const description = computed(() => {
 
 const icon = computed(() => {
     if (activity.value.entity === "shantytown") {
-        return "map-marker-alt";
+        return "tent";
     }
 
     if (activity.value.entity === "user") {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/caHHaqy4/2384

## 🛠 Description de la PR
Remplacer le symbole "Marqueur" par le sympole "Tente" sur l'historique des activité "Sites"

## 📸 Captures d'écran
![{1AF41326-CDD2-4697-8CB7-D744EC6D0273}](https://github.com/user-attachments/assets/66928a16-2232-46e5-bbde-74e2b9e6a09e)

## 🚨 Notes pour la mise en production
- ràs