### PR TITLE
#patch (2405) Corriger la route vers la page de statistiques

### DIFF
--- a/packages/frontend/ui/src/components/FooterBar/FooterBar.vue
+++ b/packages/frontend/ui/src/components/FooterBar/FooterBar.vue
@@ -24,7 +24,7 @@
                 </FooterBarFootLink>
                 <span class="w-px bg-G300 mx-3 h-4 hidden md:inline"></span>
 
-                <FooterBarFootLink :to="`${(URL || '')}/statistiques-publiques`"
+                <FooterBarFootLink :to="`${(URL || '')}/stats`"
                     title="Afficher les statistiques publiques de la plateforme">
                     {{ $t('footer.statistics') }}
                 </FooterBarFootLink>

--- a/packages/frontend/webapp/src/helpers/router.js
+++ b/packages/frontend/webapp/src/helpers/router.js
@@ -655,7 +655,7 @@ const router = createRouter({
             },
         },
         {
-            path: "/statistiques-publiques",
+            path: "/stats",
             component: () => import("@/views/StatistiquesPubliques.vue"),
             meta: {
                 title: "Statistiques publiques",

--- a/packages/frontend/webapp/src/views/NotFoundView.vue
+++ b/packages/frontend/webapp/src/views/NotFoundView.vue
@@ -20,9 +20,7 @@
                     notre travail
                 </li>
                 <li>
-                    <Link to="/statistiques-publiques"
-                        >quelques statistiques</Link
-                    >
+                    <Link to="/stats">quelques statistiques</Link>
                     sur notre mesure d'impact
                 </li>
             </ul>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/C1DWUpgO/2405

## 🛠 Description de la PR
Modifie la route vers la pages de statistiques de façon à ce que Dashlord puisse récupérer ces informations

## 🚨 Notes pour la mise en production
ràs