### PR TITLE
patch: (2377) Calcul du pourcentage de progression erroné si pas de donnée au début en Visu de Données

### DIFF
--- a/packages/api/server/services/metrics/_utils/getEvolution.ts
+++ b/packages/api/server/services/metrics/_utils/getEvolution.ts
@@ -1,6 +1,5 @@
-// export default (initialValue: number, finalValue: number): number => {
 export default (initialValue: number, finalValue: number): number => {
-    if (initialValue === 0) {
+    if (initialValue === 0 && finalValue !== 0) {
         return null;
     }
     const percentage = Math.round(((finalValue - initialValue) / initialValue) * 100);

--- a/packages/api/server/services/metrics/_utils/getEvolution.ts
+++ b/packages/api/server/services/metrics/_utils/getEvolution.ts
@@ -1,7 +1,9 @@
+// export default (initialValue: number, finalValue: number): number => {
 export default (initialValue: number, finalValue: number): number => {
     if (initialValue === 0) {
-        return 0;
+        return null;
     }
     const percentage = Math.round(((finalValue - initialValue) / initialValue) * 100);
+
     return Number.isNaN(percentage) ? 0 : percentage;
 };

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/ChartBigFigure.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/ChartBigFigure.vue
@@ -6,7 +6,7 @@
         >
             <img v-if="img" :src="img" width="40" :alt="alt" />
             <Icon v-else class="text-xl" :icon="icon" />
-            <span class="font-bold text-3xl">{{ figure }}</span>
+            <span class="font-bold text-3xl">{{ formatStat(figure) }}</span>
             <span class="font-bold text-lg" :class="color"
                 >({{ formatedEvolution }})</span
             >
@@ -18,6 +18,7 @@
 <script setup>
 import { computed, toRefs } from "vue";
 import { Icon } from "@resorptionbidonvilles/ui";
+import formatStat from "@/utils/formatStat";
 
 const props = defineProps({
     icon: {
@@ -102,8 +103,12 @@ const color = computed(() => {
 });
 
 const formatedEvolution = computed(() => {
-    return `${evolution.value >= 0 ? "+ " : "- "}${Math.abs(
-        evolution.value
-    )} %`;
+    if (evolution.value !== null) {
+        return `${evolution.value >= 0 ? "+ " : "- "}${formatStat(
+            Math.abs(evolution.value)
+        )} %`;
+    } else {
+        return "N/A";
+    }
 });
 </script>

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartInhabitants.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartInhabitants.vue
@@ -5,24 +5,24 @@
         <div class="flex mt-4 space-x-6">
             <ChartBigFigure
                 icon="people-group"
-                :figure="formatStat(data.figures.total.value)"
-                :evolution="formatStat(data.figures.total.evolution)"
+                :figure="data.figures.total.value"
+                :evolution="data.figures.total.evolution"
                 >Tous sites</ChartBigFigure
             >
 
             <ChartBigFigure
                 :img="flagEU"
                 alt="Estimation du nombre d'habitants intra UE"
-                :figure="formatStat(data.figures.european.value)"
-                :evolution="formatStat(data.figures.european.evolution)"
+                :figure="data.figures.european.value"
+                :evolution="data.figures.european.evolution"
                 >Sites exclusivement intra UE</ChartBigFigure
             >
 
             <ChartBigFigure
                 :img="flagExtraCommunautaires"
                 alt="Estimation du nombre d'habitants extra UE"
-                :figure="formatStat(data.figures.foreign.value)"
-                :evolution="formatStat(data.figures.foreign.evolution)"
+                :figure="data.figures.foreign.value"
+                :evolution="data.figures.foreign.evolution"
                 >Sites exclusivement extra UE</ChartBigFigure
             >
         </div>
@@ -37,7 +37,6 @@
 </template>
 
 <script setup>
-import formatStat from "@/utils/formatStat";
 import { computed } from "vue";
 import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
 import LineChart from "@/components/Graphs/GraphBase.vue";

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartJustice.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartJustice.vue
@@ -5,15 +5,15 @@
         <div class="flex mt-4 space-x-6">
             <ChartBigFigure
                 icon="person-military-pointing"
-                :figure="formatStat(data.figures.police.value)"
-                :evolution="formatStat(data.figures.police.evolution)"
+                :figure="data.figures.police.value"
+                :evolution="data.figures.police.evolution"
                 >Nombre total de CFP</ChartBigFigure
             >
 
             <ChartBigFigure
                 icon="scroll"
-                :figure="formatStat(data.figures.complaints.value)"
-                :evolution="formatStat(data.figures.complaints.evolution)"
+                :figure="data.figures.complaints.value"
+                :evolution="data.figures.complaints.evolution"
                 >Nombre total de plaintes</ChartBigFigure
             >
         </div>
@@ -28,7 +28,6 @@
 </template>
 
 <script setup>
-import formatStat from "@/utils/formatStat";
 import { computed } from "vue";
 import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
 import LineChart from "@/components/Graphs/GraphBase.vue";

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartLivingCondition.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartLivingCondition.vue
@@ -6,27 +6,23 @@
             <ChartBigFigure
                 v-if="chartType === 'towns'"
                 icon="tent"
-                :figure="formatStat(data.figures.towns_total.value)"
-                :evolution="formatStat(data.figures.towns_total.evolution)"
+                :figure="data.figures.towns_total.value"
+                :evolution="data.figures.towns_total.evolution"
                 >Nombre total de sites</ChartBigFigure
             >
 
             <ChartBigFigure
                 v-if="chartType === 'inhabitants'"
                 icon="people-group"
-                :figure="formatStat(data.figures.inhabitants_total.value)"
-                :evolution="
-                    formatStat(data.figures.inhabitants_total.evolution)
-                "
+                :figure="data.figures.inhabitants_total.value"
+                :evolution="data.figures.inhabitants_total.evolution"
                 >Nombre total de personnes</ChartBigFigure
             >
 
             <ChartBigFigure
                 :icon="icon"
-                :figure="formatStat(data.figures[livingConditionType].value)"
-                :evolution="
-                    formatStat(data.figures[livingConditionType].evolution)
-                "
+                :figure="data.figures[livingConditionType].value"
+                :evolution="data.figures[livingConditionType].evolution"
                 invert
                 >{{ chartLabel }}</ChartBigFigure
             >
@@ -42,7 +38,6 @@
 </template>
 
 <script setup>
-import formatStat from "@/utils/formatStat";
 import { computed, toRefs } from "vue";
 import LineChart from "@/components/Graphs/GraphBase.vue";
 import ChartBigFigure from "./ChartBigFigure.vue";

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartSchooling.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartSchooling.vue
@@ -5,15 +5,16 @@
         <div class="flex mt-4 space-x-6">
             <ChartBigFigure
                 icon="children"
-                :figure="formatStat(data.figures.minors.value)"
-                :evolution="formatStat(data.figures.minors.evolution)"
+                :figure="data.figures.minors.value"
+                :evolution="data.figures.minors.evolution"
                 neutral
                 >Mineurs</ChartBigFigure
             >
+            {{ data.figures.minors_in_school.evolution }}
             <ChartBigFigure
                 icon="school"
-                :figure="formatStat(data.figures.minors_in_school.value)"
-                :evolution="formatStat(data.figures.minors_in_school.evolution)"
+                :figure="data.figures.minors_in_school.value"
+                :evolution="data.figures.minors_in_school.evolution"
                 :invert="true"
                 >Mineurs scolarisés</ChartBigFigure
             >
@@ -29,7 +30,6 @@
 </template>
 
 <script setup>
-import formatStat from "@/utils/formatStat";
 import { computed } from "vue";
 import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
 import LineChart from "@/components/Graphs/GraphBase.vue";


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/pORo90Bp/2377-visudonn%C3%A9es-calcul-du-pourcentage-de-progression-erron%C3%A9-si-pas-de-donn%C3%A9e-au-d%C3%A9but

## 🛠 Description de la PR
La PR corrige et améliore le traitement de la donnée d'évolution (BigFigure) dans un cas où la première data du graph est un 0 (null). Elle améliore l'affichage en prenant en compte le formattage (ajout d'un espace aux milliers).
La PR améliore également le traitement du formattage du chiffre actuel également (contenu dans le même "BigFigure").

## 📸 Captures d'écran
Avant, les premières données étant 0, le calcul restait "0%" malgré l'évolution.
![image](https://github.com/user-attachments/assets/1d04f4e5-e5be-4955-9331-29ae8dd99e75)

## 🚨 Notes pour la mise en production
_Liste des choses à faire pour le déploiement (changement de configuration, migrations à faire tourner, etc.), si possible avec les éléments les plus précis possibles (commande exacte à exécuter, etc.)._