### PR TITLE
#patch (2401) Corriger le calcul du nombre de sites avec procédures judiciaires

### DIFF
--- a/packages/frontend/ui/src/components/Filter.vue
+++ b/packages/frontend/ui/src/components/Filter.vue
@@ -33,7 +33,7 @@
                     <Button 
                         size="sm"
                         variant="custom" 
-                        class="flex items-center whitespace-nowrap text-sm menuWidth pl-3 text-primary text-primary focusClasses.ring"
+                        class="flex items-center whitespace-nowrap text-sm menuWidth pl-3 text-primary focusClasses.ring"
                         @click="clear">
                         Effacer
                     </Button>

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
@@ -31,6 +31,13 @@
                     >
                     avec une procédure administrative
                 </p>
+                <p v-if="userStore.hasJusticePermission">
+                    {{ insalubrityOrderTotal }} site<template
+                        v-if="insalubrityOrderTotal > 1"
+                        >s</template
+                    >
+                    avec une opération RHI
+                </p>
             </div>
         </section>
     </div>
@@ -67,8 +74,13 @@ const justiceTotal = computed(() => {
 
 const administrativeOrderTotal = computed(() => {
     return townsStore.filteredTowns.filter(
-        ({ evacuationUnderTimeLimit, insalubrityOrder }) =>
-            evacuationUnderTimeLimit === true || insalubrityOrder === true
+        ({ evacuationUnderTimeLimit }) => evacuationUnderTimeLimit === true
+    ).length;
+});
+
+const insalubrityOrderTotal = computed(() => {
+    return townsStore.filteredTowns.filter(
+        ({ insalubrityOrder }) => insalubrityOrder === true
     ).length;
 });
 </script>

--- a/packages/frontend/webapp/src/utils/filterShantytowns.js
+++ b/packages/frontend/webapp/src/utils/filterShantytowns.js
@@ -258,7 +258,6 @@ function checkJustice(shantytown, filters) {
             );
         }
 
-        // value === null (inconnu)
         return (
             typeof shantytown.ownerComplaint !== "boolean" &&
             typeof shantytown.justiceProcedure !== "boolean"
@@ -291,7 +290,6 @@ function checkRhi(shantytown, filters) {
             return shantytown.insalubrityOrder === false;
         }
 
-        // value === null (inconnu)
         return typeof shantytown.insalubrityOrder !== "boolean";
     });
 }

--- a/packages/frontend/webapp/src/utils/filterShantytowns.js
+++ b/packages/frontend/webapp/src/utils/filterShantytowns.js
@@ -276,6 +276,7 @@ function checkAdministrativeOrder(shantytown, filters) {
             return shantytown.evacuationUnderTimeLimit === false;
         }
 
+        // value === null (inconnu)
         return typeof shantytown.evacuationUnderTimeLimit !== "boolean";
     });
 }
@@ -290,6 +291,7 @@ function checkRhi(shantytown, filters) {
             return shantytown.insalubrityOrder === false;
         }
 
+        // value === null (inconnu)
         return typeof shantytown.insalubrityOrder !== "boolean";
     });
 }

--- a/packages/frontend/webapp/src/utils/filterShantytowns.js
+++ b/packages/frontend/webapp/src/utils/filterShantytowns.js
@@ -275,7 +275,6 @@ function checkAdministrativeOrder(shantytown, filters) {
             return shantytown.evacuationUnderTimeLimit === false;
         }
 
-        // value === null (inconnu)
         return typeof shantytown.evacuationUnderTimeLimit !== "boolean";
     });
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/NXBBPBdD/2401

## 🛠 Description de la PR
- Lorsque l'on sélectionne "Inconnu" dans le filtre "Procédures judiciaires" de la liste des filtres, le nombre de sites avec porcédures administratives reste positif
- En fait, le calcul des sites avec procédures administratives incluent le nombre de sites avec opérations RHI
- Le calcul des sites avec procédures administratives a été corrigé et ne tient plus compte des avec opérations RHI 
- un calcul est fait spécifiquement pour compter le nombre de sites avec opération RHI
- le nombre de sites avec opération RHI est affichés dans l'entête, au même titre que les sites avec procédures judiciaires et les sites avec procédures administratives

## 🚨 Notes pour la mise en production
- ràs