### PR TITLE
#patch: (2379) Rendre la carto dynamique selon l'onglet

### DIFF
--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -157,6 +157,11 @@ const props = defineProps({
         required: false,
         default: false,
     },
+    activeTab: {
+        type: String,
+        required: false,
+        default: "summary",
+    },
 });
 const {
     isLoading,
@@ -170,6 +175,7 @@ const {
     townMarkerFn,
     locationMarkerFn,
     displaySkipMapLinks,
+    activeTab,
 } = toRefs(props);
 
 const map = ref(null);
@@ -352,7 +358,11 @@ function syncTownMarkers() {
                 territoryData[key][location.code].total += 1;
             });
 
-            const marker = townMarkerFn.value(town);
+            const marker = townMarkerFn.value(town, activeTab.value);
+            marker.on("mouseover", () =>
+                emit("highlightTownLine", town.id, town.city.code)
+            );
+            marker.on("mouseout", () => emit("highlightTownLine", null, null));
             marker.on("click", () => emit("townclick", town));
             return marker;
         })

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -27,7 +27,7 @@
 
             <div
                 ref="printer"
-                class="bg-white mr-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden cursor-pointer"
+                class="bg-white mr-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden !cursor-pointer"
                 @click="printMapScreenshot"
                 v-show="showPrinter"
             >
@@ -79,6 +79,7 @@ import { Icon, Spinner } from "@resorptionbidonvilles/ui";
 import getAbsoluteOffsetTop from "@/utils/getAbsoluteOffsetTop";
 import skipFocusNext from "@/utils/skipFocusNext";
 import skipFocusPrevious from "@/utils/skipFocusPrevious";
