### PR TITLE
#patch (2386) Lien vers une liste de nouveaux utilisateurs renvoie vers entraide

### DIFF
--- a/packages/frontend/webapp/src/stores/dashboard.store.js
+++ b/packages/frontend/webapp/src/stores/dashboard.store.js
@@ -70,18 +70,35 @@ export const useDashboardStore = defineStore("dashboard", () => {
         return dashboardActivitiesStore.activities.reduce(
             (acc, argActivity) => {
                 const activity = { ...argActivity };
+                if (activity.entity === "user") {
+                    const dateObj = new Date(activity.date * 1000);
+                    dateObj.setMinutes(0, 0, 0);
+
+                    activity.normalizedDate = dateObj.getTime() / 1000; // Reconvertir en secondes
+                }
+
                 if (activity.user) {
-                    const lastActivity = acc.slice(-1)[0];
-                    if (lastActivity && lastActivity.users) {
+                    const matchingActivityIndex = acc.findIndex(
+                        (prevActivity) =>
+                            prevActivity.users &&
+                            prevActivity.users.length > 0 &&
+                            prevActivity.users[0].organization ===
+                                activity.user.organization &&
+                            prevActivity.normalizedDate ===
+                                activity.normalizedDate
+                    );
+
+                    // Si une activité avec la même organisation et la même date normalisée existe déjà
+                    if (matchingActivityIndex !== -1) {
                         const newAcc = [...acc];
-                        newAcc[newAcc.length - 1].users.push(activity.user);
+                        newAcc[matchingActivityIndex].users.push(activity.user);
                         return newAcc;
                     }
 
+                    // Sinon, créer une nouvelle entrée avec users
                     activity.users = [activity.user];
                     delete activity.user;
                 }
-
                 if (
                     activity.entity === "shantytown" &&
                     activity.action === "update"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/yIju12Sv/2386

## 🛠 Description de la PR
- Lorsque plusieurs utilisateurs dont les comptes ont été activés sont mentionnés dans les dernières activités, le lien constitué par leurs noms et leur structures mènent vers la page d'accueil de l'espace d'entraide plutôt que vers la fiche de la structure.
- Par ailleurs, l'heure mentionnée est erronée pour certains utilisateurs regroupés
- La liste des comptes activés a été modifiée de façon à ne regrouper que les comptes d'une même structure activés à une même heure (on ne prend pas en compte les minutes) 

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/b76c7fb2-9d41-4ac8-9912-60b3ae55106d)

## 🚨 Notes pour la mise en production
' Ràs