### PR TITLE
#patch (2383) Corriger le calcul "7 derniers jours" dans les dernières activités

### DIFF
--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordActivites/TableauDeBordActivitesListe.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordActivites/TableauDeBordActivitesListe.vue
@@ -42,12 +42,11 @@ import { Link } from "@resorptionbidonvilles/ui";
 import TableauDeBordActivite from "./TableauDeBordActivite.vue";
 
 const dashboardStore = useDashboardStore();
-const monday = new Date();
-monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7));
-monday.setHours(0);
-monday.setMinutes(0);
-monday.setSeconds(0);
-monday.setMilliseconds(0);
+// Date d'il y a 7 jours à minuit
+const sevenDaysAgo = new Date();
+sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+sevenDaysAgo.setHours(0, 0, 0, 0);
+// date d'il y a exactement 30 jours à minuit
 const aMonthAgo = new Date();
 aMonthAgo.setDate(aMonthAgo.getDate() - 30);
 aMonthAgo.setHours(0);
@@ -74,7 +73,7 @@ const splitActivities = computed(() => {
                 return acc;
             }
 
-            if (activity.date >= monday.getTime() / 1000) {
+            if (activity.date >= sevenDaysAgo.getTime() / 1000) {
                 acc.currentWeek.push(activity);
             } else if (activity.date >= aMonthAgo.getTime() / 1000) {
                 acc.previousMonth.push(activity);

--- a/packages/frontend/webapp/src/utils/townLastUpdateManager.js
+++ b/packages/frontend/webapp/src/utils/townLastUpdateManager.js
@@ -11,7 +11,7 @@ function getMostRecentUpdateOnTown(mostRecentComment, townUpdatedAt) {
 }
 
 function getTownLastUpdatedAt(town) {
-    if (!town.comments.length) {
+    if (!town.comments || town.comments.length === 0) {
         return town.updatedAt;
     }
     const mostRecentComment = getMostRecentComment(town.comments);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/H4vG8uXV/2383

## 🛠 Description de la PR
Le calcul positionnant les items des dernières activités dans le paragraphe "7 derniers jours" ne correspond pas au libellé du paragraphe. Il permet en fait de positionner l'item dans la "semaine en cours (depuis lundi)".
Le calcul a été modifié pour calculer correctement la période correspondant aux 7 derniers jours.

## 📸 Captures d'écran
SO

## 🚨 Notes pour la mise en production
- ràs