### PR TITLE
#patch: (2413) Exclusion des utilisateurs anonymisés lors du listing de tous les utilisateurs

### DIFF
--- a/packages/api/server/controllers/user/list/user.list.ts
+++ b/packages/api/server/controllers/user/list/user.list.ts
@@ -27,6 +27,8 @@ export default async (req, res) => {
                 },
             });
         }
+        // On exclu d'emblée les utilisateurs anonymisés
+        search.push({ anonymized_at: { query: 'users.anonymized_at', operator: 'IS', value: null } });
         const users = await userModel.findAll(req.user, search);
         res.status(200).send(users);
     } catch (error) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/nzPqHgQH/2413-annuaire-filtre-compte-d%C3%A9sactiv%C3%A9-ne-doit-pas-remonter-les-comptes-anonymis%C3%A9s

## 🛠 Description de la PR
Cette PR permet de ne plus lister les utilisateurs anonymisés dans les listings. De fait, ils n'apparaissent plus dans la liste des comptes désactivés ainsi que dans le compteur (bas de page).

## 📸 Captures d'écran
![image](https://github.com/user-attachments/assets/c9f1449c-1bd7-4ed4-bd4a-51f72816ae11)

## 🚨 Notes pour la mise en production
RàS