### PR TITLE
#patch (2394) Update de l'image ubuntu utilisée pour les release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   upgrade-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       new_tag: ${{ steps.version.outputs.new_tag }}
     steps:


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/TOSwWLTE/2394-tech-mont%C3%A9e-de-version-ubuntu-sur-le-script-de-release

## 🛠 Description de la PR
La PR met à jour l'image ubuntu utilisée par le script `release.yml` suite à l'arrêt de l'utilisation de `ubuntu-20.04`.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS