### PR TITLE
#patch (2403) Ne pas afficher les utilisateurs anonymisés dans l'annuaire

### DIFF
--- a/packages/api/server/models/actionModel/findActionFinancesReaders/findActionFinancesReaders.ts
+++ b/packages/api/server/models/actionModel/findActionFinancesReaders/findActionFinancesReaders.ts
@@ -14,6 +14,7 @@ export type ActionFinancesReaderRow = {
     position: string | null,
     role_admin: string | null,
     role_regular: string,
+    user_status: string,
     id: number,
     name: string,
     abbreviation: string | null,
@@ -70,6 +71,7 @@ export default async (actionId?: number, managers?: number[], departement?: Depa
             users.position,
             users.fk_role AS role_admin,
             users.fk_role_regular AS role_regular,
+            users.fk_status AS user_status,
             organizations.organization_id as id,
             organizations.name,
             organizations.abbreviation,
@@ -158,6 +160,7 @@ export default async (actionId?: number, managers?: number[], departement?: Depa
             phone: row.phone,
             position: row.position,
             expertise_topics: [],
+            status: row.user_status,
         });
 
         return acc;

--- a/packages/api/server/models/organizationModel/findJusticeReaders.ts
+++ b/packages/api/server/models/organizationModel/findJusticeReaders.ts
@@ -14,6 +14,7 @@ export type JusticeReaderRow = {
     position: string | null,
     role_admin: string | null,
     role_regular: string,
+    user_status: string,
     id: number,
     name: string,
     abbreviation: string | null,
@@ -61,6 +62,7 @@ export default async (shantytownId?: number, location?: Location, userId?: numbe
             users.position,
             users.fk_role AS role_admin,
             users.fk_role_regular AS role_regular,
+            users.fk_status AS user_status,
             organizations.organization_id as id,
             organizations.name,
             organizations.abbreviation,
@@ -148,6 +150,7 @@ export default async (shantytownId?: number, location?: Location, userId?: numbe
             phone: row.phone,
             position: row.position,
             expertise_topics: [],
+            status: row.user_status,
         });
 
         return acc;

--- a/packages/api/server/models/organizationModel/getDirectory.ts
+++ b/packages/api/server/models/organizationModel/getDirectory.ts
@@ -2,4 +2,4 @@ import { type Transaction } from 'sequelize';
 import find from './_common/find';
 import { Organization } from '#root/types/resources/Organization.d';
 
-export default (transaction?: Transaction): Promise<Organization[]> => find({ activeOnly: true }, transaction);
+export default (transaction?: Transaction): Promise<Organization[]> => find({ activeOnly: true, nonEmpty: true }, transaction);

--- a/packages/api/test/utils/actionFinancesReader.ts
+++ b/packages/api/test/utils/actionFinancesReader.ts
@@ -19,5 +19,6 @@ export default function raw(): ActionFinancesReaderRow {
         type_category: 'association',
         type_name: 'Association',
         type_abbreviation: null,
+        user_status: 'active',
     };
 }

--- a/packages/api/test/utils/justiceReader.ts
+++ b/packages/api/test/utils/justiceReader.ts
@@ -19,5 +19,6 @@ export default function raw(): JusticeReaderRow {
         type_category: 'association',
         type_name: 'Association',
         type_abbreviation: null,
+        user_status: 'active',
     };
 }

--- a/packages/api/types/resources/Organization.d.ts
+++ b/packages/api/types/resources/Organization.d.ts
@@ -30,4 +30,5 @@ export type OrganizationUser = {
     phone: string | null,
     position: string,
     expertise_topics: UserExpertiseTopic[],
+    status: string,
 };

--- a/packages/frontend/webapp/src/helpers/dsfr.js
+++ b/packages/frontend/webapp/src/helpers/dsfr.js
@@ -3,7 +3,7 @@ import {
     DsfrTile,
     DsfrSearchBar,
     DsfrInput,
-    DsfrCheckbox
+    DsfrCheckbox,
 } from "@gouvminint/vue-dsfr";
 
 import "@gouvfr/dsfr/dist/dsfr.min.css";

--- a/packages/frontend/webapp/src/views/FicheStructureView.vue
+++ b/packages/frontend/webapp/src/views/FicheStructureView.vue
@@ -78,7 +78,7 @@ async function load() {
     try {
         organization.value = await directoryStore.get(
             organizationId.value,
-            false
+            true
         );
 
         if (organization.value) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/gBX38G4l/2403-annuaire-ne-pas-afficher-les-utilisateurs-anonymis%C3%A9s

## 🛠 Description de la PR
Cette PR corrige l'affichage des utilisateurs dans l'annuaire (liste de toutes les structures) ainsi que sur la fiche d'une structure. Elle comprend également une modification permettant de garder l'affichage du message indiquant que la structure existe mais ne contient aucun utilisateur actif.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS