### PR TITLE
#patch (2394) Déploiement de la version 24.04 de ubuntu sur toutes les étapes de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
   build-www:
     needs: upgrade-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -103,7 +103,7 @@ jobs:
 
   build-webapp:
     needs: upgrade-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -139,7 +139,7 @@ jobs:
 
   build-api:
     needs: upgrade-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/TOSwWLTE/2394-tech-mont%C3%A9e-de-version-ubuntu-sur-le-script-de-release

## 🛠 Description de la PR
Cette PR déploie l'image `ubuntu-24.04` validée sur toutes les étapes de release.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS