### PR TITLE
#patch (2392) Sauvegarder l'information du mode de désactivation d'un utilisateur

### DIFF
--- a/packages/api/db/migrations/30000089-01-alter-table-user-add-deactivated_at-col.js
+++ b/packages/api/db/migrations/30000089-01-alter-table-user-add-deactivated_at-col.js
@@ -11,6 +11,12 @@ function addColumnsTo(queryInterface, Sequelize, tableName, transaction) {
                 transaction,
             },
         ),
+        queryInterface.sequelize.query(
+            `UPDATE "${tableName}" SET deactivated_at = updated_at, deactivation_type = 'auto' WHERE fk_status = 'inactive' AND deactivated_at IS NULL;`,
+            {
+                transaction,
+            },
+        ),
     ]);
 }
 

--- a/packages/api/db/migrations/30000089-01-alter-table-user-add-deactivated_at-col.js
+++ b/packages/api/db/migrations/30000089-01-alter-table-user-add-deactivated_at-col.js
@@ -1,0 +1,52 @@
+function addColumnsTo(queryInterface, Sequelize, tableName, transaction) {
+    return Promise.all([
+        queryInterface.addColumn(
+            tableName,
+            'deactivated_at',
+            {
+                type: Sequelize.DATE,
+                allowNull: true,
+            },
+            {
+                transaction,
+            },
+        ),
+    ]);
+}
+
+function removeColumnsFrom(queryInterface, tableName, transaction) {
+    return Promise.all([
+        queryInterface.removeColumn(tableName, 'deactivated_at', { transaction }),
+    ]);
+}
+
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            await Promise.all([
+                addColumnsTo(queryInterface, Sequelize, 'users', transaction),
+            ]);
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+
+    async down(queryInterface) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            await Promise.all([
+                removeColumnsFrom(queryInterface, 'users', transaction),
+            ]);
+
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+};

--- a/packages/api/server/models/userModel/_common/query.d.ts
+++ b/packages/api/server/models/userModel/_common/query.d.ts
@@ -73,6 +73,8 @@ export type RawUser = {
     anonymized: boolean | null,
     anonymized_at: Date | null,
     anonymization_requested: boolean | null,
+    deactivated_at: Date | null,
+    deactivation_type: string | null,
 };
 
 export type RawInterventionArea = {

--- a/packages/api/server/models/userModel/_common/query.ts
+++ b/packages/api/server/models/userModel/_common/query.ts
@@ -126,6 +126,8 @@ export default async (where: Where | String = [], filters: UserQueryFilters = {}
             users.password_conformity,
             users.anonymized_at,
             users.anonymization_requested,
+            users.deactivated_at,
+            users.deactivation_type,
             COALESCE(user_expertise_topics.topics, array[]::text[]) AS topics,
             COALESCE(email_unsubscriptions.unsubscriptions, array[]::enum_user_email_subscriptions_email_subscription[]) AS email_unsubscriptions,
             COALESCE(question_subscriptions.subscriptions, array[]::text[]) AS question_subscriptions,

--- a/packages/api/server/models/userModel/_common/serializeUser.ts
+++ b/packages/api/server/models/userModel/_common/serializeUser.ts
@@ -59,6 +59,8 @@ export default (user: RawUser, userAccesses: RawUserAccess[], interventionAreas:
         anonymized: !!user.anonymized_at,
         anonymized_at: user.anonymized_at ? user.anonymized_at.getTime() / 1000 : null,
         anonymization_requested: user.anonymization_requested,
+        deactivated_at: user.deactivated_at ? user.deactivated_at.getTime() / 1000 : null,
+        deactivation_type: user.deactivation_type,
     };
 
     if (filters.auth === true) {

--- a/packages/api/server/models/userModel/deactivate.ts
+++ b/packages/api/server/models/userModel/deactivate.ts
@@ -9,7 +9,8 @@ export default async (ids: number[], deactivationType: string = 'auto', anonymiz
             fk_status = 'inactive',
             updated_at = NOW(),
             deactivation_type = :deactivationType,
-            anonymization_requested = :anonymizationRequested
+            anonymization_requested = :anonymizationRequested,
+            deactivated_at = NOW()
         WHERE
             user_id IN (:ids)
         `,

--- a/packages/api/server/services/user/deactivate.spec.ts
+++ b/packages/api/server/services/user/deactivate.spec.ts
@@ -66,8 +66,9 @@ describe('userService.deactivate()', () => {
     });
 
     it('exécute l\'ensemble des requêtes dans une transaction', async () => {
+        // ([id], 'admin', anonymizationRequested, transaction)
         await deactivateUser(42, true);
-        expect(userModel.deactivate).to.have.been.calledWith([42], transaction);
+        expect(userModel.deactivate).to.have.been.calledWith([42], 'admin', false, transaction);
         expect(userModel.findOne).to.have.been.calledWith(42, {}, null, 'deactivate', transaction);
         expect(transaction.commit).to.have.been.calledOnce;
     });

--- a/packages/api/test/utils/user.ts
+++ b/packages/api/test/utils/user.ts
@@ -140,6 +140,8 @@ export function serialized(override: Partial<User> = {}): AuthUser {
         anonymization_requested: false,
         anonymized_at: null,
         anonymized: false,
+        deactivated_at: null,
+        deactivation_type: null,
     };
 
     return Object.assign(defaultUser, override);

--- a/packages/api/types/resources/User.d.ts
+++ b/packages/api/types/resources/User.d.ts
@@ -96,4 +96,8 @@ export type User = {
     anonymized?: boolean | null,
     anonymized_at?: number | null,
     anonymization_requested: boolean | null,
+
+    // deactivation
+    deactivated_at?: number | null,
+    deactivation_type?: string | null,
 };

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnAccessDetails.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesColumn/FicheAccesColumnAccessDetails.vue
@@ -91,6 +91,19 @@
         />
 
         <FicheAccesColumnAccessDate
+            v-if="user.deactivation_type"
+            :text="`Désactivé ${
+                user.deactivation_type === 'admin'
+                    ? 'administrativement'
+                    : 'automatiquement'
+            }`"
+            :date="user.deactivated_at"
+            icon="lock"
+            color="text-G700"
+            class="mb-2"
+        />
+
+        <FicheAccesColumnAccessDate
             v-if="user.anonymized"
             text="Anonymisé"
             :date="user.anonymized_at"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/SPYF0aNR/2392-gestion-des-droits-sauvegarder-linformation-du-mode-de-d%C3%A9sactivation-dun-utilisateur

## 🛠 Description de la PR
La PR intègre la date de désactivation lors d'une désactivation, manuelle (par un administrateur) ou automatique après 6 mois sans connexion.
Elle met également une date de désactivation égale à la date de dernière mise à jour sur les compte déjà désactivés.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
Migration à effectuer