+import { useNotificationStore } from "@/stores/notification.store";
 
 const props = defineProps({
     isLoading: {
@@ -184,6 +185,7 @@ const skipPreviousLink = ref(null);
 const printer = ref(null);
 const currentMarkerGroup = ref(null);
 
+const notificationStore = useNotificationStore();
 const controls = {};
 const markersGroup = {
     towns: ref(L.markerClusterGroup(townClusteringOptions.value)),
@@ -314,6 +316,10 @@ async function printMapScreenshot() {
         trackEvent("Cartographie", "Impression");
     } catch (error) {
         console.log("Failed printing the map");
+        notificationStore.error(
+            "Erreur d'impression",
+            "Erreur lors de l'impression de la carte"
+        );
     }
 
     // on réaffiche les contrôles

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -315,7 +315,7 @@ async function printMapScreenshot() {
 
         trackEvent("Cartographie", "Impression");
     } catch (error) {
-        console.log("Failed printing the map");
+        console.log("Failed printing the map", error);
         notificationStore.error(
             "Erreur d'impression",
             "Erreur lors de l'impression de la carte"

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -23,7 +23,7 @@
             >
                 <Icon
                     :icon="`${
-                        legendeStatus === true ? 'chevron-up' : 'chevron-down'
+                        legendeStatus === true ? 'chevron-down' : 'chevron-up'
                     }`"
                 />
                 <div class="font-bold mx-2">Légende</div>

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -17,18 +17,21 @@
             ref="legende"
             class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded"
         >
-            <div @click="changeLegendeStatus" class="mb-2 mx-2 cursor-pointer">
+            <div
+                @click="changeLegendeStatus"
+                class="flex mb-2 mx-2 cursor-pointer"
+            >
                 <Icon
                     :icon="`${
                         legendeStatus === true ? 'chevron-up' : 'chevron-down'
                     }`"
                 />
-                <label class="font-bold mx-2"> Légende </label>
+                <div class="font-bold mx-2">Légende</div>
             </div>
             <div v-if="legendeStatus === true" class="flex">
                 <div class="flex">
                     <div class="grid grid-cols-1 content-start">
-                        <label
+                        <div
                             class=""
                             v-for="displayedLegendItem in displayedLegend[
                                 activeTab
@@ -36,25 +39,25 @@
                             :key="displayedLegendItem"
                         >
                             <Icon class="mx-2" :icon="displayedLegendItem" />
-                        </label>
+                        </div>
                     </div>
 
                     <div class="grid grid-cols-1 content-start">
-                        <label
+                        <div
                             v-for="displayedLegendLabel in displayedLegend[
                                 activeTab
                             ].labels"
                             :key="displayedLegendLabel"
                         >
                             {{ displayedLegendLabel }}
-                        </label>
+                        </div>
                     </div>
                 </div>
                 <div class="flex flex-col ml-4">
                     <div v-if="displayedLegend[activeTab].levelsTitle">
-                        <label class="font-bold">
+                        <div class="font-bold">
                             {{ displayedLegend[activeTab].levelsTitle }}
-                        </label>
+                        </div>
                     </div>
                     <div
                         class="flex mb-2"
@@ -62,7 +65,7 @@
                         :key="level.label"
                     >
                         <div :class="`${level.style}`"></div>
-                        <label class="ml-2"> {{ level.label }} </label>
+                        <div class="ml-2">{{ level.label }}</div>
                     </div>
                 </div>
             </div>

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -23,13 +23,11 @@
                         legendeStatus === true ? 'chevron-up' : 'chevron-down'
                     }`"
                 />
-                <label class="font-bold mx-2">
-                    {{ displayedLegend[activeTab].title }}
-                </label>
+                <label class="font-bold mx-2"> Légende </label>
             </div>
             <div v-if="legendeStatus === true" class="flex">
                 <div class="flex">
-                    <div class="grid grid-cols-1">
+                    <div class="grid grid-cols-1 content-start">
                         <label
                             class=""
                             v-for="displayedLegendItem in displayedLegend[
@@ -41,7 +39,7 @@
                         </label>
                     </div>
 
-                    <div class="grid grid-cols-1">
+                    <div class="grid grid-cols-1 content-start">
                         <label
                             v-for="displayedLegendLabel in displayedLegend[
                                 activeTab
@@ -108,7 +106,6 @@ const displayedLegend = {
     livingConditionsByTown: null,
     livingConditionsByInhabitant: null,
     summary: {
-        title: "Légende conditions de vie",
         icons: [
             "faucet-drip",
             "bolt",
@@ -133,7 +130,6 @@ const displayedLegend = {
         ],
     },
     schooling: {
-        title: "Légende scolarisation",
         icons: ["child", "school"],
         labels: ["Mineurs", "Mineurs scolarisés"],
         levelsTitle: "Pourcentage de scolarisation",

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -10,10 +10,11 @@
         :locationMarkerFn="marqueurLocationStats"
         :townClusteringOptions="{ maxClusterRadius: 0 }"
         :defaultView="departementMetricsStore.lastMapView || undefined"
+        :activeTab="activeTab"
         displaySkipMapLinks
     >
         <div
-            ref="legendeConditionsDeVie"
+            ref="legende"
             class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded"
         >
             <div @click="changeLegendeStatus" class="mb-2 mx-2 cursor-pointer">
@@ -22,53 +23,48 @@
                         legendeStatus === true ? 'chevron-up' : 'chevron-down'
                     }`"
                 />
-                <label class="font-bold mx-2"> Légende </label>
+                <label class="font-bold mx-2">
+                    {{ displayedLegend[activeTab].title }}
+                </label>
             </div>
             <div v-if="legendeStatus === true" class="flex">
                 <div class="flex">
                     <div class="grid grid-cols-1">
-                        <label class="flex items-center space-x-2">
-                            <Icon class="mx-2" icon="faucet-drip" />
-                        </label>
-                        <label class="flex items-center space-x-2">
-                            <Icon class="mx-2" icon="bolt" />
-                        </label>
-                        <label class="flex items-center space-x-2">
-                            <Icon class="mx-2" icon="trash-alt" />
-                        </label>
-                        <label class="flex items-center space-x-2">
-                            <Icon class="mx-2" icon="fire-extinguisher" />
-                        </label>
-                        <label class="flex items-center space-x-2">
-                            <Icon class="mx-2" icon="toilet" />
-                        </label>
-                        <label class="flex items-center space-x-2">
-                            <Icon class="mx-2" icon="bug-slash" />
+                        <label
+                            class=""
+                            v-for="displayedLegendItem in displayedLegend[
+                                activeTab
+                            ].icons"
+                            :key="displayedLegendItem"
+                        >
+                            <Icon class="mx-2" :icon="displayedLegendItem" />
                         </label>
                     </div>
 
                     <div class="grid grid-cols-1">
-                        <label> Accès à l'eau </label>
-                        <label> Accès à l'électricité </label>
-                        <label> Evacuation des déchets </label>
-                        <label> Prévention incendie </label>
-                        <label> Accès aux toilettes </label>
-                        <label> Absence de nuisibles </label>
+                        <label
+                            v-for="displayedLegendLabel in displayedLegend[
+                                activeTab
+                            ].labels"
+                            :key="displayedLegendLabel"
+                        >
+                            {{ displayedLegendLabel }}
+                        </label>
                     </div>
                 </div>
                 <div class="flex flex-col ml-4">
-                    <div class="flex mb-2">
-                        <div class="bg-success w-10 border"></div>
-                        <label class="ml-2"> Satisfaisant </label>
+                    <div v-if="displayedLegend[activeTab].levelsTitle">
+                        <label class="font-bold">
+                            {{ displayedLegend[activeTab].levelsTitle }}
+                        </label>
                     </div>
-
-                    <div class="flex mb-2">
-                        <div class="bg-error w-10"></div>
-                        <label class="ml-2"> A améliorer </label>
-                    </div>
-                    <div class="flex">
-                        <div class="border w-10 crossed"></div>
-                        <label class="ml-2"> Inexistant </label>
+                    <div
+                        class="flex mb-2"
+                        v-for="level in displayedLegend[activeTab].levels"
+                        :key="level.label"
+                    >
+                        <div :class="`${level.style}`"></div>
+                        <label class="ml-2"> {{ level.label }} </label>
                     </div>
                 </div>
             </div>
@@ -77,26 +73,81 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from "vue";
+import { computed, ref, toRefs, watch } from "vue";
 import L from "leaflet";
 import Carto from "@/components/Carto/Carto.vue";
 import marqueurSiteStats from "@/utils/marqueurSiteStats";
 import marqueurLocationStats from "@/utils/marqueurLocationStats";
 import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
 import { Icon } from "@resorptionbidonvilles/ui";
+
+const props = defineProps({
+    activeTab: {
+        type: String,
+        default: "summary",
+        required: false,
+    },
+});
+const { activeTab } = toRefs(props);
+
 const departementMetricsStore = useDepartementMetricsStore();
 const carto = ref(null);
 const markersGroup = ref(L.geoJSON([], {}));
-const legendeConditionsDeVie = ref(null);
+const legende = ref(null);
 const legendeStatus = ref(false);
 
 watch(carto, () => {
     if (carto.value) {
         carto.value.map.addLayer(markersGroup.value);
         carto.value.map.on("move", onMove);
-        carto.value.addControl("legendeConditionsDeVie", createLegende());
+        carto.value.addControl("legende", createLegende());
     }
 });
+
+const displayedLegend = {
+    livingConditionsByTown: null,
+    livingConditionsByInhabitant: null,
+    summary: {
+        title: "Légende conditions de vie",
+        icons: [
+            "faucet-drip",
+            "bolt",
+            "trash-alt",
+            "fire-extinguisher",
+            "toilet",
+            "bug-slash",
+        ],
+        labels: [
+            "Accès à l'eau",
+            "Accès à l'électricité",
+            "Evacuation des déchets",
+            "Prévention incendie",
+            "Accès aux toilettes",
+            "Absence de nuisibles",
+        ],
+        levelsTitle: null,
+        levels: [
+            { style: "bg-success w-10 border", label: "Satisfaisant" },
+            { style: "bg-error w-10", label: "A améliorer" },
+            { style: "border w-10 crossed", label: "Inexistant" },
+        ],
+    },
+    schooling: {
+        title: "Légende scolarisation",
+        icons: ["child", "school"],
+        labels: ["Mineurs", "Mineurs scolarisés"],
+        levelsTitle: "Pourcentage de scolarisation",
+        levels: [
+            { style: "bg-success w-10 border", label: ">= 70 %" },
+            { style: "bg-warningOrange w-10", label: ">= 30 %" },
+            { style: "bg-error w-10", label: "< 30 %" },
+            { style: "bg-G400 w-10 border", label: "Pas de mineurs" },
+        ],
+    },
+};
+// Pas de différence entre summary et livingConditions (temporaire)
+displayedLegend.livingConditionsByTown = displayedLegend.summary;
+displayedLegend.livingConditionsByInhabitant = displayedLegend.summary;
 
 function onMove() {
     const { map } = carto.value;
@@ -114,7 +165,7 @@ function createLegende() {
         },
 
         onAdd() {
-            return legendeConditionsDeVie.value;
+            return legende.value;
         },
     });
 

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/DonneesStatistiquesDepartement.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/DonneesStatistiquesDepartement.vue
@@ -29,6 +29,7 @@
                     @unhighlightTown="onMouseLeave"
                     @townClick="onTownRowClick"
                     @townZoom="onTownRowZoom"
+                    :highlightedTown="highlightedTown"
                 />
             </div>
             <div class="w-1 bg-blue300">
@@ -76,6 +77,8 @@
                     :isLoading="isLoading"
                     :towns="towns"
                     @townclick="onTownClick"
+                    @highlightTownLine="toggleTownHighlight"
+                    :activeTab="departementMetricsStore.activeTab"
                 />
             </div>
         </div>
@@ -150,6 +153,7 @@ const tables = {
     schooling: SchoolingTable,
     justice: JusticeTable,
 };
+const highlightedTown = ref(null);
 
 const userTabs = computed(() => {
     if (!userStore.hasJusticePermission) {
@@ -280,6 +284,17 @@ function onTownClick(town) {
 }
 
 const { currentFormat } = toRefs(departementMetricsStore);
+
+const toggleTownHighlight = (townId, cityCode) => {
+    highlightedTown.value = townId;
+    if (townId === null) {
+        onMouseLeave();
+    } else if (highlightedTown.value === townId) {
+        onMouseEnter(townId, cityCode);
+    } else {
+        onMouseEnter(townId, cityCode);
+    }
+};
 watch(currentFormat, () => {
     loadGeojson();
 });

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/tables/CitySubTable.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/tables/CitySubTable.vue
@@ -12,6 +12,9 @@
             @click="$emit('townClick', town, data.city)"
             @townZoom="$emit('townZoom', town, data.city)"
             @unhighlightTown="onUnhighlight"
+            :class="{
+                'bg-blue200': highlightedTown === town.id,
+            }"
         />
     </template>
 </template>
@@ -34,8 +37,13 @@ const props = defineProps({
         type: Boolean,
         required: true,
     },
+    highlightedTown: {
+        type: Number,
+        required: false,
+    },
 });
-const { data, columns, showTowns } = toRefs(props);
+const { data, columns, showTowns, highlightedTown } = toRefs(props);
+
 const emit = defineEmits([
     "highlightTown",
     "townZoom",

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/tables/TemplateTable.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/tables/TemplateTable.vue
@@ -16,6 +16,7 @@
                             data.city.code
                         ] !== false
                     "
+                    :highlightedTown="highlightedTown"
                     @highlightTown="onHighlight"
                     @unhighlightTown="onUnhighlight"
                     @townClick="onTownClick"
@@ -75,8 +76,12 @@ const props = defineProps({
         type: Array,
         required: true,
     },
+    highlightedTown: {
+        type: Number,
+        required: false,
+    },
 });
-const { columns, metrics } = toRefs(props);
+const { columns, metrics, highlightedTown } = toRefs(props);
 const departementMetricsStore = useDepartementMetricsStore();
 const emit = defineEmits([
     "highlightTown",

--- a/packages/frontend/webapp/src/utils/marqueurSiteStats.js
+++ b/packages/frontend/webapp/src/utils/marqueurSiteStats.js
@@ -19,24 +19,33 @@ const iconMap = {
 iconMap.livingConditionsByInhabitant = iconMap.summary;
 iconMap.livingConditionsByTown = iconMap.summary;
 
+const colorizeSchooling = (minors, percentage) => {
+    if (minors === 0 || minors === null) {
+        return "text-G400";
+    }
+
+    if (percentage >= 70) {
+        return "text-green";
+    } else if (percentage >= 30) {
+        return "text-warningOrange";
+    }
+
+    return "text-red";
+};
+
 export default (town, activeTab) => {
     const livingConditionsHTML = Object.keys(iconMap[activeTab])
         .reduce((acc, key) => {
-            let color = "text-green";
+            let color;
             if (activeTab === "schooling") {
                 const schoolingPercentage = Math.round(
                     (town.number_of_schooled_minors / town.number_of_minors) *
                         100
                 );
-                color =
-                    town.number_of_minors === 0 ||
-                    town.number_of_minors === null
-                        ? "text-G400"
-                        : schoolingPercentage >= 70
-                        ? "text-green"
-                        : schoolingPercentage >= 30
-                        ? "text-warningOrange"
-                        : "text-red";
+                color = colorizeSchooling(
+                    town.number_of_minors,
+                    schoolingPercentage
+                );
             } else {
                 if (town[key] === "bad" || town[key] === "unknown") {
                     return acc;

--- a/packages/frontend/webapp/src/utils/marqueurSiteStats.js
+++ b/packages/frontend/webapp/src/utils/marqueurSiteStats.js
@@ -1,24 +1,51 @@
 import L from "leaflet";
 
 const iconMap = {
-    access_to_water: "faucet-drip",
-    access_to_electricity: "bolt",
-    trash_evacuation: "trash-can",
-    fire_prevention: "fire-extinguisher",
-    working_toilets: "toilet",
-    absence_of_pest_animals: "bug-slash",
+    livingConditionsByTown: null,
+    livingConditionsByInhabitant: null,
+    summary: {
+        access_to_water: "faucet-drip",
+        access_to_electricity: "bolt",
+        trash_evacuation: "trash-can",
+        fire_prevention: "fire-extinguisher",
+        working_toilets: "toilet",
+        absence_of_pest_animals: "bug-slash",
+    },
+    schooling: {
+        number_of_schooled_minors: "school",
+    },
 };
+// On donne temporairement les mêmes valeurs que summary aux lovingConditions
+iconMap.livingConditionsByInhabitant = iconMap.summary;
+iconMap.livingConditionsByTown = iconMap.summary;
 
-export default (town) => {
-    const livingConditionsHTML = Object.keys(iconMap)
+export default (town, activeTab) => {
+    const livingConditionsHTML = Object.keys(iconMap[activeTab])
         .reduce((acc, key) => {
-            if (town[key] === "bad" || town[key] === "unknown") {
-                return acc;
-            }
+            let color = "text-green";
+            if (activeTab === "schooling") {
+                const schoolingPercentage = Math.round(
+                    (town.number_of_schooled_minors / town.number_of_minors) *
+                        100
+                );
+                color =
+                    town.number_of_minors === 0 ||
+                    town.number_of_minors === null
+                        ? "text-G400"
+                        : schoolingPercentage >= 70
+                        ? "text-green"
+                        : schoolingPercentage >= 30
+                        ? "text-warningOrange"
+                        : "text-red";
+            } else {
+                if (town[key] === "bad" || town[key] === "unknown") {
+                    return acc;
+                }
 
-            const color = town[key] === "good" ? "text-green" : "text-red";
+                color = town[key] === "good" ? "text-green" : "text-red";
+            }
             acc.push(
-                `<i class="fa-solid fa-${iconMap[key]} ${color} ml-1"></i>`
+                `<i class="fa-solid fa-${iconMap[activeTab][key]} ${color} ml-1"></i>`
             );
             return acc;
         }, [])
@@ -30,8 +57,11 @@ export default (town) => {
             html: `<span id="marqueur-site-stats-${
                 town.id
             }" class="border-2 border-primary rounded bg-white px-2 py-1 whitespace-nowrap">
-                ${town.number_of_persons || "0"} ${livingConditionsHTML}
-            </span>`,
+                ${
+                    activeTab === "schooling"
+                        ? town.number_of_minors || "0"
+                        : town.number_of_persons || "0"
+                } ${livingConditionsHTML}`,
         }),
     });
 };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/xkdID9LH/2379-visudonn%C3%A9es-rendre-la-carto-dynamique-selon-longlet

## 🛠 Description de la PR
Cette PR permet d'afficher des marqueurs en rapport avec l'onglet affiché en visualisation des données > situation à date.
Ainsi, lorsque l'on affiche l'onglet "scolarisation", les marqueurs sont modifiés afin d'afficher:
- Nombre de mineurs du site *(à la place de la population totale du site)*
- Items "école" colorisé, représentant le pourcentage de scolarisation
La colorisation de l'item est basé sur la matrice suivante:
- 0 mineurs: gris
- de 0 à 30% de scolarisation: rouge
- de 30 à 70% de scolarisation: orange
- supérieur à 70% de scolarisation: vert
La PR ajoute aussi une mise à jour automatique de la légende de la carte en fonction du tableau affiché.

Pour finir, la PR apporte également une amélioration du système de mise en surbrillance. Auparavant, survoler la ligne d'un site dans le tableau mettait en surbrillance le marqueur du site sur la carte. Maintenant, l'effet inverse est également vrai: survoler un site sur la cartographie mettra sa ligne correspondante en surbrillance dans le tableau.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/a2a37f11-f297-4845-8f87-c143c1379382)

## 🚨 Notes pour la mise en production
RàS