### PR TITLE
#patch (2388) Ajout du statut 'désactivé' dans le filtrage par défaut

### DIFF
--- a/packages/frontend/webapp/src/stores/acces.store.js
+++ b/packages/frontend/webapp/src/stores/acces.store.js
@@ -94,7 +94,7 @@ export const useAccesStore = defineStore("acces", () => {
     }
 
     function resetFilters() {
-        const defaultFilters = ["deactivated", "refused"];
+        const defaultFilters = ["refused"];
         filters.search.value = "";
         filters.status.value = Object.keys(accessStatuses).filter(
             (status) => !defaultFilters.includes(status)


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/x4GqNpY9/2388-administration-ajouter-la-valeur-d%C3%A9sactiv%C3%A9-au-filtre-du-statut-des-comptes

## 🛠 Description de la PR
La PR modifie les valeurs par défaut du filtre de statut de profils utilisateurs dans l'interface d'administration pour y rajouter "désactivé".

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/c1d3aba0-4a41-40db-bd07-2e69f44e9b77)

## 🚨 Notes pour la mise en production
RàS