### PR TITLE
#patch: (2414) Corrections de design sur des boutons et listes déroulantes

### DIFF
--- a/packages/frontend/ui/src/components/Input/SelectUi.vue
+++ b/packages/frontend/ui/src/components/Input/SelectUi.vue
@@ -2,7 +2,7 @@
     <InputWrapper :hasErrors="!!error" :withoutMargin="withoutMargin" :id="name">
         <InputLabel :label="label" :info="info" :showMandatoryStar="showMandatoryStar" :for="id" />
 
-        <div class="relative" :class="width">
+        <div class="relative border-1 border-G500" :class="width">
             <InputIcon position="before" :icon="icon" />
             <select :class="[focusClasses.ring, classes]" :value="modelValue" :disabled="disabled || isLoading" @change="onChange" :id="id">
                 <slot />

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsExport/ListeDesActionsExportModal.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsExport/ListeDesActionsExportModal.vue
@@ -65,6 +65,7 @@
                             v-if="actionsExportIsSelected"
                             variant="primaryOutline"
                             size="md"
+                            class="!border-2 !border-primary hover:!bg-primaryDark !py-1.5"
                             @click.stop="toggleActionsExportIsSelected"
                         >
                             Annuler</Button
@@ -129,3 +130,8 @@ const title = computed(() => {
     return actionsExportIsSelected.value ? "Export des actions" : "Exports";
 });
 </script>
+<style scoped>
+button {
+    border: inherit;
+}
+</style>

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesExport/ListeDesSitesExport.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesExport/ListeDesSitesExport.vue
@@ -12,7 +12,7 @@
             <Button
                 variant="primaryOutline"
                 @click="() => modale.close()"
-                class="mr-2"
+                class="!border-2 !border-primary hover:!bg-primaryDark mr-2"
                 >Annuler</Button
             >
             <Button
@@ -108,3 +108,8 @@ async function download() {
     isLoading.value = false;
 }
 </script>
+<style scoped>
+button {
+    border: inherit;
+}
+</style>

--- a/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUser.vue
+++ b/packages/frontend/webapp/src/components/ModaleChangerRoleUser/ModaleChangerRoleUser.vue
@@ -20,6 +20,7 @@
                 variant="primaryText"
                 :loading="loading"
                 @click="() => modale.close()"
+                class="!border-2 !border-primary hover:!bg-primaryDark hover:!text-white"
                 >Annuler</Button
             >
             <Button
@@ -118,3 +119,8 @@ async function updateUserRole() {
     return true;
 }
 </script>
+<style scoped>
+button {
+    border: inherit;
+}
+</style>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/rQPMBwUD/2414-actionssites-le-bouton-annuler-de-lexport-nest-pas-d%C3%A9limit%C3%A9

## 🛠 Description de la PR
Cette PR corrige des design erronés de boutons et de listes déroulantes induits par l'ajout du DSFR:
- Bouton annuler et liste déroulante de l'export des actions
- Bouton annuler de l'export des sites
- Bouton annuler de la modale de changement de rôle utilisateur
- Toutes les listes déroulantes basées sur le composant "Select" modifié

## 📸 Captures d'écran
Exemple sur l'export des actions
![image](https://github.com/user-attachments/assets/841b381f-7b60-4e9c-a9a3-ac5345465de7)

## 🚨 Notes pour la mise en production
RàS