### PR TITLE
#patch (2387) [Page stat publiques] Renommer utilisateurs inscrits en utilisateurs actifs

### DIFF
--- a/packages/frontend/webapp/src/components/StatistiquesPubliques/Graphs/NombreUtilisateursParSemaine.vue
+++ b/packages/frontend/webapp/src/components/StatistiquesPubliques/Graphs/NombreUtilisateursParSemaine.vue
@@ -24,7 +24,7 @@ const { data } = toRefs(props);
 const chartData = computed(() => {
     const datasets = [
         generateDataset(
-            "Nombre d'utilisateurs inscrits",
+            "Nombre d'utilisateurs actifs",
             "255, 0, 0",
             data.value.datasets[0].data,
             {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/2lxcP9yw/2387

## 🛠 Description de la PR
Changer le libellé du set de données "Nombre d'utilisateurs inscrits" en "Nombre d'utilisateurs actifs".

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/303fa938-ec69-49d1-90d8-97b05cd0195e)

## 🚨 Notes pour la mise en production
- ràs