### PR TITLE
#patch (2389) Permettre de consulter la fiche d'une structure sans aucun utilisateur actif

### DIFF
--- a/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
+++ b/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
@@ -46,8 +46,8 @@
                     : "Aucun utilisateur"
             }}</template>
             <template v-slot:content
-                >Cette structure ne compte aucun utilisateur inscrit sur la
-                plateforme{{
+                >Cette structure ne compte aucun utilisateur actif ou inscrit
+                sur la plateforme{{
                     expertiseTopicsFilter.length > 0
                         ? " avec les sujets d'expertise demandés"
                         : ""

--- a/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
+++ b/packages/frontend/webapp/src/components/FicheStructure/FicheStructure.vue
@@ -14,7 +14,11 @@
         </ViewHeader>
 
         <FicheStructureInfos :organization="organization" />
-        <FicheStructureFiltres v-model="expertiseTopicsFilter" class="mb-6" />
+        <FicheStructureFiltres
+            v-if="filteredUsers.length > 0"
+            v-model="expertiseTopicsFilter"
+            class="mb-6"
+        />
         <FicheStructureWarningFiltreActif
             v-if="
                 expertiseTopicsFilter.length > 0 &&

--- a/packages/frontend/webapp/src/views/FicheStructureView.vue
+++ b/packages/frontend/webapp/src/views/FicheStructureView.vue
@@ -78,7 +78,7 @@ async function load() {
     try {
         organization.value = await directoryStore.get(
             organizationId.value,
-            true
+            false
         );
 
         if (organization.value) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/1tSTSRsY/2389

## 🛠 Description de la PR
- Afficher la fiche d'une structure trouvée lors d'une recherche dans la barre de recherche, même si elle ne possède aucun utilisateur actif.

## 📸 Captures d'écran
![{E7E3382C-9A88-462D-9FED-6138442C1B5D}](https://github.com/user-attachments/assets/6be07c97-2231-43d0-9865-24c902f371e1)

## 🚨 Notes pour la mise en production
- ràs