### PR TITLE
#fix: (2397) Forcer la mise à jour des marqueurs de la cartographie au changement d'onglet

### DIFF
--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -411,7 +411,7 @@ function skipMap(skipMapFunc, el) {
     }
 }
 
-watch(towns, syncTownMarkers);
+watch(towns, syncTownMarkers, activeTab);
 
 defineExpose({
     addControl,

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -411,7 +411,15 @@ function skipMap(skipMapFunc, el) {
     }
 }
 
-watch(towns, syncTownMarkers, activeTab);
+watch(towns, syncTownMarkers);
+
+watch(
+    activeTab,
+    () => {
+        syncTownMarkers();
+    },
+    { immediate: true }
+);
 
 defineExpose({
     addControl,

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -29,7 +29,7 @@
                 <div class="font-bold mx-2">Légende</div>
             </div>
             <div v-if="legendeStatus === true" class="flex">
-                <div :key="activeTab" class="flex">
+                <div class="flex">
                     <div class="grid grid-cols-1 content-start">
                         <div
                             class=""
@@ -95,21 +95,12 @@ const markersGroup = ref(L.geoJSON([], {}));
 const legende = ref(null);
 const legendeStatus = ref(false);
 
-const drawMap = () => {
-    carto.value.map.addLayer(markersGroup.value);
-    carto.value.map.on("move", onMove);
-    carto.value.addControl("legende", createLegende());
-};
-
 watch(carto, () => {
     if (carto.value) {
-        drawMap();
+        carto.value.map.addLayer(markersGroup.value);
+        carto.value.map.on("move", onMove);
+        carto.value.addControl("legende", createLegende());
     }
-});
-
-watch(activeTab, () => {
-    carto.value.map.removeLayer(markersGroup.value);
-    drawMap();
 });
 
 const displayedLegend = {
@@ -192,6 +183,8 @@ defineExpose({
     }),
     setView(...args) {
         if (carto.value) {
+            console.log("setView", args);
+
             return carto.value.setView(...args);
         }
 

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -44,7 +44,9 @@
 
                     <div class="grid grid-cols-1 content-start">
                         <div
-                            v-for="displayedLegendLabel in displayedLegendByActiveTab.labels"
+                            v-for="displayedLegendLabel in displayedLegend[
+                                activeTab
+                            ].labels"
                             :key="displayedLegendLabel"
                         >
                             {{ displayedLegendLabel }}
@@ -146,10 +148,6 @@ const displayedLegend = {
 displayedLegend.livingConditionsByTown = displayedLegend.summary;
 displayedLegend.livingConditionsByInhabitant = displayedLegend.summary;
 
-const displayedLegendByActiveTab = computed(() => {
-    return displayedLegend[activeTab.value];
-});
-
 function onMove() {
     const { map } = carto.value;
     const { lat: latitude, lng: longitude } = map.getCenter();
@@ -183,8 +181,6 @@ defineExpose({
     }),
     setView(...args) {
         if (carto.value) {
-            console.log("setView", args);
-
             return carto.value.setView(...args);
         }
 

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -29,7 +29,7 @@
                 <div class="font-bold mx-2">Légende</div>
             </div>
             <div v-if="legendeStatus === true" class="flex">
-                <div class="flex">
+                <div :key="activeTab" class="flex">
                     <div class="grid grid-cols-1 content-start">
                         <div
                             class=""

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -97,12 +97,21 @@ const markersGroup = ref(L.geoJSON([], {}));
 const legende = ref(null);
 const legendeStatus = ref(false);
 
+const drawMap = () => {
+    carto.value.map.addLayer(markersGroup.value);
+    carto.value.map.on("move", onMove);
+    carto.value.addControl("legende", createLegende());
+};
+
 watch(carto, () => {
     if (carto.value) {
-        carto.value.map.addLayer(markersGroup.value);
-        carto.value.map.on("move", onMove);
-        carto.value.addControl("legende", createLegende());
+        drawMap();
     }
+});
+
+watch(activeTab, () => {
+    carto.value.map.removeLayer(markersGroup.value);
+    drawMap();
 });
 
 const displayedLegend = {

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -33,10 +33,10 @@
                     <div class="grid grid-cols-1 content-start">
                         <div
                             class=""
-                            v-for="(
-                                displayedLegendItem, index
-                            ) in displayedLegend[activeTab].icons"
-                            :key="`${displayedLegendItem}-${index}`"
+                            v-for="displayedLegendItem in displayedLegend[
+                                activeTab
+                            ].icons"
+                            :key="displayedLegendItem"
                         >
                             <Icon class="mx-2" :icon="displayedLegendItem" />
                         </div>
@@ -44,9 +44,7 @@
 
                     <div class="grid grid-cols-1 content-start">
                         <div
-                            v-for="displayedLegendLabel in displayedLegend[
-                                activeTab
-                            ].labels"
+                            v-for="displayedLegendLabel in displayedLegendByActiveTab.labels"
                             :key="displayedLegendLabel"
                         >
                             {{ displayedLegendLabel }}
@@ -98,7 +96,6 @@ const legende = ref(null);
 const legendeStatus = ref(false);
 
 const drawMap = () => {
-    console.log("Création de la carte, de la légende et des marqueurs");
     carto.value.map.addLayer(markersGroup.value);
     carto.value.map.on("move", onMove);
     carto.value.addControl("legende", createLegende());
@@ -115,7 +112,7 @@ watch(activeTab, () => {
     drawMap();
 });
 
-const displayedLegend = ref({
+const displayedLegend = {
     livingConditionsByTown: null,
     livingConditionsByInhabitant: null,
     summary: {
@@ -153,11 +150,14 @@ const displayedLegend = ref({
             { style: "bg-G400 w-10 border", label: "Pas de mineurs" },
         ],
     },
-});
+};
 // Pas de différence entre summary et livingConditions (temporaire)
-displayedLegend.value.livingConditionsByTown = displayedLegend.value.summary;
-displayedLegend.value.livingConditionsByInhabitant =
-    displayedLegend.value.summary;
+displayedLegend.livingConditionsByTown = displayedLegend.summary;
+displayedLegend.livingConditionsByInhabitant = displayedLegend.summary;
+
+const displayedLegendByActiveTab = computed(() => {
+    return displayedLegend[activeTab.value];
+});
 
 function onMove() {
     const { map } = carto.value;

--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -33,10 +33,10 @@
                     <div class="grid grid-cols-1 content-start">
                         <div
                             class=""
-                            v-for="displayedLegendItem in displayedLegend[
-                                activeTab
-                            ].icons"
-                            :key="displayedLegendItem"
+                            v-for="(
+                                displayedLegendItem, index
+                            ) in displayedLegend[activeTab].icons"
+                            :key="`${displayedLegendItem}-${index}`"
                         >
                             <Icon class="mx-2" :icon="displayedLegendItem" />
                         </div>
@@ -98,6 +98,7 @@ const legende = ref(null);
 const legendeStatus = ref(false);
 
 const drawMap = () => {
+    console.log("Création de la carte, de la légende et des marqueurs");
     carto.value.map.addLayer(markersGroup.value);
     carto.value.map.on("move", onMove);
     carto.value.addControl("legende", createLegende());
@@ -114,7 +115,7 @@ watch(activeTab, () => {
     drawMap();
 });
 
-const displayedLegend = {
+const displayedLegend = ref({
     livingConditionsByTown: null,
     livingConditionsByInhabitant: null,
     summary: {
@@ -152,10 +153,11 @@ const displayedLegend = {
             { style: "bg-G400 w-10 border", label: "Pas de mineurs" },
         ],
     },
-};
+});
 // Pas de différence entre summary et livingConditions (temporaire)
-displayedLegend.livingConditionsByTown = displayedLegend.summary;
-displayedLegend.livingConditionsByInhabitant = displayedLegend.summary;
+displayedLegend.value.livingConditionsByTown = displayedLegend.value.summary;
+displayedLegend.value.livingConditionsByInhabitant =
+    displayedLegend.value.summary;
 
 function onMove() {
     const { map } = carto.value;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/zn4j7PeB/2397-visudonn%C3%A9es-bug-sur-laffichage-de-la-carte-pour-les-donn%C3%A9es-scolarisation

## 🛠 Description de la PR
Dans la Visualisation de Données, en "situation à date", lors d'un changement d'onglet, la carte doit être mise à jour pour afficher des marqueurs en lien avec les données du tableau affiché (conditions de vie, scolarisation) ainsi que la légende liée. Cette PR force la suppression et nouvel affichage des calques de la cartographie lors d'un changement d'onglet.

## 📸 Captures d'écran
N/A (cf #1183 )

## 🚨 Notes pour la mise en production
RàS