### PR TITLE
#patch (2385) [BUG] Erreur lors de la mise à jour d'un site

### DIFF
--- a/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
+++ b/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
@@ -1427,14 +1427,11 @@ export default mode => ([
             if (value === null || value === undefined) {
                 return true;
             }
-            const noProcedureActive = (
-                req.body.justice_procedure !== true
+            // Si aucune procédure n'est active mais que police_status est renseigné
+            if (req.body.justice_procedure !== true
                 && req.body.evacuation_under_time_limit !== true
-                && req.body.insalubrity_order !== true
-            );
-            if (noProcedureActive) {
-                req.policeStatusErrorType = 'noProcedure'; // Stocker le type d'erreur
-                return false;
+                && req.body.insalubrity_order !== true) {
+                throw new Error('Veuillez renseigner une procédure judiciaire ou administrative pour justifier du recours à la force publique');
             }
             if (!['none', 'requested', 'granted', 'refused'].includes(value)) {
                 req.policeStatusErrorType = 'invalidValue'; // Stocker le type d'erreur

--- a/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
+++ b/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
@@ -1423,14 +1423,20 @@ export default mode => ([
      ********************************************************************************************* */
     body('police_status')
         .optional({ nullable: true })
-        .custom((value, { req }) => {
-            if (
-                req.body.justice_procedure !== true
-                && req.body.evacuation_under_time_limit !== true
-                && req.body.insalubrity_order !== true
-            ) {
-                return value === null;
+        // .custom((value, { req }) => {
+        .custom((value) => {
+            if (value === null || value === undefined) {
+                return true;
             }
+            // Désactiver car bloque les saisie pour lesquelles des CFP ont été saisie
+            // sans procédure judiciaire ou administrative en cours (avant la mise en place de ces champs)
+            // if (
+            //     req.body.justice_procedure !== true
+            //     && req.body.evacuation_under_time_limit !== true
+            //     && req.body.insalubrity_order !== true
+            // ) {
+            //     return value === null;
+            // }
             return ['none', 'requested', 'granted', 'refused'].includes(value);
         })
         .withMessage('Le champ "Concours de la force publique" est invalide'),

--- a/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
+++ b/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
@@ -1424,22 +1424,18 @@ export default mode => ([
     body('police_status')
         .optional({ nullable: true })
         .custom((value, { req }) => {
-            // Si la valeur est null ou undefined, c'est toujours valide
             if (value === null || value === undefined) {
                 return true;
             }
-            // Vérifie si aucune des procédures n'est activée
             const noProcedureActive = (
                 req.body.justice_procedure !== true
                 && req.body.evacuation_under_time_limit !== true
                 && req.body.insalubrity_order !== true
             );
-            // Si aucune procédure n'est active mais que police_status est renseigné
             if (noProcedureActive) {
                 req.policeStatusErrorType = 'noProcedure'; // Stocker le type d'erreur
                 return false;
             }
-            // Sinon, on vérifie que la valeur fait partie des valeurs autorisées
             if (!['none', 'requested', 'granted', 'refused'].includes(value)) {
                 req.policeStatusErrorType = 'invalidValue'; // Stocker le type d'erreur
                 return false;
@@ -1447,7 +1443,6 @@ export default mode => ([
             return true;
         })
         .withMessage((value, { req }) => {
-            // Message d'erreur conditionnel basé sur le type d'erreur
             if (req.policeStatusErrorType === 'noProcedure') {
                 return 'Veuillez renseigner une procédure judiciaire ou administrative pour justifier du concours de la force publique';
             }

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -48,6 +48,7 @@ import {
     computed,
     defineExpose,
     defineProps,
+    nextTick,
     ref,
     toRef,
     toRefs,
@@ -354,6 +355,20 @@ const deleteOriginalAttachment = (attachments) => {
     originalValues.existingAttachments = attachments;
 };
 
+// Méthode pour définir le focus sur le composant ErrorSummary en cas d'erreur remontée par le backend
+const focusOnErrorSummary = async () => {
+    await nextTick();
+
+    const errorSummary = document.getElementById("erreurs");
+
+    if (errorSummary) {
+        errorSummary.scrollIntoView({ behavior: "smooth", block: "start" });
+
+        errorSummary.setAttribute("tabindex", "-1");
+        errorSummary.focus();
+    }
+};
+
 defineExpose({
     submit: handleSubmit(async (sentValues) => {
         const formattedValues = formatValuesForApi(sentValues);
@@ -383,9 +398,8 @@ defineExpose({
 
         error.value = null;
 
+        const notificationStore = useNotificationStore();
         try {
-            const notificationStore = useNotificationStore();
-
             const { submit, notification } = config[mode.value];
 
             const respondedTown = await submit(formattedValues, town.value?.id);
@@ -401,6 +415,12 @@ defineExpose({
             if (e?.fields) {
                 setErrors(e.fields);
             }
+            focusOnErrorSummary();
+
+            notificationStore.error(
+                "Echec de la création ou mise à jour du site",
+                e?.user_message
+            );
         }
     }),
     isSubmitting,

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -362,10 +362,10 @@ const focusOnErrorSummary = async () => {
     const errorSummary = document.getElementById("erreurs");
 
     if (errorSummary) {
-        errorSummary.scrollIntoView({ behavior: "smooth", block: "start" });
-
-        errorSummary.setAttribute("tabindex", "-1");
-        errorSummary.focus();
+        errorSummary
+            .scrollIntoView({ behavior: "smooth", block: "start" })
+            .setAttribute("tabindex", "-1")
+            .focus();
     }
 };
 

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteProcedure.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/sections/FormDeclarationDeSiteProcedure.vue
@@ -238,7 +238,8 @@ const policeInformationRequested = computed(() => {
     return (
         values.value.justice_procedure === 1 ||
         values.value.evacuation_under_time_limit == 1 ||
-        values.value.insalubrity_order == 1
+        values.value.insalubrity_order == 1 ||
+        ["requested", "granted"].includes(values.value.police_status)
     );
 });
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Cio8PE6H/2385

## 🛠 Description de la PR
Voir ticket Trello pour une explication plus détaillée. En substance, le bug a été introduit lors de la mise en place courant 12022 d'une règle imposant qu'une procédure judiciaire ou administrative soit en cours pour permettre de saisir le recours à la force publique. Or, des recours avait déjà été saisis plus tôt et la mise à jour de ces sites n'est possible que si les utilisateurs renseignent les infos liées aux procédures judiciaire ou administrative.

**Ce qui a été corrigé:**
 - En cas d'erreur, même si aucune procédure n'est renseignée, le concours de la force publique est affiché si la valeur du champ correspondant n'est pas "null"
 - Le message remonté par `express-validator` (backend) est affiché clairement dans le composant `ErrorSummary`
- Une notification affiche que la création ou mise à jour n'a pas aboutie
- Le focus est donnée au composant `ErrorSummary` (ce qui n'était pas le cas jusqu'à présent - l'utilisateur était face au formulaire sans aucune information lui indiquant si la lise à jour avait aboutie ou non)

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/f4b37d3f-89ac-4f7c-b0db-91030613e209)

## 🚨 Notes pour la mise en production
- ràs