### PR TITLE
#patch: (2377-fix) Corrections mineures

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartSchooling.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartSchooling.vue
@@ -10,7 +10,6 @@
                 neutral
                 >Mineurs</ChartBigFigure
             >
-            {{ data.figures.minors_in_school.evolution }}
             <ChartBigFigure
                 icon="school"
                 :figure="data.figures.minors_in_school.value"

--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartTowns.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/charts/EvolutionChartTowns.vue
@@ -5,31 +5,29 @@
         <div class="flex mt-4 space-x-6">
             <ChartBigFigure
                 icon="tent"
-                :figure="formatStat(data.figures.total.value)"
-                :evolution="formatStat(data.figures.total.evolution)"
+                :figure="data.figures.total.value"
+                :evolution="data.figures.total.evolution"
                 >Tous sites</ChartBigFigure
             >
 
             <ChartBigFigure
                 icon="tent"
-                :figure="formatStat(data.figures.less_than_10.value)"
-                :evolution="formatStat(data.figures.less_than_10.evolution)"
+                :figure="data.figures.less_than_10.value"
+                :evolution="data.figures.less_than_10.evolution"
                 >Sites de moins de 10 habitants</ChartBigFigure
             >
 
             <ChartBigFigure
                 icon="tent"
-                :figure="formatStat(data.figures.between_10_and_99.value)"
-                :evolution="
-                    formatStat(data.figures.between_10_and_99.evolution)
-                "
+                :figure="data.figures.between_10_and_99.value"
+                :evolution="data.figures.between_10_and_99.evolution"
                 >Sites de moins de 100 habitants</ChartBigFigure
             >
 
             <ChartBigFigure
                 icon="tent"
-                :figure="formatStat(data.figures.more_than_99.value)"
-                :evolution="formatStat(data.figures.more_than_99.evolution)"
+                :figure="data.figures.more_than_99.value"
+                :evolution="data.figures.more_than_99.evolution"
                 >Sites de plus de 100 habitants</ChartBigFigure
             >
         </div>
@@ -44,7 +42,6 @@
 </template>
 
 <script setup>
-import formatStat from "@/utils/formatStat";
 import { computed } from "vue";
 import { useDepartementMetricsStore } from "@/stores/metrics.departement.store";
 import LineChart from "@/components/Graphs/GraphBase.vue";


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/pORo90Bp/2377-visudonn%C3%A9es-calcul-du-pourcentage-de-progression-erron%C3%A9-si-pas-de-donn%C3%A9e-au-d%C3%A9but

## 🛠 Description de la PR
La PR supprime l'affichage d'un log et corrige le formattage des BigFigures de l'évolution des sites (logique déportée).

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/100b0787-a7bd-4594-b63f-ca23c4260cb7)

## 🚨 Notes pour la mise en production
RàS