### PR TITLE
#patch (2404) Corriger les notifications d'invitations

### DIFF
--- a/packages/api/server/controllers/invitation/create/invitation.create.ts
+++ b/packages/api/server/controllers/invitation/create/invitation.create.ts
@@ -38,9 +38,20 @@ async function sendMattermostNotifications(guests, greeter, invite_from) {
     if (invite_from === 'access_request') {
         from = "via le formulaire de demande d'accès";
     } else if (invite_from === 'contact_others') {
-        from = "via le formulaire de contact (signaler / aider / demande d'info / demander de l'aide)";
+        from = "via le formulaire de contact (signaler / aider / demander des infos / demander de l'aide / demander un accès)";
     } else if (invite_from === 'push_mail') {
         from = 'via push mail J+15';
+    } else if (invite_from === 'navbar') {
+        from = 'via le menu de navigation';
+    } else if (invite_from === 'annuaire') {
+        from = 'via l\'annuaire';
+    } else {
+        from = 'via une origine inconnue';
+    }
+
+    const greeterUser = await userModel.findOneByEmail(greeter.email);
+    if (greeterUser !== null) {
+        greeter.id = greeterUser.id;
     }
 
     for (let i = 0; i < guests.length; i += 1) {
@@ -70,6 +81,8 @@ export default async (req, res, next) => {
 
     // Send a mattermost alert for each guest
     try {
+        // La méthode qui suit attend l'id de l'utilisateur pour l'accès à sa fiche sur la lateforme. 
+        // Or, l'id n'est pas contenu dans l'objet "greeter"
         await sendMattermostNotifications(guests, greeter, invite_from);
     } catch (err) {
         // ignore

--- a/packages/api/server/controllers/invitation/create/invitation.create.ts
+++ b/packages/api/server/controllers/invitation/create/invitation.create.ts
@@ -81,8 +81,6 @@ export default async (req, res, next) => {
 
     // Send a mattermost alert for each guest
     try {
-        // La méthode qui suit attend l'id de l'utilisateur pour l'accès à sa fiche sur la lateforme. 
-        // Or, l'id n'est pas contenu dans l'objet "greeter"
         await sendMattermostNotifications(guests, greeter, invite_from);
     } catch (err) {
         // ignore

--- a/packages/api/server/controllers/invitation/create/invitation.create.ts
+++ b/packages/api/server/controllers/invitation/create/invitation.create.ts
@@ -50,15 +50,16 @@ async function sendMattermostNotifications(guests, greeter, invite_from) {
     }
 
     const greeterUser = await userModel.findOneByEmail(greeter.email);
+    let greeterWithId = greeter;
     if (greeterUser !== null) {
-        greeter.id = greeterUser.id;
+        greeterWithId = { ...greeter, id: greeterUser.id };
     }
 
     for (let i = 0; i < guests.length; i += 1) {
         // Send a mattermost alert, if it fails, do nothing
         try {
             // eslint-disable-next-line no-await-in-loop
-            await triggerPeopleInvitedAlert(guests[i], greeter, from);
+            await triggerPeopleInvitedAlert(guests[i], greeterWithId, from);
         } catch (err) {
             // eslint-disable-next-line no-console
             console.log(`Error with invited people mattermost webhook : ${Object.entries(err.message).flat()}`);

--- a/packages/api/server/controllers/invitation/create/invitation.create.validator.ts
+++ b/packages/api/server/controllers/invitation/create/invitation.create.validator.ts
@@ -9,7 +9,7 @@ export default [
         .trim()
         .notEmpty().bail().withMessage('L\'origine de l\'invitation est obligatoire')
         .custom((value) => {
-            if (!['access_request', 'contact_others', 'push_mail', 'unknown'].includes(value)) {
+            if (!['access_request', 'contact_others', 'push_mail', 'navbar', 'annuaire', 'unknown'].includes(value)) {
                 throw new Error('L\'origine de l\'invitation est invalide');
             }
             return true;

--- a/packages/api/server/utils/mattermost.ts
+++ b/packages/api/server/utils/mattermost.ts
@@ -295,7 +295,7 @@ async function triggerPeopleInvitedAlert(guest: User, greeter: User, msg: string
         // channel: '#notif-personnes-invitées',
         username: 'Alerte Résorption Bidonvilles',
         icon_emoji: ':robot:',
-        text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg}`,
+        text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg ? msg : ''}`,
         attachments: [
             {
                 color: '#f2c744',

--- a/packages/api/server/utils/mattermost.ts
+++ b/packages/api/server/utils/mattermost.ts
@@ -302,7 +302,7 @@ async function triggerPeopleInvitedAlert(guest: User, greeter: User, msg: string
         // channel: '#notif-personnes-invitées',
         username: 'Alerte Résorption Bidonvilles',
         icon_emoji: ':robot:',
-        text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg ? msg : ''}`,
+        text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg || ''}`,
         attachments: [
             {
                 color: '#f2c744',

--- a/packages/api/server/utils/mattermost.ts
+++ b/packages/api/server/utils/mattermost.ts
@@ -299,7 +299,7 @@ async function triggerPeopleInvitedAlert(guest: User, greeter: User, msg: string
 
     const mattermostMessage = {
         // Don't initialize the channel name because the incoming webhook has been designed for this one
-        channel: '#notif-personnes-invitées',
+        // channel: '#notif-personnes-invitées',
         username: 'Alerte Résorption Bidonvilles',
         icon_emoji: ':robot:',
         text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg ? msg : ''}`,

--- a/packages/api/server/utils/mattermost.ts
+++ b/packages/api/server/utils/mattermost.ts
@@ -8,6 +8,7 @@ import { User } from '#root/types/resources/User.d';
 const { mattermost, webappUrl } = config;
 const formatAddress = (town: Shantytown): string => `${town.address} ${town.name ? `« ${town.name} » ` : ''}`;
 const formatUsername = (user: { id: number, first_name: string, last_name: string }): string => `[${user.first_name} ${user.last_name}](${webappUrl}/nouvel-utilisateur/${user.id}) `;
+const formatUsernameWithEmailLink = (user: { first_name: string, last_name: string, email: string, }): string => `[${user.first_name} ${user.last_name}](mailto:${user.email}) `;
 const formatTownLink = (townID: number, text: string): string => `[${text}](${webappUrl}/site/${townID})`;
 const formatActionLink = (actionID: number, text: string): string => `[${text}](${webappUrl}/action/${actionID})`;
 
@@ -287,12 +288,18 @@ async function triggerPeopleInvitedAlert(guest: User, greeter: User, msg: string
 
     const peopleInvitedAlert = new IncomingWebhook(mattermost);
 
-    const guestName = formatUsername(guest);
-    const greeterName = formatUsername(greeter);
+    const guestName = formatUsernameWithEmailLink(guest);
+
+    let greeterName = '';
+    if (greeter.id) {
+        greeterName = formatUsername(greeter);
+    } else {
+        greeterName = formatUsernameWithEmailLink(greeter);
+    }
 
     const mattermostMessage = {
         // Don't initialize the channel name because the incoming webhook has been designed for this one
-        // channel: '#notif-personnes-invitées',
+        channel: '#notif-dev-test',
         username: 'Alerte Résorption Bidonvilles',
         icon_emoji: ':robot:',
         text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg ? msg : ''}`,
@@ -302,7 +309,7 @@ async function triggerPeopleInvitedAlert(guest: User, greeter: User, msg: string
                 fields: [
                     {
                         short: 'false',
-                        value: `*Personne invitée*: ${guestName} <${guest.email}>`,
+                        value: `*Personne invitée*: ${guestName}`,
                     },
                 ],
             }],

--- a/packages/api/server/utils/mattermost.ts
+++ b/packages/api/server/utils/mattermost.ts
@@ -299,7 +299,7 @@ async function triggerPeopleInvitedAlert(guest: User, greeter: User, msg: string
 
     const mattermostMessage = {
         // Don't initialize the channel name because the incoming webhook has been designed for this one
-        channel: '#notif-dev-test',
+        channel: '#notif-personnes-invitées',
         username: 'Alerte Résorption Bidonvilles',
         icon_emoji: ':robot:',
         text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg ? msg : ''}`,

--- a/packages/frontend/webapp/src/components/Annuaire/Annuaire.vue
+++ b/packages/frontend/webapp/src/components/Annuaire/Annuaire.vue
@@ -15,7 +15,7 @@
                 inscrites sur la plateforme
             </template>
             <template v-slot:actions>
-                <Link to="/invitation"
+                <Link to="/invitation?from=annuaire"
                     ><Icon icon="user-plus" /> Inviter des utilisateurs</Link
                 >
             </template>

--- a/packages/frontend/webapp/src/components/FormInvitation/FormInvitation.vue
+++ b/packages/frontend/webapp/src/components/FormInvitation/FormInvitation.vue
@@ -111,11 +111,10 @@ const props = defineProps({
     },
     from: {
         type: String,
-        required: true,
+        default: "unknown",
     },
     showSkip: {
         type: Boolean,
-        required: false,
         default: false,
     },
 });

--- a/packages/frontend/webapp/src/stores/navigation.store.js
+++ b/packages/frontend/webapp/src/stores/navigation.store.js
@@ -19,7 +19,7 @@ const topItems = [
     {
         icon: "fa-regular fa-user-plus",
         label: "Inviter des utilisateurs",
-        route: "/invitation",
+        route: "/invitation?from=navbar",
         authRequirement: "signedIn",
     },
     {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/y4hCP0ka/2404

## 🛠 Description de la PR
- Seules les invitations générées lors d'une demande d'accès font l'objet d'un affichage à ce jour (mention " via le formulaire de demande d'accès" après l'affichage des nom et prénom de la personne invitée). Les autres sont ignorées (affichage de "null").
- Lorsqu'une personne demande un accès en précisant n'être pas acteur ou actrice de la résorption des bidonvilles, elle n'est pas inscrite dans la table des utilisateur et ne peut donc pas faire l'objet d'un affichage dans la liste des accès de la plateforme. Le lien indiqué sur la notification est "https://app.resorption-bidonvilles.dihal.gouv.fr/nouvel-utilisateur/undefined". Dans ce cas, on affiche maintenant son adresse mail dans le corps de la notification.

## 📸 Captures d'écran
- So

## 🚨 Notes pour la mise en production
- ràs