### PR TITLE
#patch (2390) Case à cocher "Voir les adresses des sites" + comportement bouton impression

### DIFF
--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -27,11 +27,12 @@
 
             <div
                 ref="printer"
-                class="bg-white mr-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden !cursor-pointer"
+                class="bg-white text-primary mr-3 my-3 border-2 border-primary py-1 px-2 print:hidden !cursor-pointer hover:!bg-primary hover:!text-white"
                 @click="printMapScreenshot"
                 v-show="showPrinter"
             >
-                <Icon icon="print" /> Imprimer la carte
+                <Icon icon="print" />
+                Imprimer la carte
             </div>
 
             <slot />

--- a/packages/frontend/webapp/src/components/CartoNationale/CartoNationale.vue
+++ b/packages/frontend/webapp/src/components/CartoNationale/CartoNationale.vue
@@ -22,15 +22,22 @@
 
         <div
             ref="addressToggler"
-            class="bg-white ml-3 my-3 border-2 border-G500 py-1 px-2 rounded print:hidden"
+            class="bg-white text-primary ml-3 my-3 border-2 border-primary py-1 px-2 print:hidden !cursor-pointer hover:!bg-primary hover:text-white"
         >
-            <label class="flex items-center space-x-2">
+            <label class="flex items-center space-x-2 !cursor-pointer">
                 <input
                     type="checkbox"
                     v-model="showAddressesModel"
                     @change="emit('addressVisibilityChange')"
                 />
-                <span>Voir les adresses des sites</span>
+                <Icon
+                    :icon="showAddressesModel ? 'eye' : 'eye-slash'"
+                    class="p-0 !ml-0"
+                />
+                <span
+                    >{{ showAddressesModel ? "Masquer" : "Voir" }} les adresses
+                    des sites</span
+                >
             </label>
         </div>
     </Carto>
@@ -49,6 +56,7 @@
 <script setup>
 import { computed, ref, toRefs, watch } from "vue";
 import { useForm } from "vee-validate";
+import { Icon } from "@resorptionbidonvilles/ui";
 import L from "leaflet";
 import Carto from "@/components/Carto/Carto.vue";
 import marqueurSiteEau from "@/utils/marqueurSiteEau";


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/leW9dQJY/2390-regressioncarte-case-%C3%A0-cocher-voir-les-adresses-des-sites-comportement-bouton-impression

## 🛠 Description de la PR
Cette PR corrige et harmonise l'affichage des boutons de la cartographie nationale.

## 📸 Captures d'écran
Avant:
![image](https://github.com/user-attachments/assets/2c517b81-c738-43d3-95ae-16f26ca693a8)
Après:
![image](https://github.com/user-attachments/assets/b890fab8-2090-4fcd-8cbe-7fae6a7eb93d)

## 🚨 Notes pour la mise en production
RàS