### PR TITLE
#patch: (2406) Ajouter l'icône "canicule" sur la carte de Visualisation de données

### DIFF
--- a/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/CartoDonneesStatistiques/CartoDonneesStatistiques.vue
@@ -116,6 +116,7 @@ const displayedLegend = {
             "fire-extinguisher",
             "toilet",
             "bug-slash",
+            "temperature-high",
         ],
         labels: [
             "Accès à l'eau",
@@ -124,6 +125,7 @@ const displayedLegend = {
             "Prévention incendie",
             "Accès aux toilettes",
             "Absence de nuisibles",
+            "Alerte canicule",
         ],
         levelsTitle: null,
         levels: [

--- a/packages/frontend/webapp/src/utils/marqueurSiteStats.js
+++ b/packages/frontend/webapp/src/utils/marqueurSiteStats.js
@@ -10,6 +10,7 @@ const iconMap = {
         fire_prevention: "fire-extinguisher",
         working_toilets: "toilet",
         absence_of_pest_animals: "bug-slash",
+        heatwave: "temperature-high",
     },
     schooling: {
         number_of_schooled_minors: "school",
@@ -47,7 +48,11 @@ export default (town, activeTab) => {
                     schoolingPercentage
                 );
             } else {
-                if (town[key] === "bad" || town[key] === "unknown") {
+                if (
+                    town[key] === "bad" ||
+                    town[key] === "unknown" ||
+                    !town[key]
+                ) {
                     return acc;
                 }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/MpJxKOvb/2406-visu-donn%C3%A9es-ajouter-licone-canicule-sur-la-carte

## 🛠 Description de la PR
La PR ajoute l'icône de canicule sur les sites dont l'alerte est activée. L'icône est affichée en rouge. Si l'alerte n'est pas activée pour le site, l'icône n'apparaît pas.
L'icône est également rajoutée à la légende.

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/49ecd61c-3dfa-4474-bbc6-0866c5ada257)
![image](https://github.com/user-attachments/assets/d902d74b-732e-4ee7-b43c-ce7c233a6da5)

## 🚨 Notes pour la mise en production
RàS