### PR TITLE
#patch (2409) Correction du placement du tag des PJ

### DIFF
--- a/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
@@ -13,7 +13,7 @@
             @mouseleave="isHover = false"
         >
             <div
-                class="mb-4 px-6 -mt-1 pt-px flex lg:flex-row justify-between gap-2"
+                class="mb-4 px-6 -mt-1 pt-px flex flex-col sm:flex-row justify-between sm:gap-2"
             >
                 <div>
                     <Tag
@@ -38,7 +38,7 @@
                         </span>
                     </Tag>
                 </div>
-                <div class="flex right-14 mt-[3px]" v-if="attachmentsLabel">
+                <div class="mt-[3px]" v-if="attachmentsLabel">
                     <Tag
                         tabindex="1"
                         :aria-label="attachmentsLabel"
@@ -57,7 +57,9 @@
                 {{ action.name }}
             </div>
 
-            <div class="md:grid cardGridTemplateColumns gap-10 px-6 py-4">
+            <div
+                class="lg:grid cardGridTemplateColumnsSmall lg:cardGridTemplateColumnsLarge gap-10 px-6 py-4"
+            >
                 <CarteActionColonneChampsIntervention :topics="action.topics" />
                 <CarteActionDetailleeColonneDepartement
                     :departement="action.location.departement"
@@ -138,7 +140,10 @@ const attachmentsLabel = computed(() => {
 </script>
 
 <style scoped lang="scss">
-.cardGridTemplateColumns {
+.cardGridTemplateColumnsLarge {
     grid-template-columns: 222px 208px auto 300px 200px;
+}
+.cardGridTemplateColumnsSmall {
+    grid-template-columns: 111px 104px auto 200px 150px;
 }
 </style>

--- a/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
@@ -12,7 +12,9 @@
             @mouseenter="isHover = true"
             @mouseleave="isHover = false"
         >
-            <div class="mb-4 px-6 -mt-1 pt-px flex gap-2">
+            <div
+                class="mb-4 px-6 -mt-1 pt-px flex lg:flex-row justify-between gap-2"
+            >
                 <div>
                     <Tag
                         tabindex="0"
@@ -36,10 +38,7 @@
                         </span>
                     </Tag>
                 </div>
-                <div
-                    class="flex sm:absolute sm:right-14 mt-[3px]"
-                    v-if="attachmentsLabel"
-                >
+                <div class="flex right-14 mt-[3px]" v-if="attachmentsLabel">
                     <Tag
                         tabindex="1"
                         :aria-label="attachmentsLabel"

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
@@ -30,7 +30,7 @@
                 class="mt-1 items-center py-2"
             />
         </div>
-        <div class="flex lg:absolute lg:right-14" v-if="attachmentsLabel">
+        <div class="flex right-14" v-if="attachmentsLabel">
             <Tag
                 variant="highlight"
                 :class="[


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kgcwHxzz/2409-bug-affichage-de-lindicateur-de-pj-en-dehors-du-cartouche-liste-des-sites

## 🛠 Description de la PR
La PR corrige le placement excentré du tag indiquant la présence de pièces jointes dans la liste des sites. La tag était déporté à l'extérieur du cadre du site si la résolution présentait une largeur supérieure à la normale.

## 📸 Captures d'écran
Avant:
![image](https://github.com/user-attachments/assets/1692ea65-9df7-4e38-bbed-9f21eab9d74e)
Après:
![image](https://github.com/user-attachments/assets/11cad4c1-83fb-45b0-b8d6-b12bf6439094)

## 🚨 Notes pour la mise en production
RàS