### PR TITLE
#patch (2399) Remplacer "Métropole" par "Hexagone"

### DIFF
--- a/packages/api/server/services/metrics/getNationMetrics.ts
+++ b/packages/api/server/services/metrics/getNationMetrics.ts
@@ -31,7 +31,7 @@ export default async (user: User, argFrom: Date, argTo: Date):Promise<NationMetr
     const metropoleData:NationMetrics = {
         level: 'nation',
         uid: 'metropole',
-        name: 'Métropole',
+        name: 'Hexagone',
         metrics: {
             number_of_towns_with_water: 0,
             number_of_persons_with_water: 0,

--- a/packages/frontend/webapp/src/stores/user.store.js
+++ b/packages/frontend/webapp/src/stores/user.store.js
@@ -109,7 +109,7 @@ export const useUserStore = defineStore("user", {
                                 longitude: 2.0497727,
                                 metropole: {
                                     code: "metropole",
-                                    name: "Métropole",
+                                    name: "Hexagone",
                                 },
                             },
                             ...configStore.config.user.intervention_areas.areas,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/SUI83j8r/2399

## 🛠 Description de la PR
- Renommer le territoire "Métropole" en "Hexagone" sur la liste des sites, des actions et dans la visualisation des données

## 📸 Captures d'écran
![{DB44A9EB-AF4B-4DB5-A5A4-2E25DAA14F46}](https://github.com/user-attachments/assets/9b9f8082-fa87-466c-9d20-7adf717671ea)
![{C58C1947-408E-4D29-BBC4-EAEA865B34C9}](https://github.com/user-attachments/assets/98e9918a-bd95-4da2-98ee-26297cc000c1)

## 🚨 Notes pour la mise en production
- Ràs