### PR TITLE
#patch (2395) Ne pas envoyer de mel aux comptes désactivés

### DIFF
--- a/packages/api/server/controllers/user/deactivate/user.deactivate.ts
+++ b/packages/api/server/controllers/user/deactivate/user.deactivate.ts
@@ -4,9 +4,11 @@ import { User } from '#root/types/resources/User.d';
 
 const ERRORS = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
+    deactivation_permission_failure: { code: 500, message: 'Vous n\'avez pas la perlmission de désactiver ce compte' },
     deactivation_failure: { code: 500, message: 'Une erreur est survenue lors de la désactivation du compte' },
     refresh_failure: { code: 500, message: 'Une erreur est survenue lors de la lecture des données en base' },
     transaction_failure: { code: 500, message: 'Une erreur est survenue lors de la validation de la désactivation' },
+    user_already_inactive: { code: 400, message: 'L\'utilisateur est déjà inactif' },
 };
 
 interface UserDeactivateRequest extends Request {
@@ -20,7 +22,8 @@ interface UserDeactivateRequest extends Request {
 
 export default async (req: UserDeactivateRequest, res: Response, next: NextFunction): Promise<void> => {
     try {
-        const updatedUser = await userService.deactivate(req.body.user.id, req.user.id === req.body.user.id, req.body.user, req.body.reason, req.body.anonymizationRequested);
+        const userId = parseInt(req.params.id, 10);
+        const updatedUser = await userService.deactivate(userId, userId === req.user.id, req.user, req.body.reason, req.body.anonymizationRequested);
         res.status(200).send(updatedUser);
     } catch (error) {
         const { code, message } = ERRORS[error?.code] || ERRORS.undefined;

--- a/packages/api/server/controllers/user/deactivate/user.deactivate.ts
+++ b/packages/api/server/controllers/user/deactivate/user.deactivate.ts
@@ -20,7 +20,7 @@ interface UserDeactivateRequest extends Request {
 
 export default async (req: UserDeactivateRequest, res: Response, next: NextFunction): Promise<void> => {
     try {
-        const updatedUser = await userService.deactivate(req.body.user.id, req.user.id === req.body.user.id, req.body.reason, req.body.anonymizationRequested);
+        const updatedUser = await userService.deactivate(req.body.user.id, req.user.id === req.body.user.id, req.body.user, req.body.reason, req.body.anonymizationRequested);
         res.status(200).send(updatedUser);
     } catch (error) {
         const { code, message } = ERRORS[error?.code] || ERRORS.undefined;

--- a/packages/api/server/controllers/user/deactivate/user.deactivate.ts
+++ b/packages/api/server/controllers/user/deactivate/user.deactivate.ts
@@ -4,7 +4,7 @@ import { User } from '#root/types/resources/User.d';
 
 const ERRORS = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
-    deactivation_permission_failure: { code: 500, message: 'Vous n\'avez pas la perlmission de désactiver ce compte' },
+    deactivation_permission_failure: { code: 500, message: 'Vous n\'avez pas la permission de désactiver ce compte' },
     deactivation_failure: { code: 500, message: 'Une erreur est survenue lors de la désactivation du compte' },
     refresh_failure: { code: 500, message: 'Une erreur est survenue lors de la lecture des données en base' },
     transaction_failure: { code: 500, message: 'Une erreur est survenue lors de la validation de la désactivation' },

--- a/packages/api/server/controllers/user/deactivate/user.deactivate.validator.ts
+++ b/packages/api/server/controllers/user/deactivate/user.deactivate.validator.ts
@@ -1,43 +1,27 @@
 /* eslint-disable newline-per-chained-call */
 import { body, param } from 'express-validator';
-import userModel from '#server/models/userModel';
 
 export default [
     param('id')
         .toInt()
-        .isInt().bail().withMessage('L\'identifiant de l\'utilisateur est invalide')
-        .custom(async (value, { req }) => {
-            if (req.user.id === value) {
-                req.body.user = req.user;
-                return true;
-            }
+        .isInt().bail().withMessage('L\'identifiant de l\'utilisateur est invalide'),
 
-            let user;
-            try {
-                user = await userModel.findOne(value, undefined, req.user, 'deactivate');
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la lecture en base de données');
-            }
-
-            if (user === null) {
-                throw new Error('L\'utilisateur n\'existe pas ou vous n\'avez pas les droits suffisants pour le désactiver');
-            }
-
-            if (user.status === 'inactive') {
-                throw new Error('L\'accès de cet utilisateur est déjà désactivé');
-            }
-
-            req.body.user = user;
-            return true;
-        }),
 
     body('reason')
-        .if((value, { req }) => req.body?.user?.id !== undefined && req.body.user.id !== req.user.id)
-        .isString().withMessage('La raison doit être une chaîne de caractères')
-        .trim()
-        .notEmpty().withMessage('La raison est obligatoire'),
+        .custom((value, { req }) => {
+            const requestedUserId = parseInt(req.params.id, 10);
+            const isModifyingOtherUser = requestedUserId !== req.user.id;
 
-    body('anonymizationRequested')
-        .if((value, { req }) => req.body?.user?.id !== undefined && req.body.user.id !== req.user.id)
-        .isBoolean().withMessage('La demande d\'anonymisation n\'est pas valide'),
+            if (isModifyingOtherUser) {
+                if (!value || typeof value !== 'string') {
+                    throw new Error('La raison doit être une chaîne de caractères');
+                }
+
+                if (value.trim().length === 0) {
+                    throw new Error('La raison est obligatoire');
+                }
+            }
+
+            return true;
+        }),
 ];

--- a/packages/api/server/controllers/user/setRoleAdmin/user.setRoleAdmin.ts
+++ b/packages/api/server/controllers/user/setRoleAdmin/user.setRoleAdmin.ts
@@ -17,7 +17,9 @@ export default async (req, res, next) => {
 
         if (user && admin) {
             await userModel.upgradeLocalAdmin(req.params.id);
-            await sendAdminWelcome(user);
+            if (['active', 'new'].includes(user.status)) {
+                await sendAdminWelcome(user);
+            }
         } else if (user) {
             await userModel.downgradeLocalAdmin(req.params.id);
         }

--- a/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.html
+++ b/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.html
@@ -1,0 +1,356 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title>[Résorption-bidonvilles] - Un commentaire a été supprimé</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+        </style>
+      <!--<![endif]-->
+
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+    </style>
+    
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#FFFFFF;">
+    
+    
+      <div style="background-color:#FFFFFF;" lang="und" dir="auto">
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0 0 16px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:600px;">
+              
+      <img alt src="{{var:backUrl}}/assets/mails/hero.jpg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="600" height="auto">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0 0 16px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Bonjour,</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Le commentaire ci-dessous, posté par un utilisateur désactivé, a été supprimé par un administrateur.</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">La raison mentionnée par celui-ci est :</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">"{{var:message}}".</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0 0 16px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+        <tbody>
+          <tr>
+            <td style="background-color:#dddddd;vertical-align:top;padding:1rem;">
+              
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">"{{var:comment.description}}".</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}}, {{var:town.city.name}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0 0 16px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Cordialement,</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">L'équipe <span class="font-italic" style="font-style: italic;">Résorption-bidonvilles</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0 0 0.5rem 0;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:40px;">
+              
+      <img alt src="{{var:backUrl}}/assets/mails/marianne.png" style="border:0;display:block;outline:none;text-decoration:none;height:15;width:100%;font-size:16px;" width="40" height="15">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-style:italic;font-weight:bold;line-height:1.5em;text-align:left;color:#000000;">Résorption-bidonvilles</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-style:italic;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Agir pour résorber les bidonvilles</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="mailto: contact-resorption-bidonvilles@dihal.gouv.fr" style="color: #000091; text-decoration: none;"> contact-resorption-bidonvilles@dihal.gouv.fr</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos outils méthodologiques sur votre <a class="link" href="{{var:blogUrl}}" style="color: #000091; text-decoration: none;">blog</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><a class="link" href="https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=" style="color: #000091; text-decoration: none;">Abonnez-vous à la lettre d'info</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Développé par la <a href="https://www.gouvernement.fr/resorption-des-bidonvilles" class="link" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none;">Dihal</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.subject.text
+++ b/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.subject.text
@@ -1,0 +1,1 @@
+[Résorption-bidonvilles] - Un commentaire a été supprimé

--- a/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.text
+++ b/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.text
@@ -1,0 +1,24 @@
+Bonjour,
+Le commentaire ci-dessous, posté par un utilisateur désactivé, a été supprimé
+par un administrateur.
+La raison mentionnée par celui-ci est :
+"{{var:message}}".
+
+"{{var:comment.description}}".
+Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}},
+{{var:town.city.name}}
+
+Cordialement,
+L'équipe Résorption-bidonvilles
+
+
+
+Résorption-bidonvilles
+Agir pour résorber les bidonvilles
+contact-resorption-bidonvilles@dihal.gouv.fr [
+contact-resorption-bidonvilles@dihal.gouv.fr]
+Suivez toute l'actualité de la résorption des bidonvilles et retrouvez tous vos
+outils méthodologiques sur votre blog [{{var:blogUrl}}]
+Abonnez-vous à la lettre d'info
+[https://a757ac69.sibforms.com/serve/MUIFALVz73sp9nySQNDVaSPuG57ypOIGQrx7oMDqyu-lukbiAq1DqhoTh4UQfghOgE-jTVCzMUDQJ6CAQG5GtpsztQ3C3hPleVgcZDEEU0Y_3aPMffVdQjm_YRNdGAnjF4sET4aCQynW4QVbe1bjXnRuyTR0ETJCNgdje0QbaxOzYTKMIAPCdKNJkcYdS3Boj9Vsbj1RXYTzE_Q=]
+Développé par la Dihal [https://www.gouvernement.fr/resorption-des-bidonvilles]

--- a/packages/api/server/mails/dist/shantytown_actor_invitation.html
+++ b/packages/api/server/mails/dist/shantytown_actor_invitation.html
@@ -135,7 +135,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Un de vos partenaire vous invite à partager sur le site {{var:siteAddress}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:28px;font-weight:700;line-height:32px;text-align:left;color:#000091;">Un de vos partenaires vous invite à partager sur le site {{var:siteAddress}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/shantytown_actor_invitation.text
+++ b/packages/api/server/mails/dist/shantytown_actor_invitation.text
@@ -1,4 +1,4 @@
-Un de vos partenaire vous invite à partager sur le site {{var:siteAddress}}
+Un de vos partenaires vous invite à partager sur le site {{var:siteAddress}}
 Bonjour,
 {{var:inviterName}} vous a invité à rejoindre la communauté des acteurs de
 terrain sur la plateforme Résorption-bidonvilles [{{var:webappUrl}}] en

--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -634,6 +634,26 @@ export default {
      * @param {User} recipient  Recipient of the email (must includes first_name, last_name, email)
      * @param {Object} options
      */
+    sendAdminCommentDeletion: (recipient, options: MailOptions = {}) => {
+        const { variables, preserveRecipient } = options;
+
+        return mailService.send('admin_comment_from_deactivated_user_deletion', {
+            recipient,
+            variables: {
+                town: variables.town,
+                comment: variables.comment,
+                message: variables.message,
+                backUrl,
+                blogUrl,
+            },
+            preserveRecipient,
+        });
+    },
+
+    /**
+     * @param {User} recipient  Recipient of the email (must includes first_name, last_name, email)
+     * @param {Object} options
+     */
     sendUserFeatures: (recipient, options: MailOptions = {}) => {
         const { preserveRecipient } = options;
 

--- a/packages/api/server/mails/src/admin_comment_from_deactivated_user_deletion.mjml
+++ b/packages/api/server/mails/src/admin_comment_from_deactivated_user_deletion.mjml
@@ -1,0 +1,34 @@
+<mjml>
+    <mj-head>
+        <mj-title>[Résorption-bidonvilles] - Un commentaire a été supprimé</mj-title>
+        <mj-include path='common/attributes.mjml' />
+        <mj-include path='common/styles.mjml' />
+    </mj-head>
+    <mj-body mj-class='bg-white'>
+        <mj-include path='common/hero.mjml' />
+
+        <mj-section>
+            <mj-column>
+                <mj-text mj-class="pb-4">Bonjour,</mj-text>
+                <mj-text mj-class="pb-4">
+                    Le commentaire ci-dessous, posté par un utilisateur désactivé, a été supprimé par un administrateur.
+                </mj-text>
+                <mj-text>
+                    La raison mentionnée par celui-ci est :
+                </mj-text>
+                <mj-text>
+                    "{{var:message}}".
+                </mj-text>
+            </mj-column>
+        </mj-section>
+        <mj-section>
+            <mj-column padding="1rem" background-color="#dddddd">
+                <mj-text mj-class="pb-4">
+                    "{{var:comment.description}}".
+                </mj-text>
+                <mj-text>Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}}, {{var:town.city.name}}</mj-text>
+            </mj-column>
+        </mj-section>
+        <mj-include path='common/footer.mjml' />
+    </mj-body>
+</mjml>

--- a/packages/api/server/mails/src/shantytown_actor_invitation.mjml
+++ b/packages/api/server/mails/src/shantytown_actor_invitation.mjml
@@ -10,7 +10,7 @@
         <mj-section>
             <mj-column>
                 <mj-text mj-class='text-primary text-display pb-4'>
-                    Un de vos partenaire vous invite à partager sur le site {{var:siteAddress}}
+                    Un de vos partenaires vous invite à partager sur le site {{var:siteAddress}}
                 </mj-text>
                 <mj-text mj-class="pb-4">Bonjour,</mj-text>
                 <mj-text mj-class="pb-4">

--- a/packages/api/server/models/actionActorModel/findAll.ts
+++ b/packages/api/server/models/actionActorModel/findAll.ts
@@ -23,7 +23,7 @@ type ActionActor = {
     actions: Action[]
 };
 
-export default async (year: number): Promise<ActionActor[]> => {
+export default async (year: number, activeOnly: boolean = false): Promise<ActionActor[]> => {
     const rows: ActionActorRow[] = await sequelize.query(
         `
         SELECT
@@ -47,6 +47,7 @@ export default async (year: number): Promise<ActionActor[]> => {
         LEFT JOIN actions ON t.fk_action = actions.action_id
         LEFT JOIN users ON t.fk_user = users.user_id
         WHERE actions.started_at < :maxStartedAt AND (actions.ended_at IS NULL OR actions.ended_at >= :minEndedAt)
+        ${activeOnly ? 'AND users.fk_active = \'active\'' : ''}
         `,
         {
             type: QueryTypes.SELECT,

--- a/packages/api/server/models/userModel/getQuestionSubscribers.ts
+++ b/packages/api/server/models/userModel/getQuestionSubscribers.ts
@@ -15,11 +15,13 @@ export default (questionId: number): Promise<QuestionSubscriberRow[]> => sequeli
         u.email,
         u.first_name,
         u.last_name,
+        u.fk_status,
         u.user_id = q.created_by AS is_author
     FROM user_question_subscriptions uqs
     LEFT JOIN questions q ON uqs.fk_question = q.question_id
     LEFT JOIN users u ON uqs.fk_user = u.user_id
     WHERE uqs.fk_question = :questionId AND uqs.active IS TRUE
+    AND u.fk_status = 'active'
     `,
     {
         type: QueryTypes.SELECT,

--- a/packages/api/server/services/accessRequest/accessRequestService.ts
+++ b/packages/api/server/services/accessRequest/accessRequestService.ts
@@ -134,7 +134,6 @@ export default {
         // notify the user
         await sendEmail.toUser.accessPending(
             user,
-            user.user_accesses[0].sent_by,
             getAccountActivationLink(user.user_accesses[0].id),
             new Date(user.user_accesses[0].expires_at * 1000),
         );

--- a/packages/api/server/services/accessRequest/mailer.ts
+++ b/packages/api/server/services/accessRequest/mailer.ts
@@ -103,7 +103,7 @@ export default {
             });
         },
 
-        accessPending(user, admin, activationLink, expiracyDate) {
+        accessPending(user, activationLink, expiracyDate) {
             return sendUserAccessPending(user, {
                 variables: {
                     activationUrl: activationLink,

--- a/packages/api/server/services/action/sendAlert.ts
+++ b/packages/api/server/services/action/sendAlert.ts
@@ -13,7 +13,7 @@ export default async (variant: ActionAlertVariant): Promise<void> => {
         year -= 1;
     }
 
-    const actors = await actionActorModel.findAll(year);
+    const actors = await actionActorModel.findAll(year, true);
     await Promise.all(
         actors.map(actor => sender[variant](
             { email: actor.email, first_name: actor.first_name, last_name: actor.last_name },

--- a/packages/api/server/services/answer/deleteAnswer.ts
+++ b/packages/api/server/services/answer/deleteAnswer.ts
@@ -1,15 +1,16 @@
-import deleteAnswer from '#server/models/answerModel/delete';
+// import deleteAnswer from '#server/models/answerModel/delete';
 import getNationalAdmins from '#server/models/userModel/_common/getNationalAdmins';
 import ServiceError from '#server/errors/ServiceError';
 import mails from '#server/mails/mails';
 import dateUtils from '#server/utils/date';
+import userModel from '#server/models/userModel';
 import { RawAnswer } from '#root/types/resources/AnswerRaw.d';
 import { EnrichedQuestion } from '#root/types/resources/QuestionEnriched.d';
 import { User } from '#root/types/resources/User.d';
 
 export default async (question: EnrichedQuestion, answer: RawAnswer, reason?: string): Promise<void> => {
     try {
-        await deleteAnswer(answer.id);
+        // await deleteAnswer(answer.id);
     } catch (error) {
         throw new ServiceError('delete_failed', error);
     }
@@ -23,6 +24,11 @@ export default async (question: EnrichedQuestion, answer: RawAnswer, reason?: st
         }
 
         try {
+            const fullUser = await userModel.findOne(answer.createdBy.id);
+            if (fullUser === null || fullUser.status !== 'active') {
+                return;
+            }
+
             await mails.sendAnswerDeletionNotification(answer.createdBy, {
                 variables: {
                     message: answer.description,

--- a/packages/api/server/services/answer/deleteAnswer.ts
+++ b/packages/api/server/services/answer/deleteAnswer.ts
@@ -1,4 +1,4 @@
-// import deleteAnswer from '#server/models/answerModel/delete';
+import deleteAnswer from '#server/models/answerModel/delete';
 import getNationalAdmins from '#server/models/userModel/_common/getNationalAdmins';
 import ServiceError from '#server/errors/ServiceError';
 import mails from '#server/mails/mails';
@@ -10,7 +10,7 @@ import { User } from '#root/types/resources/User.d';
 
 export default async (question: EnrichedQuestion, answer: RawAnswer, reason?: string): Promise<void> => {
     try {
-        // await deleteAnswer(answer.id);
+        await deleteAnswer(answer.id);
     } catch (error) {
         throw new ServiceError('delete_failed', error);
     }

--- a/packages/api/server/services/shantytown/deleteComment.ts
+++ b/packages/api/server/services/shantytown/deleteComment.ts
@@ -58,22 +58,24 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
     try {
         if (!isOwner) {
             const nationalAdmins = await userModel.getNationalAdmins();
-            await mails.sendUserCommentDeletion(author, {
-                variables: {
-                    town: {
-                        usename: town.usename,
-                        city: {
-                            name: town.city.name,
+            if (author.status === 'active') {
+                await mails.sendUserCommentDeletion(author, {
+                    variables: {
+                        town: {
+                            usename: town.usename,
+                            city: {
+                                name: town.city.name,
+                            },
                         },
+                        comment: {
+                            description: comment.description,
+                            created_at: tsToString(comment.createdAt, 'd/m/Y'),
+                        },
+                        message,
                     },
-                    comment: {
-                        description: comment.description,
-                        created_at: tsToString(comment.createdAt, 'd/m/Y'),
-                    },
-                    message,
-                },
-                bcc: nationalAdmins,
-            });
+                    bcc: nationalAdmins,
+                });
+            }
         }
     } catch (error) {
         // ignore

--- a/packages/api/server/services/shantytown/deleteComment.ts
+++ b/packages/api/server/services/shantytown/deleteComment.ts
@@ -75,6 +75,22 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
                     },
                     bcc: nationalAdmins,
                 });
+            } else {
+                await Promise.all(nationalAdmins.map(nationalAdmin => mails.sendUserCommentDeletion(nationalAdmin, {
+                    variables: {
+                        town: {
+                            usename: town.usename,
+                            city: {
+                                name: town.city.name,
+                            },
+                        },
+                        comment: {
+                            description: comment.description,
+                            created_at: tsToString(comment.createdAt, 'd/m/Y'),
+                        },
+                        message,
+                    },
+                })));
             }
         }
     } catch (error) {

--- a/packages/api/server/services/shantytown/deleteComment.ts
+++ b/packages/api/server/services/shantytown/deleteComment.ts
@@ -58,38 +58,27 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
     try {
         if (!isOwner) {
             const nationalAdmins = await userModel.getNationalAdmins();
+            const mailVariables = {
+                town: {
+                    usename: town.usename,
+                    city: {
+                        name: town.city.name,
+                    },
+                },
+                comment: {
+                    description: comment.description,
+                    created_at: tsToString(comment.createdAt, 'd/m/Y'),
+                },
+                message,
+            };
             if (author.status === 'active') {
                 await mails.sendUserCommentDeletion(author, {
-                    variables: {
-                        town: {
-                            usename: town.usename,
-                            city: {
-                                name: town.city.name,
-                            },
-                        },
-                        comment: {
-                            description: comment.description,
-                            created_at: tsToString(comment.createdAt, 'd/m/Y'),
-                        },
-                        message,
-                    },
+                    variables: mailVariables,
                     bcc: nationalAdmins,
                 });
             } else {
                 await Promise.all(nationalAdmins.map(nationalAdmin => mails.sendAdminCommentDeletion(nationalAdmin, {
-                    variables: {
-                        town: {
-                            usename: town.usename,
-                            city: {
-                                name: town.city.name,
-                            },
-                        },
-                        comment: {
-                            description: comment.description,
-                            created_at: tsToString(comment.createdAt, 'd/m/Y'),
-                        },
-                        message,
-                    },
+                    variables: mailVariables,
                     preserveRecipient: false,
                 })));
             }

--- a/packages/api/server/services/shantytown/deleteComment.ts
+++ b/packages/api/server/services/shantytown/deleteComment.ts
@@ -76,7 +76,7 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
                     bcc: nationalAdmins,
                 });
             } else {
-                await Promise.all(nationalAdmins.map(nationalAdmin => mails.sendUserCommentDeletion(nationalAdmin, {
+                await Promise.all(nationalAdmins.map(nationalAdmin => mails.sendAdminCommentDeletion(nationalAdmin, {
                     variables: {
                         town: {
                             usename: town.usename,
@@ -90,6 +90,7 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
                         },
                         message,
                     },
+                    preserveRecipient: false,
                 })));
             }
         }

--- a/packages/api/server/services/user/deactivate.ts
+++ b/packages/api/server/services/user/deactivate.ts
@@ -36,7 +36,6 @@ async function deactivateUserWithTransaction(id: number, anonymizationRequested:
     const transaction = await sequelize.transaction();
 
     try {
-        // (ids: number[], deactivationType: string = 'auto', anonymizationRequested: boolean = false, transaction: Transaction = undefined): Promise<UserStatus[]> => {
         const updatedUsers = await userModel.deactivate([id], 'admin', anonymizationRequested, transaction);
 
         if (!updatedUsers || updatedUsers.length !== 1) {
@@ -119,7 +118,7 @@ export default async (id: number, selfDeactivation: boolean, author: User, reaso
     const user = await findAndValidateUser(id);
     const updatedUser = await deactivateUserWithTransaction(id, anonymizationRequested, user);
 
-    // Désactivation éventuelle des jobs programmé par accessActivatedOnboarding s'ils sont actifs
+    // Désactivation éventuelle des jobs programmés par accessActivatedOnboarding s'ils sont actifs
     await sendNotifications(updatedUser, selfDeactivation, reason);
     const agenda = agendaFactory();
     await Promise.all(onboardingJob.map(async (jobName) => {

--- a/packages/api/server/utils/getActiveAdminWhoGrantedAccess.ts
+++ b/packages/api/server/utils/getActiveAdminWhoGrantedAccess.ts
@@ -1,0 +1,20 @@
+import userModel from '../models/userModel';
+import { User } from '#root/types/resources/User.d';
+/**
+ * Check if the admin who granted access is still active
+ *
+ * @param {User} user: User - User object with access information
+ * @returns {Promise<User|null>} - Returns admin object if active, null otherwise
+ */
+export default async (user: User): Promise<User | null> => {
+    if (user.user_accesses && user.user_accesses.length > 0) {
+        const adminId = user.user_accesses[0].sent_by.id;
+        const admin = await userModel.findOne(adminId);
+
+        if (admin !== null && admin.status === 'active') {
+            return admin;
+        }
+    }
+
+    return null;
+};

--- a/packages/frontend/ui/src/components/ErrorSummary.vue
+++ b/packages/frontend/ui/src/components/ErrorSummary.vue
@@ -28,6 +28,9 @@ const props = defineProps({
 
 const { message, summary } = toRefs(props);
 const summaryErrors = computed(() => {
+    if (!summary.value) {
+        return [];
+    }
     return Object.keys(summary.value).map((key) => ({
         key,
         message: summary.value[key]

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyDeactivate.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyDeactivate.vue
@@ -48,7 +48,7 @@
             <Button
                 variant="tertiaryA11Yalt"
                 @click="deactivate"
-                :disabled="deactivationReason.length === 0"
+                :disabled="deactivationReason.length === 0 || isLoading"
                 :loading="isLoading"
                 class="hover:!bg-tertiaryA11Yalt"
                 >{{ wording.button }}</Button
@@ -80,7 +80,7 @@ const { user } = toRefs(props);
 
 const deactivationReason = ref("");
 const anonymizationRequested = ref(false);
-const isLoading = ref(null);
+const isLoading = ref(false);
 const error = ref(null);
 const errorSummary = ref(null);
 const wordings = {
@@ -105,10 +105,11 @@ const wording = computed(() => {
 function cancelReason() {
     deactivationReason.value = "";
     anonymizationRequested.value = false;
+    error.value = null;
 }
 
 async function deactivate() {
-    if (isLoading.value === true) {
+    if (isLoading.value) {
         return;
     }
     console.log("Anonymization?", anonymizationRequested.value);
@@ -140,9 +141,9 @@ async function deactivate() {
                 {}
             );
         }
+    } finally {
+        isLoading.value = false;
     }
-
-    isLoading.value = false;
 }
 </script>
 

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyOptions.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyOptions.vue
@@ -59,6 +59,7 @@ watch(values, () => {
 watch(options, () => {
     if (
         options.value &&
+        values.options &&
         options.value.length === values.options.length &&
         options.value.every((v) => values.options.includes(v))
     ) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/W0uSVxko/2395

## 🛠 Description de la PR
Vérifie pour tous les mails qui n'ont pas déjà fait l'objet de ce contrôle, que les comptes auxquels on adresse un mail sont bien actif. 
On vérifie les comptes utilisateurs et les comptes admins parfois en copie (Cc), parfois adressés dans une méthode dédiée
Dans le cas de la suppression d'un commentaire, par exemple, où le compte utilisateur est désactivé  mais que le mail est envoyé en copie aux admins, on envoie maintenant un mel spécifique aux admins indiquant qu'un commentaire posté par un utilisateur désactivé depuis son post a été supprimé par un modérateur

## 🚨 Notes pour la mise en production
- ràs