### PR TITLE
#patch (2367) Réactiver la tracking Matomo

### DIFF
--- a/packages/frontend/webapp/src/helpers/env.js
+++ b/packages/frontend/webapp/src/helpers/env.js
@@ -1,24 +1,12 @@
 // Log pour déboguer VITE_MATOMO_ENABLE - placé au début du module pour exécution
-const rawMatomoEnableFromEnv = import.meta.env.VITE_MATOMO_ENABLE;
+const meta_matomo_enable = import.meta.env.VITE_MATOMO_ENABLE;
 console.log(
     "[ENV Debug] Raw import.meta.env.VITE_MATOMO_ENABLE:",
-    rawMatomoEnableFromEnv
-);
-
-const matomoEnableValueForCheck =
-    rawMatomoEnableFromEnv || "${VITE_MATOMO_ENABLE}"; // Utilise la valeur brute ou le fallback
-console.log(
-    "[ENV Debug] Value used for MATOMO check (after || fallback):",
-    matomoEnableValueForCheck
-);
-
-const isMatomoActuallyEnabled = matomoEnableValueForCheck === "true";
-console.log(
-    "[ENV Debug] Comparison result (isMatomoActuallyEnabled):",
-    isMatomoActuallyEnabled
+    meta_matomo_enable
 );
 
 const MATOMO_CONFIG = {
+    ENABLE: import.meta.env.VITE_MATOMO_ENABLE || "${VITE_MATOMO_ENABLE}",
     HOST: import.meta.env.VITE_MATOMO_HOST || "${VITE_MATOMO_HOST}",
     SITE_ID: import.meta.env.VITE_MATOMO_SITE_ID || "${VITE_MATOMO_SITE_ID}",
     DOMAIN: import.meta.env.VITE_MATOMO_DOMAIN || "${VITE_MATOMO_DOMAIN}",
@@ -30,6 +18,8 @@ const MATOMO_CONFIG = {
         "${VITE_MATOMO_DESCRIPTION_PAGE_SEPARATOR}",
 };
 
+console.log("[ENV Debug] Final MATOMO_CONFIG:", MATOMO_CONFIG);
+
 const SENTRY_CONFIG = {
     DSN: import.meta.env.VITE_SENTRY_DSN || "${VITE_SENTRY_DSN}",
 };
@@ -39,7 +29,7 @@ export default {
     API_URL: import.meta.env.VITE_API_URL || "${VITE_API_URL}",
     CONTACT_EMAIL:
         import.meta.env.VITE_CONTACT_EMAIL || "${VITE_CONTACT_EMAIL}",
-    MATOMO: isMatomoActuallyEnabled ? MATOMO_CONFIG : null,
+    MATOMO: MATOMO_CONFIG.ENABLE === "true" ? MATOMO_CONFIG : null,
     SENTRY:
         (import.meta.env.VITE_SENTRY_ENABLE || "${VITE_SENTRY_ENABLE}") ===
         "true"

--- a/packages/frontend/webapp/src/helpers/env.js
+++ b/packages/frontend/webapp/src/helpers/env.js
@@ -30,7 +30,7 @@ export default {
     API_URL: import.meta.env.VITE_API_URL || "${VITE_API_URL}",
     CONTACT_EMAIL:
         import.meta.env.VITE_CONTACT_EMAIL || "${VITE_CONTACT_EMAIL}",
-    MATOMO: MATOMO_CONFIG.ENABLE === "true" ? MATOMO_CONFIG : null,
+    MATOMO: MATOMO_CONFIG, // Toujours assigner MATOMO_CONFIG, la vérification de ENABLE est dans matomo.js
     SENTRY:
         (import.meta.env.VITE_SENTRY_ENABLE || "${VITE_SENTRY_ENABLE}") ===
         "true"

--- a/packages/frontend/webapp/src/helpers/env.js
+++ b/packages/frontend/webapp/src/helpers/env.js
@@ -1,11 +1,3 @@
-// Log pour déboguer VITE_MATOMO_ENABLE - placé au début du module pour exécution
-const meta_matomo_enable =
-    import.meta.env.VITE_MATOMO_ENABLE || "${VITE_MATOMO_ENABLE}";
-console.log(
-    "[ENV Debug] Raw import.meta.env.VITE_MATOMO_ENABLE:",
-    meta_matomo_enable
-);
-
 const MATOMO_CONFIG = {
     ENABLE: import.meta.env.VITE_MATOMO_ENABLE || "${VITE_MATOMO_ENABLE}",
     HOST: import.meta.env.VITE_MATOMO_HOST || "${VITE_MATOMO_HOST}",
@@ -18,8 +10,6 @@ const MATOMO_CONFIG = {
         import.meta.env.VITE_MATOMO_DESCRIPTION_PAGE_SEPARATOR ||
         "${VITE_MATOMO_DESCRIPTION_PAGE_SEPARATOR}",
 };
-
-console.log("[ENV Debug] Final MATOMO_CONFIG:", MATOMO_CONFIG);
 
 const SENTRY_CONFIG = {
     DSN: import.meta.env.VITE_SENTRY_DSN || "${VITE_SENTRY_DSN}",

--- a/packages/frontend/webapp/src/helpers/env.js
+++ b/packages/frontend/webapp/src/helpers/env.js
@@ -1,5 +1,6 @@
 // Log pour déboguer VITE_MATOMO_ENABLE - placé au début du module pour exécution
-const meta_matomo_enable = import.meta.env.VITE_MATOMO_ENABLE;
+const meta_matomo_enable =
+    import.meta.env.VITE_MATOMO_ENABLE || "${VITE_MATOMO_ENABLE}";
 console.log(
     "[ENV Debug] Raw import.meta.env.VITE_MATOMO_ENABLE:",
     meta_matomo_enable

--- a/packages/frontend/webapp/src/helpers/env.js
+++ b/packages/frontend/webapp/src/helpers/env.js
@@ -1,4 +1,24 @@
-const MATOMO = {
+// Log pour déboguer VITE_MATOMO_ENABLE - placé au début du module pour exécution
+const rawMatomoEnableFromEnv = import.meta.env.VITE_MATOMO_ENABLE;
+console.log(
+    "[ENV Debug] Raw import.meta.env.VITE_MATOMO_ENABLE:",
+    rawMatomoEnableFromEnv
+);
+
+const matomoEnableValueForCheck =
+    rawMatomoEnableFromEnv || "${VITE_MATOMO_ENABLE}"; // Utilise la valeur brute ou le fallback
+console.log(
+    "[ENV Debug] Value used for MATOMO check (after || fallback):",
+    matomoEnableValueForCheck
+);
+
+const isMatomoActuallyEnabled = matomoEnableValueForCheck === "true";
+console.log(
+    "[ENV Debug] Comparison result (isMatomoActuallyEnabled):",
+    isMatomoActuallyEnabled
+);
+
+const MATOMO_CONFIG = {
     HOST: import.meta.env.VITE_MATOMO_HOST || "${VITE_MATOMO_HOST}",
     SITE_ID: import.meta.env.VITE_MATOMO_SITE_ID || "${VITE_MATOMO_SITE_ID}",
     DOMAIN: import.meta.env.VITE_MATOMO_DOMAIN || "${VITE_MATOMO_DOMAIN}",
@@ -10,7 +30,7 @@ const MATOMO = {
         "${VITE_MATOMO_DESCRIPTION_PAGE_SEPARATOR}",
 };
 
-const SENTRY = {
+const SENTRY_CONFIG = {
     DSN: import.meta.env.VITE_SENTRY_DSN || "${VITE_SENTRY_DSN}",
 };
 
@@ -19,14 +39,10 @@ export default {
     API_URL: import.meta.env.VITE_API_URL || "${VITE_API_URL}",
     CONTACT_EMAIL:
         import.meta.env.VITE_CONTACT_EMAIL || "${VITE_CONTACT_EMAIL}",
-    MATOMO:
-        (import.meta.env.VITE_MATOMO_ENABLE || "${VITE_MATOMO_ENABLE}") ===
-        "true"
-            ? MATOMO
-            : null,
+    MATOMO: isMatomoActuallyEnabled ? MATOMO_CONFIG : null,
     SENTRY:
         (import.meta.env.VITE_SENTRY_ENABLE || "${VITE_SENTRY_ENABLE}") ===
         "true"
-            ? SENTRY
+            ? SENTRY_CONFIG
             : null,
 };

--- a/packages/frontend/webapp/src/helpers/matomo.js
+++ b/packages/frontend/webapp/src/helpers/matomo.js
@@ -2,45 +2,21 @@ import VueMatomo from "vue-matomo";
 import { computed } from "vue";
 import ENV from "@/helpers/env.js";
 
-// const { MATOMO } = ENV; // Supprimé pour utiliser ENV.MATOMO directement dans useMatomo
 const $piwik = computed(() => {
     return typeof window !== "undefined" ? window.Piwik?.getTracker() : null;
 });
 
 export function useMatomo(app, router) {
-    // Accéder à ENV.MATOMO directement ici
     if (!ENV.MATOMO) {
-        console.warn(
-            "[Matomo Debug] Matomo not initialized because ENV.MATOMO is not defined.",
-            ENV.MATOMO
-        );
         return;
     }
 
-    // Logguer la valeur et le type de ENABLE avant de comparer
-    console.log(
-        "[Matomo Debug] Checking ENV.MATOMO.ENABLE: ",
-        `'${ENV.MATOMO.ENABLE}'`,
-        "(type:",
-        typeof ENV.MATOMO.ENABLE,
-        ")"
-    );
-
-    // Utiliser .trim() pour enlever les espaces potentiels avant la comparaison
     if (
         typeof ENV.MATOMO.ENABLE !== "string" ||
         ENV.MATOMO.ENABLE.trim() !== "true"
     ) {
-        console.warn(
-            "[Matomo Debug] Matomo not initialized because ENV.MATOMO.ENABLE is not 'true'. Actual value:",
-            `'${ENV.MATOMO.ENABLE}'` // Affiche la valeur avec des apostrophes pour voir les espaces
-        );
         return;
     }
-
-    console.log(
-        "[Matomo Debug] Conditions passed, proceeding with Matomo initialization."
-    ); // Nouveau log
 
     // Si on utilise le serveur matomo DNUM, il faut modifier l'URL
     // avant l'envoi à Matomo pour rester compatible avec Xiti
@@ -66,12 +42,7 @@ export function useMatomo(app, router) {
         cookieDomain: `*.${ENV.MATOMO.DOMAIN}`,
         domains: `*.${ENV.MATOMO.DOMAIN}`,
         trackerFileName: ENV.MATOMO.TRACKER_FILENAME,
-        debug: true,
     };
-    console.log(
-        "[Matomo Debug] Initializing VueMatomo with config:",
-        matomoConfig
-    );
     app.use(VueMatomo, matomoConfig);
 }
 
@@ -107,18 +78,13 @@ export function trackLogout() {
 
 export function trackEvent(category, action, name, value) {
     if (typeof window === "undefined") {
-        console.warn(
-            "[Matomo Debug] trackEvent called in non-browser environment."
-        );
         return;
     }
 
-    // Assure que window._paq est initialisé comme un tableau
     window._paq = window._paq || [];
 
     const eventDetails = ["trackEvent", category, action];
 
-    // Ajoute name et value seulement s'ils sont définis, car Matomo les attend dans cet ordre.
     if (name !== undefined) {
         eventDetails.push(name);
         if (value !== undefined) {
@@ -126,7 +92,6 @@ export function trackEvent(category, action, name, value) {
         }
     }
 
-    console.log("[Matomo Debug] Pushing to _paq:", eventDetails);
     window._paq.push(eventDetails);
 }
 

--- a/packages/frontend/webapp/src/helpers/matomo.js
+++ b/packages/frontend/webapp/src/helpers/matomo.js
@@ -9,14 +9,38 @@ const $piwik = computed(() => {
 
 export function useMatomo(app, router) {
     // Accéder à ENV.MATOMO directement ici
-    if (!ENV.MATOMO || ENV.MATOMO.ENABLE !== "true") {
-        // Vérifier aussi explicitement ENABLE
+    if (!ENV.MATOMO) {
         console.warn(
-            "[Matomo Debug] Matomo not initialized because ENV.MATOMO is not defined or not enabled.",
+            "[Matomo Debug] Matomo not initialized because ENV.MATOMO is not defined.",
             ENV.MATOMO
         );
         return;
     }
+
+    // Logguer la valeur et le type de ENABLE avant de comparer
+    console.log(
+        "[Matomo Debug] Checking ENV.MATOMO.ENABLE: ",
+        `'${ENV.MATOMO.ENABLE}'`,
+        "(type:",
+        typeof ENV.MATOMO.ENABLE,
+        ")"
+    );
+
+    // Utiliser .trim() pour enlever les espaces potentiels avant la comparaison
+    if (
+        typeof ENV.MATOMO.ENABLE !== "string" ||
+        ENV.MATOMO.ENABLE.trim() !== "true"
+    ) {
+        console.warn(
+            "[Matomo Debug] Matomo not initialized because ENV.MATOMO.ENABLE is not 'true'. Actual value:",
+            `'${ENV.MATOMO.ENABLE}'` // Affiche la valeur avec des apostrophes pour voir les espaces
+        );
+        return;
+    }
+
+    console.log(
+        "[Matomo Debug] Conditions passed, proceeding with Matomo initialization."
+    ); // Nouveau log
 
     // Si on utilise le serveur matomo DNUM, il faut modifier l'URL
     // avant l'envoi à Matomo pour rester compatible avec Xiti

--- a/packages/frontend/webapp/src/helpers/matomo.js
+++ b/packages/frontend/webapp/src/helpers/matomo.js
@@ -69,12 +69,27 @@ export function trackLogout() {
     $piwik.value.setCustomVariable(5, "departement_code", null);
 }
 
-export function trackEvent(...args) {
-    if (!$piwik.value) {
+export function trackEvent(category, action, name, value) {
+    if (typeof window === "undefined") {
+        console.warn("[Matomo Debug] trackEvent called in non-browser environment.");
         return;
     }
 
-    return $piwik.value.trackEvent(...args);
+    // Assure que window._paq est initialisé comme un tableau
+    window._paq = window._paq || [];
+
+    const eventDetails = ['trackEvent', category, action];
+
+    // Ajoute name et value seulement s'ils sont définis, car Matomo les attend dans cet ordre.
+    if (name !== undefined) {
+        eventDetails.push(name);
+        if (value !== undefined) {
+            eventDetails.push(value);
+        }
+    }
+    
+    console.log("[Matomo Debug] Pushing to _paq:", eventDetails);
+    window._paq.push(eventDetails);
 }
 
 export function optOut() {

--- a/packages/frontend/webapp/src/helpers/matomo.js
+++ b/packages/frontend/webapp/src/helpers/matomo.js
@@ -27,8 +27,7 @@ export function useMatomo(app, router) {
             return { ...to, fullPath: modifiedPath };
         };
     }
-
-    app.use(VueMatomo, {
+    const matomoConfig = {
         host: MATOMO.HOST,
         siteId: MATOMO.SITE_ID,
         router,
@@ -36,7 +35,12 @@ export function useMatomo(app, router) {
         cookieDomain: `*.${MATOMO.DOMAIN}`,
         domains: `*.${MATOMO.DOMAIN}`,
         trackerFileName: MATOMO.TRACKER_FILENAME,
-    });
+    };
+    console.log(
+        "[Matomo Debug] Initializing VueMatomo with config:",
+        matomoConfig
+    );
+    app.use(VueMatomo, matomoConfig);
 }
 
 export function trackLogin(user) {
@@ -71,14 +75,16 @@ export function trackLogout() {
 
 export function trackEvent(category, action, name, value) {
     if (typeof window === "undefined") {
-        console.warn("[Matomo Debug] trackEvent called in non-browser environment.");
+        console.warn(
+            "[Matomo Debug] trackEvent called in non-browser environment."
+        );
         return;
     }
 
     // Assure que window._paq est initialisé comme un tableau
     window._paq = window._paq || [];
 
-    const eventDetails = ['trackEvent', category, action];
+    const eventDetails = ["trackEvent", category, action];
 
     // Ajoute name et value seulement s'ils sont définis, car Matomo les attend dans cet ordre.
     if (name !== undefined) {
@@ -87,7 +93,7 @@ export function trackEvent(category, action, name, value) {
             eventDetails.push(value);
         }
     }
-    
+
     console.log("[Matomo Debug] Pushing to _paq:", eventDetails);
     window._paq.push(eventDetails);
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/dIm97Go7/2367

## 🛠 Description de la PR
- Ajouter la ligne `window._paq.push(["trackPageView"]); ` après l'initialisation du plugin `vue-matomo`. La plupart des implémentations de Matomo auraient besoin de cette ligne pour fonctionner correctement, car elle déclenche le début du suivi pour la session utilisateur.

## 📸 Captures d'écran
- SO

## 🚨 Notes pour la mise en production
- Test en PREPROD pour voir si cela corrige le problème avant passage en PROD