### PR TITLE
#patch: (2418) Affichage permanent des bouton "alerte canicule" et "mettre à jour"

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="flex justify-end h-14 items-center mr-4 space-x-4 print:hidden">
         <Button
-            v-if="isHover"
             variant="primaryOutline"
             icon="temperature-high"
             iconPosition="left"
@@ -15,7 +14,7 @@
             <template v-else>Supprimer l'alerte Canicule</template>
         </Button>
         <Button
-            v-if="isHover && isOpen && hasUpdateShantytownPermission"
+            v-if="isOpen && hasUpdateShantytownPermission"
             variant="primaryOutline"
             size="sm"
             icon="pencil-alt"
@@ -51,15 +50,11 @@ import { Icon, Button, Link } from "@resorptionbidonvilles/ui";
 
 const props = defineProps({
     shantytown: Object,
-    isHover: {
-        type: Boolean,
-        default: false,
-    },
 });
 const userStore = useUserStore();
 const notificationStore = useNotificationStore();
 const townsStore = useTownsStore();
-const { shantytown, isHover } = toRefs(props);
+const { shantytown } = toRefs(props);
 
 const hasUpdateShantytownPermission = computed(() => {
     return userStore.hasUpdateShantytownPermission(shantytown.value);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/iu4wIKpD/2418-liste-des-sites-laisser-visible-les-boutons-alerte-canicule-et-maj

## 🛠 Description de la PR
La PR force l'affichage permanent des boutons d'activation/désactivation de l'alerte canicule ainsi que le bouton de mise à jour sur les cartes de site.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/258e62a2-719d-4f74-bd59-8d97a5047c01)

## 🚨 Notes pour la mise en production
RàS