### PR TITLE
#patch (2402) Permettre la suppression d'un commentaire dans le journal des actions

### DIFF
--- a/packages/api/server/controllers/action/deleteComment/action.deleteComment.route.ts
+++ b/packages/api/server/controllers/action/deleteComment/action.deleteComment.route.ts
@@ -1,0 +1,9 @@
+import { type ApplicationWithCustomRoutes } from '#server/loaders/customRouteMethodsLoader';
+import controller from './action.deleteComment';
+
+export default (app: ApplicationWithCustomRoutes): void => {
+    app.customRoutes.delete('/actions/:id/comments/:commentId', controller, undefined, {
+        authenticate: true,
+        multipart: false,
+    });
+};

--- a/packages/api/server/controllers/action/deleteComment/action.deleteComment.ts
+++ b/packages/api/server/controllers/action/deleteComment/action.deleteComment.ts
@@ -1,5 +1,6 @@
 
 import deleteComment from '#server/services/action/deleteComment';
+import { ActionEnrichedComment } from '#root/types/resources/ActionCommentEnriched.d';
 
 const ERROR_RESPONSES = {
     fetch_failed: { code: 400, message: 'Une lecture en base de données a échoué' },
@@ -11,7 +12,7 @@ const ERROR_RESPONSES = {
 
 
 export default async (req, res, next) => {
-    let comments: boolean;
+    let comments: { comments: ActionEnrichedComment[] };
     try {
         comments = await deleteComment(req.user, req.params.id, req.params.commentId, req.body.message);
     } catch (error) {

--- a/packages/api/server/controllers/action/deleteComment/action.deleteComment.ts
+++ b/packages/api/server/controllers/action/deleteComment/action.deleteComment.ts
@@ -1,0 +1,26 @@
+
+import deleteComment from '#server/services/action/deleteComment';
+
+const ERROR_RESPONSES = {
+    fetch_failed: { code: 400, message: 'Une lecture en base de données a échoué' },
+    data_incomplete: { code: 400, message: 'Données manquantes' },
+    permission_denied: { code: 403, message: 'Permission refusée' },
+    delete_failed: { code: 500, message: 'La suppression du commentaire en base de données a échoué' },
+    undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
+};
+
+
+export default async (req, res, next) => {
+    let comments;
+    try {
+        comments = await deleteComment(req.user, req.params.id, req.params.commentId, req.body.message);
+    } catch (error) {
+        const { code, message } = ERROR_RESPONSES[error && error.code] || ERROR_RESPONSES.undefined;
+        res.status(code).send({
+            user_message: message,
+        });
+        return next(error.nativeError || error);
+    }
+
+    return res.status(200).send(comments);
+};

--- a/packages/api/server/controllers/action/deleteComment/action.deleteComment.ts
+++ b/packages/api/server/controllers/action/deleteComment/action.deleteComment.ts
@@ -11,15 +11,15 @@ const ERROR_RESPONSES = {
 
 
 export default async (req, res, next) => {
-    let comments;
+    let comments: boolean;
     try {
         comments = await deleteComment(req.user, req.params.id, req.params.commentId, req.body.message);
     } catch (error) {
-        const { code, message } = ERROR_RESPONSES[error && error.code] || ERROR_RESPONSES.undefined;
+        const { code, message }: { code: number; message: string } = ERROR_RESPONSES[error?.code] ?? ERROR_RESPONSES.undefined;
         res.status(code).send({
             user_message: message,
         });
-        return next(error.nativeError || error);
+        return next(error.nativeError ?? error);
     }
 
     return res.status(200).send(comments);

--- a/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.html
+++ b/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.html
@@ -210,7 +210,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}}, {{var:town.city.name}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Écrit le {{var:comment.created_at}}, concernant {{ var:entity.type }} : {{var:entity.name}}, {{var:entity.location.name}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.text
+++ b/packages/api/server/mails/dist/admin_comment_from_deactivated_user_deletion.text
@@ -5,8 +5,8 @@ La raison mentionnée par celui-ci est :
 "{{var:message}}".
 
 "{{var:comment.description}}".
-Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}},
-{{var:town.city.name}}
+Écrit le {{var:comment.created_at}}, concernant {{ var:entity.type }} :
+{{var:entity.name}}, {{var:entity.location.name}}
 
 Cordialement,
 L'équipe Résorption-bidonvilles

--- a/packages/api/server/mails/dist/user_comment_deletion.html
+++ b/packages/api/server/mails/dist/user_comment_deletion.html
@@ -210,7 +210,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}}, {{var:town.city.name}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Écrit le {{var:comment.created_at}}, concernant {{ var:entity.type }} : {{var:entity.name}}, {{var:entity.location.name}}</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_comment_deletion.text
+++ b/packages/api/server/mails/dist/user_comment_deletion.text
@@ -4,8 +4,8 @@ La raison mentionnée par celui-ci est :
 "{{var:message}}".
 
 "{{var:comment.description}}".
-Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}},
-{{var:town.city.name}}
+Écrit le {{var:comment.created_at}}, concernant {{ var:entity.type }} :
+{{var:entity.name}}, {{var:entity.location.name}}
 
 Pour rappel, conformément à la réglementation relative aux données à caractère
 personnel, un commentaire doit :

--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -619,7 +619,7 @@ export default {
         return mailService.send('user_comment_deletion', {
             recipient,
             variables: {
-                town: variables.town,
+                entity: variables.entity,
                 comment: variables.comment,
                 message: variables.message,
                 backUrl,
@@ -640,7 +640,7 @@ export default {
         return mailService.send('admin_comment_from_deactivated_user_deletion', {
             recipient,
             variables: {
-                town: variables.town,
+                entity: variables.entity,
                 comment: variables.comment,
                 message: variables.message,
                 backUrl,

--- a/packages/api/server/mails/src/admin_comment_from_deactivated_user_deletion.mjml
+++ b/packages/api/server/mails/src/admin_comment_from_deactivated_user_deletion.mjml
@@ -26,7 +26,7 @@
                 <mj-text mj-class="pb-4">
                     "{{var:comment.description}}".
                 </mj-text>
-                <mj-text>Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}}, {{var:town.city.name}}</mj-text>
+                <mj-text>Écrit le {{var:comment.created_at}}, concernant {{ var:entity.type }} : {{var:entity.name}}, {{var:entity.location.name}}</mj-text>
             </mj-column>
         </mj-section>
         <mj-include path='common/footer.mjml' />

--- a/packages/api/server/mails/src/user_comment_deletion.mjml
+++ b/packages/api/server/mails/src/user_comment_deletion.mjml
@@ -26,7 +26,7 @@
                 <mj-text mj-class="pb-4">
                     "{{var:comment.description}}".
                 </mj-text>
-                <mj-text>Écrit le {{var:comment.created_at}}, concernant le site : {{var:town.usename}}, {{var:town.city.name}}</mj-text>
+                <mj-text>Écrit le {{var:comment.created_at}}, concernant {{ var:entity.type }} : {{var:entity.name}}, {{var:entity.location.name}}</mj-text>
             </mj-column>
         </mj-section>
         <mj-section>

--- a/packages/api/server/models/actionModel/deleteComment/deleteComment.ts
+++ b/packages/api/server/models/actionModel/deleteComment/deleteComment.ts
@@ -1,0 +1,19 @@
+import { sequelize } from '#db/sequelize';
+import { Transaction } from 'sequelize';
+
+export default async (commentId: number, transaction?: Transaction): Promise<void> => {
+    const response = sequelize.query(
+        'DELETE FROM action_comments WHERE action_comment_id = :id',
+        {
+            transaction,
+            replacements: {
+                id: commentId,
+            },
+        },
+    );
+
+    const rowCount: number = response[0] as unknown as number;
+    if (rowCount === 0) {
+        throw new Error(`Comment ${commentId} introuvable`);
+    }
+};

--- a/packages/api/server/services/action/deleteComment.spec.ts
+++ b/packages/api/server/services/action/deleteComment.spec.ts
@@ -8,9 +8,7 @@ import permissionUtils from '#server/utils/permission';
 import { serialized as fakeUser } from '#test/utils/user';
 import { serialized as fakeAction } from '#test/utils/action';
 import { AuthUser } from '#server/middlewares/authMiddleware';
-
-import actionModel from '#server/models/actionModel';
-import deleteActionComment from './deleteComment';
+import ServiceError from '#server/errors/ServiceError';
 
 const { expect } = chai;
 chai.use(sinonChai);
@@ -18,29 +16,48 @@ chai.use(chaiSubset);
 
 const sandbox = sinon.createSandbox();
 const stubs = {
-    deleteComment: sandbox.stub().resolves(true),
+    deleteComment: sandbox.stub().resolves({ comments: [] }),
     fetchCommentsModel: sandbox.stub(),
+    fetchAction: sandbox.stub(),
+    userModel: { findOne: sandbox.stub(), getNationalAdmins: sandbox.stub() },
     fetchUserModel: sandbox.stub(),
     canDeleteComment: sandbox.stub(),
+    enrichCommentsAttachments: sandbox.stub().resolves([]),
+    validator: {
+        trim: sandbox.stub().callsFake(value => value.trim()),
+    },
+    dateUtils: {
+        fromTsToFormat: sandbox.stub().callsFake(ts => (ts ? new Date(ts).toISOString() : 'Invalid Date')),
+        tsToString: sandbox.stub().callsFake(ts => (ts ? new Date(ts * 1000).toLocaleDateString('fr-FR') : 'Invalid Date')),
+    },
+    mails: {
+        sendUserCommentDeletion: sandbox.stub().resolves(),
+    },
     can: sandbox.stub(permissionUtils, 'can'),
     do: sandbox.stub(),
     on: sandbox.stub(),
 };
 
-stubs.can.returns({
-    do: stubs.do,
+rewiremock('#server/models/actionModel').with({
+    fetch: stubs.fetchAction,
+    fetchComments: sandbox.stub().resolves([]),
 });
-stubs.do.returns({
-    on: stubs.on,
-});
-
-rewiremock('#server/models/actionModel/fetchComments/fetchComments').with(stubs.fetchCommentsModel);
-rewiremock('#server/models/userModel/findOne').with(stubs.fetchUserModel);
-rewiremock('#server/utils/permission').with({ can: stubs.canDeleteComment });
+rewiremock('#server/mails/mails').with(stubs.mails);
+rewiremock('#server/models/userModel').with(stubs.userModel);
+rewiremock('#server/utils/permission').with({ can: stubs.can });
+rewiremock('./enrichCommentsAttachments').with(stubs.enrichCommentsAttachments);
 rewiremock('#server/models/actionModel/deleteComment/deleteComment').with(stubs.deleteComment);
+rewiremock('validator').with(stubs.validator);
+rewiremock('#server/utils/date').with(stubs.dateUtils);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import deleteActionComment from './deleteComment';
+rewiremock.disable();
 
 describe('services/action.deleteComment()', () => {
     let user: AuthUser;
+    const deletionMessage = 'Test supression message action';
 
     beforeEach(() => {
         user = fakeUser();
@@ -65,63 +82,144 @@ describe('services/action.deleteComment()', () => {
                 },
             },
         };
-        sandbox.stub(actionModel, 'fetch').resolves([fakeAction()]);
+
         stubs.fetchUserModel.resolves(user);
-        // stubs.canDeleteComment.usingPromise(Boolean).resolves(true);
+        stubs.userModel.findOne.resolves(user);
+        stubs.fetchAction.resolves([fakeAction()]);
+        stubs.can.returns({
+            do: stubs.do,
+        });
+        stubs.do.returns({
+            on: stubs.on,
+        });
     });
 
     afterEach(() => {
         sandbox.reset();
     });
 
-    it('supprime un commentaire après vérification des droits', async () => {
-        user.id = 1; // Surcharge de l'ID utilisateur pour simuler qu'il est propriétaire du commentaire
-        const commentId = 1;
-        const deletionMessage = 'Test supression message action';
-        stubs.deleteComment.resolves({ id: 1, comments: [] });
-        const result = await deleteActionComment(user, fakeAction().id, commentId, deletionMessage);
-
-        expect(stubs.can).to.have.been.calledOnceWith(user);
-        expect(stubs.do).to.have.been.calledOnceWith('moderate', 'data');
-        expect(stubs.on).to.have.been.calledOnce;
-        expect(result).to.be.true;
-    });
-
-    // it('retourne une erreur si la suppression est demandée par un admin sans message de suppression', async () => {
-    //     user.id = 2;
-    //     try {
-    //         await expect(deleteActionComment(user, fakeAction().id, fakeAction().comments[0].id, '')).to.be.rejectedWith(ServiceError, 'data_incomplete');
-    //     }
-    // });
-    /*
-    it('should send notification email when deleted by non-owner', async () => {
-        // Arrange
-        const user = { id: 2 };
-        const action = { id: 1, comments: [{ id: 1, createdBy: { id: 1 } }] };
-
-        // Mocks
-        sandbox.stub(actionModel, 'fetch').resolves([fakeAction]);
-        sandbox.stub(userModel, 'findOne').resolves(user);
-        sandbox.stub(permissionUtils, 'can').returns(true);
-        sandbox.stub(deleteComment).resolves();
-        sandbox.stub(mails, 'sendUserCommentDeletion').resolves();
-
-        // Act
-        await deleteActionComment(user, action.id, 1, 'Test message');
-
-        // Assert
-        expect(mails.sendUserCommentDeletion).to.have.been.calledOnce;
-    });
-    it('should throw permission error when user lacks permission', async () => {
-        fetchCommentsModel.resolves([fakeActionComment]);
-        fetchUserModel.resolves(fakeUser);
-        canDeleteComment.usingPromise(Boolean).resolves(true);
-        expect(canDeleteComment).to.have.been.calledOnceWith(fakeUser);
+    it('vérifie que l\'utilisateur a le droit de supprimer le commentaire', async () => {
+        const fakeTestUser = fakeUser();
+        fakeTestUser.id = 1; // Surcharge l'ID pour ne pas être le propriétaire du message
+        try {
+            await deleteActionComment(fakeTestUser, fakeAction().id, 1, deletionMessage);
+        } catch (error) {
+            // ignore
+        }
+        expect(stubs.can).to.have.been.calledOnceWith(fakeTestUser);
         expect(stubs.do).to.have.been.calledOnceWith('moderate', 'data');
         // eslint-disable-next-line no-unused-expressions
         expect(stubs.on).to.have.been.calledOnce;
-        // Act & Assert
-        await expect(deleteActionComment(user, action.id, 1, 'Test message')).to.be.rejectedWith(ServiceError, 'permission_denied');
     });
-    */
+
+    it('si aucune exception n\'est soulevée, supprime le commentaire en bdd et renvoie la liste des commentaires du site à jour', async () => {
+        stubs.on.returns(true);
+        const commentsUpdated = await deleteActionComment(user, fakeAction().id, 1, deletionMessage);
+        expect(stubs.deleteComment).to.have.been.calledOnceWith(1);
+        expect(commentsUpdated).to.eql({
+            comments: [],
+        });
+    });
+
+    it('renvoie une exception ServiceError \'fetch_failed\' si le site correspondant au commentaire n\'existe pas en bdd', async () => {
+        stubs.fetchAction.rejects(new Error());
+        let responseError;
+        try {
+            await deleteActionComment(user, fakeAction().id, 1, deletionMessage);
+        } catch (error) {
+            responseError = error;
+        }
+        expect(responseError).to.be.instanceOf(ServiceError);
+        expect(responseError.code).to.be.eql('fetch_failed');
+    });
+
+    it('renvoie une exception ServiceError \'fetch_failed\' si le commentaire à supprimer n\'existe pas en bdd', async () => {
+        let responseError;
+        try {
+            await deleteActionComment(user, fakeAction().id, 2, deletionMessage); // 2 est un Id qui ne correspond à aucun commentaire dans notre test
+        } catch (error) {
+            responseError = error;
+        }
+        expect(responseError).to.be.instanceOf(ServiceError);
+        expect(responseError.code).to.be.eql('fetch_failed');
+    });
+
+    it('renvoie une exception ServiceError \'fetch_failed\' si l\'auteur du commentaire n\'existe pas en bdd', async () => {
+        stubs.userModel.findOne.rejects(new Error());
+        let responseError;
+        try {
+            await deleteActionComment(user, fakeAction().id, 0, deletionMessage);
+        } catch (error) {
+            responseError = error;
+        }
+        expect(responseError).to.be.instanceOf(ServiceError);
+        expect(responseError.code).to.be.eql('fetch_failed');
+    });
+
+    it('renvoie une exception ServiceError \'permission_denied\' si l\'utilisateur n\' pas la permission de supprimer le commentaire', async () => {
+        user.id = 1;
+        const fakeTestUser = fakeUser();
+
+        stubs.deleteComment.resolves({ id: 1, comments: [] });
+        let responseError: ServiceError | undefined;
+        try {
+            await deleteActionComment(fakeTestUser, fakeAction().id, 1, deletionMessage);
+        } catch (error) {
+            responseError = error;
+        }
+
+        expect(responseError).to.be.instanceOf(ServiceError);
+        expect(responseError.code).to.be.eql('permission_denied');
+    });
+
+    it('renvoie une exception ServiceError \'data_incomplete\' si le motif de suppression du message est vide', async () => {
+        stubs.on.returns(true);
+        stubs.validator.trim.returns('');
+        user.id = 1;
+        const fakeTestUser = fakeUser();
+        let responseError;
+        try {
+            await deleteActionComment(fakeTestUser, fakeAction().id, 1, deletionMessage);
+        } catch (error) {
+            responseError = error;
+        }
+        expect(responseError).to.be.instanceOf(ServiceError);
+        expect(responseError.code).to.be.eql('data_incomplete');
+    });
+
+    it('renvoie une exception ServiceError \'delete_failed\' si le modèle deleteComment échoue', async () => {
+        stubs.on.returns(true);
+        stubs.deleteComment.rejects(new Error());
+        let responseError;
+        try {
+            await deleteActionComment(user, fakeAction().id, 1, deletionMessage);
+        } catch (error) {
+            responseError = error;
+        }
+        expect(responseError).to.be.instanceOf(ServiceError);
+        expect(responseError.code).to.be.eql('delete_failed');
+    });
+
+    it('envoie une notification de suppression du message', async () => {
+        stubs.on.returns(true);
+        user.id = 1;
+        const fakeTestUser = fakeUser();
+        const nationalAdmins = [fakeUser(), fakeUser()];
+        stubs.userModel.getNationalAdmins.resolves(nationalAdmins);
+
+        try {
+            await deleteActionComment(fakeTestUser, fakeAction().id, 1, deletionMessage);
+        } catch (error) {
+            // ignore
+        }
+
+        expect(stubs.mails.sendUserCommentDeletion).to.have.been.calledOnce;
+
+        const { args } = stubs.mails.sendUserCommentDeletion.getCall(0);
+        expect(args[1]).to.have.property('bcc');
+        expect(args[1].bcc).to.have.lengthOf(nationalAdmins.length);
+        expect(args[1]).to.containSubset({
+            bcc: nationalAdmins,
+        });
+    });
 });

--- a/packages/api/server/services/action/deleteComment.spec.ts
+++ b/packages/api/server/services/action/deleteComment.spec.ts
@@ -17,10 +17,8 @@ chai.use(chaiSubset);
 const sandbox = sinon.createSandbox();
 const stubs = {
     deleteComment: sandbox.stub().resolves({ comments: [] }),
-    fetchCommentsModel: sandbox.stub(),
     fetchAction: sandbox.stub(),
     userModel: { findOne: sandbox.stub(), getNationalAdmins: sandbox.stub() },
-    canDeleteComment: sandbox.stub(),
     enrichCommentsAttachments: sandbox.stub().resolves([]),
     validator: {
         trim: sandbox.stub().callsFake(value => value.trim()),

--- a/packages/api/server/services/action/deleteComment.spec.ts
+++ b/packages/api/server/services/action/deleteComment.spec.ts
@@ -1,438 +1,127 @@
-/*
-Tests à effectuer:
-- Vérifier que la suppression d'un commentaire fonctionne correctement.
-- Vérifier que la suppression d'un commentaire sans message de suppression renvoie une erreur.
-- Vérifier que la suppression d'un commentaire par un utilisateur non propriétaire envoie un email de notification.
-- Vérifier que la suppression d'un commentaire par un utilisateur propriétaire ne nécessite pas de message de suppression.
-- Vérifier que la suppression d'un commentaire par un utilisateur sans permission renvoie une erreur de permission.
-*/
-
 import chai from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiSubset from 'chai-subset';
 
 import { rewiremock } from '#test/rewiremock';
-
-import validator from 'validator';
-import actionModel from '#server/models/actionModel';
-import userModel from '#server/models/userModel';
-import mails from '#server/mails/mails';
 import permissionUtils from '#server/utils/permission';
 import { serialized as fakeUser } from '#test/utils/user';
 import { serialized as fakeAction } from '#test/utils/action';
-import { serialized as fakeActionComment, row as fakeActionCommentRow } from '#test/utils/actionComment';
-import ServiceError from '#server/errors/ServiceError';
+import { AuthUser } from '#server/middlewares/authMiddleware';
+
+import actionModel from '#server/models/actionModel';
 import deleteActionComment from './deleteComment';
 
 const { expect } = chai;
 chai.use(sinonChai);
 chai.use(chaiSubset);
 
-// stubs
 const sandbox = sinon.createSandbox();
-// const sequelize = {
-//     transaction: sandbox.stub(),
-// };
-// const transaction = {
-//     commit: sandbox.stub(),
-//     rollback: sandbox.stub(),
-// };
-const deleteComment = sandbox.stub();
+const stubs = {
+    deleteComment: sandbox.stub().resolves(true),
+    fetchCommentsModel: sandbox.stub(),
+    fetchUserModel: sandbox.stub(),
+    canDeleteComment: sandbox.stub(),
+    can: sandbox.stub(permissionUtils, 'can'),
+    do: sandbox.stub(),
+    on: sandbox.stub(),
+};
 
-// const fetchCommentsModel = sandbox.stub();
-// // const uploadAttachments = sandbox.stub();
-// const serializeComment = sandbox.stub();
-// const sendMattermostNotification = sandbox.stub();
-// const sendMailNotifications = sandbox.stub();
-// const enrichCommentsAttachments = sandbox.stub();
-// const scanAttachmentErrors = sandbox.stub();
+stubs.can.returns({
+    do: stubs.do,
+});
+stubs.do.returns({
+    on: stubs.on,
+});
 
-// rewiremock('#db/sequelize').with({ sequelize });
-// rewiremock('#server/models/actionModel/deleteComment/deleteComment').with(deleteCommentModel);
-// rewiremock('#server/models/actionModel/fetchComments/fetchComments').with(fetchCommentsModel); // balek
-// rewiremock('#server/models/actionModel/fetchComments/serializeComment').with(serializeComment); // balek
-// rewiremock('#server/services/attachment/upload').with(uploadAttachments); // balek
-// rewiremock('./createComment.sendMattermostNotification').with(sendMattermostNotification); // balek
-// rewiremock('./createComment.sendMailNotifications').with(sendMailNotifications);
-// rewiremock('./enrichCommentsAttachments').with(enrichCommentsAttachments); // balek
-// rewiremock('#server/services/attachment/scanAttachmentErrors').with(scanAttachmentErrors); // balek
-// import validator from 'validator';
-// import actionModel from '#server/models/actionModel';
-// import userModel from '#server/models/userModel';
-// import mails from '#server/mails/mails';
-// import permissionUtils from '#server/utils/permission';
-// import dateUtils from '#server/utils/date';
-// import ServiceError from '#server/errors/ServiceError';
-// import { Location } from '#server/models/geoModel/Location.d';
-// rewiremock('#server/models/actionModel').with(actionModel);
-// rewiremock('#server/models/userModel').with(userModel);
-// rewiremock('#server/mails/mails').with(mails);
-// rewiremock('#server/utils/permission').with(permissionUtils);
-// rewiremock('#server/utils/date').with(dateUtils);
-// rewiremock('#server/errors/ServiceError').with(ServiceError);
-// rewiremock('#server/models/geoModel/Location').with({ Location });
-rewiremock('#server/models/actionModel/deleteComment/deleteComment').with(deleteComment);
-
-rewiremock.enable();
-// eslint-disable-next-line import/newline-after-import, import/first
-// import deleteActionComment from './deleteComment';
-rewiremock.disable();
+rewiremock('#server/models/actionModel/fetchComments/fetchComments').with(stubs.fetchCommentsModel);
+rewiremock('#server/models/userModel/findOne').with(stubs.fetchUserModel);
+rewiremock('#server/utils/permission').with({ can: stubs.canDeleteComment });
+rewiremock('#server/models/actionModel/deleteComment/deleteComment').with(stubs.deleteComment);
 
 describe('services/action.deleteComment()', () => {
-    // beforeEach(() => {
-    //     sequelize.transaction.resolves(transaction);
-    // });
-    let stubs;
-    const user = { id: 0 };
-    const author = { id: 1 };
-    const shantytownId = 0;
-    const commentId = 0;
-    const comment = fakeActionComment;
-    const deletionMessage = 'deletionMessage';
-    const town = {
-        region: null,
-        departement: null,
-        epci: null,
-        city: 0,
-        comments: [comment],
-    };
-    beforeEach(() => {
-        stubs = {
-            actionModelfetch: sinon.stub(actionModel, 'fetch'),
-            userModelFindOne: sinon.stub(userModel, 'findOne'),
-            userModelGetNationalAdmins: sinon.stub(userModel, 'getNationalAdmins'),
-            can: sinon.stub(permissionUtils, 'can'),
-            do: sinon.stub(),
-            on: sinon.stub(),
-            trim: sinon.stub(validator, 'trim'),
-            sendUserCommentDeletion: sinon.stub(mails, 'sendUserCommentDeletion'),
-        };
-        stubs.can.returns({
-            do: stubs.do,
-        });
-        stubs.do.returns({
-            on: stubs.on,
-        });
+    let user: AuthUser;
 
-        stubs.shantytownModelfindOne.resolves(town);
-        stubs.userModelFindOne.resolves(author);
+    beforeEach(() => {
+        user = fakeUser();
+        user.permissions = {
+            data: {
+                moderate: {
+                    allowed: true,
+                    allowed_on_national: true,
+                    allowed_on: {
+                        regions: [],
+                        departements: [{
+                            type: 'departement',
+                            city: null,
+                            epci: null,
+                            departement: { code: '78', name: 'Yvelines' },
+                            region: { code: '11', name: 'Île-De-France' },
+                        }],
+                        epci: [],
+                        cities: [],
+                        actions: [1],
+                    },
+                },
+            },
+        };
+        sandbox.stub(actionModel, 'fetch').resolves([fakeAction()]);
+        stubs.fetchUserModel.resolves(user);
+        // stubs.canDeleteComment.usingPromise(Boolean).resolves(true);
     });
 
     afterEach(() => {
         sandbox.reset();
     });
 
-    it('supprime le commentaire en base de données', async () => {
-        // fetchCommentsModel.resolves([fakeActionCommentRow()]);
-        console.log('req.user:', 1, 'comment ID:', fakeAction());
-        const action = fakeAction();
-        // console.log(fakeActionComment());
+    it('supprime un commentaire après vérification des droits', async () => {
+        user.id = 1; // Surcharge de l'ID utilisateur pour simuler qu'il est propriétaire du commentaire
+        const commentId = 1;
+        const deletionMessage = 'Test supression message action';
+        stubs.deleteComment.resolves({ id: 1, comments: [] });
+        const result = await deleteActionComment(user, fakeAction().id, commentId, deletionMessage);
 
-        // req.user, req.params.id, req.params.commentId, req.body.message
-        await deleteActionComment(
-            1,
-            action.id,
-            action.comments[0].id,
-            'message de suppression',
-        );
-
-        // expect(createCommentModel).to.have.been.calledOnce;
-        // expect(createCommentModel).to.have.been.calledOnceWith(1, {
-        //     description: 'description',
-        //     created_by: 1,
-        // }, transaction);
-        expect(deleteComment).to.have.been.calledOnceWith(1, 1, 1, 'message de suppression');
+        expect(stubs.can).to.have.been.calledOnceWith(user);
+        expect(stubs.do).to.have.been.calledOnceWith('moderate', 'data');
+        expect(stubs.on).to.have.been.calledOnce;
+        expect(result).to.be.true;
     });
 
-    // it('en cas d\'échec d\'insertion du commentaire, rollback la transaction', async () => {
-    //     createCommentModel.rejects(new Error('fake error'));
-
+    // it('retourne une erreur si la suppression est demandée par un admin sans message de suppression', async () => {
+    //     user.id = 2;
     //     try {
-    //         await createComment(1, fakeAction(), { description: 'description', files: [] });
-    //     } catch (e) {
-    //         // ignore
+    //         await expect(deleteActionComment(user, fakeAction().id, fakeAction().comments[0].id, '')).to.be.rejectedWith(ServiceError, 'data_incomplete');
     //     }
-
-    //     expect(transaction.rollback).to.have.been.calledOnce;
     // });
+    /*
+    it('should send notification email when deleted by non-owner', async () => {
+        // Arrange
+        const user = { id: 2 };
+        const action = { id: 1, comments: [{ id: 1, createdBy: { id: 1 } }] };
 
-    // it('en cas d\'échec d\'insertion du commentaire, lance un ServiceError avec le code insert_failed', async () => {
-    //     const nativeError = new Error('fake error');
-    //     createCommentModel.rejects(nativeError);
+        // Mocks
+        sandbox.stub(actionModel, 'fetch').resolves([fakeAction]);
+        sandbox.stub(userModel, 'findOne').resolves(user);
+        sandbox.stub(permissionUtils, 'can').returns(true);
+        sandbox.stub(deleteComment).resolves();
+        sandbox.stub(mails, 'sendUserCommentDeletion').resolves();
 
-    //     let caughtError;
-    //     try {
-    //         await createComment(1, fakeAction(), { description: 'description', files: [] });
-    //     } catch (error) {
-    //         caughtError = error;
-    //     }
+        // Act
+        await deleteActionComment(user, action.id, 1, 'Test message');
 
-    //     expect(caughtError).to.be.an.instanceOf(ServiceError);
-    //     expect(caughtError.code).to.be.eql('insert_failed');
-    //     expect(caughtError.nativeError).to.be.eql(nativeError);
-    // });
-
-    // it('enregistre les pièces-jointes', async () => {
-    //     createCommentModel.resolves(42);
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-    //     const files = [fakeFile(), fakeFile()];
-    //     await createComment(
-    //         1,
-    //         fakeAction(),
-    //         {
-    //             description: 'description',
-    //             files,
-    //         },
-    //     );
-
-    //     expect(uploadAttachments).to.have.been.calledOnce;
-    //     expect(uploadAttachments).to.have.been.calledOnceWith('action_comment', 42, 1, files, transaction);
-    // });
-
-    // it('ne lance pas d\'erreur si aucune pièce-jointe n\'est fournie', async () => {
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-
-    //     let caughtError;
-    //     try {
-    //         await createComment(
-    //             1,
-    //             fakeAction(),
-    //             {
-    //                 description: 'description',
-    //                 files: [],
-    //             },
-    //         );
-    //     } catch (error) {
-    //         caughtError = error;
-    //     }
-
-    //     expect(caughtError).to.be.eql(undefined);
-    //     expect(uploadAttachments).to.not.have.been.called;
-    // });
-
-    // it('en cas d\'échec d\'enregistrement des pièces-jointes, rollback la transaction', async () => {
-    //     uploadAttachments.rejects(new Error('fake error'));
-
-    //     try {
-    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
-    //     } catch (e) {
-    //         // ignore
-    //     }
-
-    //     expect(transaction.rollback).to.have.been.calledOnce;
-    // });
-
-    // it('en cas d\'échec d\'enregistrement des pièces-jointes, lance un ServiceError avec le code upload_failed', async () => {
-    //     const nativeError = new Error('fake error');
-    //     uploadAttachments.rejects(new Error('fake error'));
-
-    //     let caughtError;
-    //     try {
-    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
-    //     } catch (error) {
-    //         caughtError = error;
-    //     }
-
-    //     expect(caughtError).to.be.an.instanceOf(ServiceError);
-    //     expect(caughtError.code).to.be.eql('upload_failed');
-    //     expect(caughtError.nativeError).to.be.eql(nativeError);
-    // });
-
-    // it('commit la transaction une fois toutes les requêtes effectuées', async () => {
-    //     createCommentModel.resolves(42);
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-    //     await createComment(
-    //         1,
-    //         fakeAction(),
-    //         {
-    //             description: 'description',
-    //             files: [],
-    //         },
-    //     );
-
-    //     expect(transaction.commit).to.have.been.calledOnce;
-    //     expect(transaction.commit).to.have.been.calledAfter(fetchCommentsModel);
-    // });
-
-    // it('en cas d\'échec dans le fetch des commentaires, rollback la transaction', async () => {
-    //     fetchCommentsModel.rejects(new Error('fake error'));
-
-    //     try {
-    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
-    //     } catch (e) {
-    //         // ignore
-    //     }
-
-    //     expect(transaction.rollback).to.have.been.calledOnce;
-    // });
-
-    // it('en cas d\'échec dans le fetch des commentaires, lance un ServiceError avec le code commit_failed', async () => {
-    //     const nativeError = new Error('fake error');
-    //     fetchCommentsModel.rejects(new Error('fake error'));
-
-    //     let caughtError;
-    //     try {
-    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
-    //     } catch (error) {
-    //         caughtError = error;
-    //     }
-
-    //     expect(caughtError).to.be.an.instanceOf(ServiceError);
-    //     expect(caughtError.code).to.be.eql('commit_failed');
-    //     expect(caughtError.nativeError).to.be.eql(nativeError);
-    // });
-
-    // it('en cas d\'échec de commit, rollback la transaction', async () => {
-    //     transaction.commit.rejects(new Error('fake error'));
-
-    //     try {
-    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
-    //     } catch (e) {
-    //         // ignore
-    //     }
-
-    //     expect(transaction.rollback).to.have.been.calledOnce;
-    // });
-
-    // it('en cas d\'échec de commit, lance un ServiceError avec le code commit_failed', async () => {
-    //     const nativeError = new Error('fake error');
-    //     transaction.commit.rejects(new Error('fake error'));
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-
-    //     let caughtError;
-    //     try {
-    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
-    //     } catch (error) {
-    //         caughtError = error;
-    //     }
-
-    //     expect(caughtError).to.be.an.instanceOf(ServiceError);
-    //     expect(caughtError.code).to.be.eql('commit_failed');
-    //     expect(caughtError.nativeError).to.be.eql(nativeError);
-    // });
-
-    // it('envoie une notification mattermost', async () => {
-    //     const action = fakeAction();
-    //     const comment = fakeActionComment();
-    //     serializeComment.returns(comment);
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-
-    //     await createComment(
-    //         1,
-    //         action,
-    //         {
-    //             description: 'description',
-    //             files: [],
-    //         },
-    //     );
-
-    //     expect(sendMattermostNotification).to.have.been.calledOnce;
-    //     expect(sendMattermostNotification).to.have.been.calledOnceWith(
-    //         action,
-    //         comment,
-    //     );
-    // });
-
-    // it('ne lance pas d\'erreur en cas d\'échec d\'envoi de la notification mattermost', async () => {
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-    //     sendMattermostNotification.rejects(new Error('fake error'));
-
-    //     let caughtError;
-    //     try {
-    //         await createComment(
-    //             1,
-    //             fakeAction(),
-    //             {
-    //                 description: 'description',
-    //                 files: [],
-    //             },
-    //         );
-    //     } catch (error) {
-    //         caughtError = error;
-    //     }
-
-    //     expect(caughtError).to.be.eql(undefined);
-    // });
-
-    // it('envoie une notification mail aux personnes concernées', async () => {
-    //     const action = fakeAction();
-    //     const comment = fakeActionComment();
-    //     serializeComment.returns(comment);
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-
-    //     await createComment(
-    //         1,
-    //         action,
-    //         {
-    //             description: 'description',
-    //             files: [],
-    //         },
-    //     );
-
-    //     expect(sendMailNotifications).to.have.been.calledOnce;
-    //     expect(sendMailNotifications).to.have.been.calledOnceWith(
-    //         action,
-    //         comment,
-    //     );
-    // });
-    // it('ne lance pas d\'erreur en cas d\'échec d\'envoi de la notification mail', async () => {
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-    //     sendMailNotifications.rejects(new Error('fake error'));
-
-    //     let caughtError;
-    //     try {
-    //         await createComment(
-    //             1,
-    //             fakeAction(),
-    //             {
-    //                 description: 'description',
-    //                 files: [],
-    //             },
-    //         );
-    //     } catch (error) {
-    //         caughtError = error;
-    //     }
-
-    //     expect(caughtError).to.be.eql(undefined);
-    // });
-
-    // it('retourne le commentaire fraîchement créé', async () => {
-    //     const comment = fakeActionComment();
-    //     serializeComment.returns(comment);
-    //     enrichCommentsAttachments.resolves(comment);
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-
-    //     const response = await createComment(
-    //         1,
-    //         fakeAction(),
-    //         {
-    //             description: 'description',
-    //             files: [],
-    //         },
-    //     );
-
-    //     expect(enrichCommentsAttachments).to.have.been.calledOnce;
-    //     expect(response).to.be.an('object');
-    //     expect(response).to.have.property('comment');
-    //     expect(response.comment).to.be.eql(comment);
-    // });
-
-    // it('retourne le nombre de personnes notifiées par mail', async () => {
-    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
-    //     sendMailNotifications.resolves(42);
-
-    //     const response = await createComment(
-    //         1,
-    //         fakeAction(),
-    //         {
-    //             description: 'description',
-    //             files: [],
-    //         },
-    //     );
-
-    //     expect(response).to.be.an('object');
-    //     expect(response).to.have.property('numberOfObservers');
-    //     expect(response.numberOfObservers).to.be.eql(42);
-    // });
+        // Assert
+        expect(mails.sendUserCommentDeletion).to.have.been.calledOnce;
+    });
+    it('should throw permission error when user lacks permission', async () => {
+        fetchCommentsModel.resolves([fakeActionComment]);
+        fetchUserModel.resolves(fakeUser);
+        canDeleteComment.usingPromise(Boolean).resolves(true);
+        expect(canDeleteComment).to.have.been.calledOnceWith(fakeUser);
+        expect(stubs.do).to.have.been.calledOnceWith('moderate', 'data');
+        // eslint-disable-next-line no-unused-expressions
+        expect(stubs.on).to.have.been.calledOnce;
+        // Act & Assert
+        await expect(deleteActionComment(user, action.id, 1, 'Test message')).to.be.rejectedWith(ServiceError, 'permission_denied');
+    });
+    */
 });

--- a/packages/api/server/services/action/deleteComment.spec.ts
+++ b/packages/api/server/services/action/deleteComment.spec.ts
@@ -20,7 +20,6 @@ const stubs = {
     fetchCommentsModel: sandbox.stub(),
     fetchAction: sandbox.stub(),
     userModel: { findOne: sandbox.stub(), getNationalAdmins: sandbox.stub() },
-    fetchUserModel: sandbox.stub(),
     canDeleteComment: sandbox.stub(),
     enrichCommentsAttachments: sandbox.stub().resolves([]),
     validator: {
@@ -83,7 +82,6 @@ describe('services/action.deleteComment()', () => {
             },
         };
 
-        stubs.fetchUserModel.resolves(user);
         stubs.userModel.findOne.resolves(user);
         stubs.fetchAction.resolves([fakeAction()]);
         stubs.can.returns({

--- a/packages/api/server/services/action/deleteComment.spec.ts
+++ b/packages/api/server/services/action/deleteComment.spec.ts
@@ -39,7 +39,6 @@ const stubs = {
 
 rewiremock('#server/models/actionModel').with({
     fetch: stubs.fetchAction,
-    fetchComments: sandbox.stub().resolves([]),
 });
 rewiremock('#server/mails/mails').with(stubs.mails);
 rewiremock('#server/models/userModel').with(stubs.userModel);

--- a/packages/api/server/services/action/deleteComment.spec.ts
+++ b/packages/api/server/services/action/deleteComment.spec.ts
@@ -1,0 +1,438 @@
+/*
+Tests à effectuer:
+- Vérifier que la suppression d'un commentaire fonctionne correctement.
+- Vérifier que la suppression d'un commentaire sans message de suppression renvoie une erreur.
+- Vérifier que la suppression d'un commentaire par un utilisateur non propriétaire envoie un email de notification.
+- Vérifier que la suppression d'un commentaire par un utilisateur propriétaire ne nécessite pas de message de suppression.
+- Vérifier que la suppression d'un commentaire par un utilisateur sans permission renvoie une erreur de permission.
+*/
+
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiSubset from 'chai-subset';
+
+import { rewiremock } from '#test/rewiremock';
+
+import validator from 'validator';
+import actionModel from '#server/models/actionModel';
+import userModel from '#server/models/userModel';
+import mails from '#server/mails/mails';
+import permissionUtils from '#server/utils/permission';
+import { serialized as fakeUser } from '#test/utils/user';
+import { serialized as fakeAction } from '#test/utils/action';
+import { serialized as fakeActionComment, row as fakeActionCommentRow } from '#test/utils/actionComment';
+import ServiceError from '#server/errors/ServiceError';
+import deleteActionComment from './deleteComment';
+
+const { expect } = chai;
+chai.use(sinonChai);
+chai.use(chaiSubset);
+
+// stubs
+const sandbox = sinon.createSandbox();
+// const sequelize = {
+//     transaction: sandbox.stub(),
+// };
+// const transaction = {
+//     commit: sandbox.stub(),
+//     rollback: sandbox.stub(),
+// };
+const deleteComment = sandbox.stub();
+
+// const fetchCommentsModel = sandbox.stub();
+// // const uploadAttachments = sandbox.stub();
+// const serializeComment = sandbox.stub();
+// const sendMattermostNotification = sandbox.stub();
+// const sendMailNotifications = sandbox.stub();
+// const enrichCommentsAttachments = sandbox.stub();
+// const scanAttachmentErrors = sandbox.stub();
+
+// rewiremock('#db/sequelize').with({ sequelize });
+// rewiremock('#server/models/actionModel/deleteComment/deleteComment').with(deleteCommentModel);
+// rewiremock('#server/models/actionModel/fetchComments/fetchComments').with(fetchCommentsModel); // balek
+// rewiremock('#server/models/actionModel/fetchComments/serializeComment').with(serializeComment); // balek
+// rewiremock('#server/services/attachment/upload').with(uploadAttachments); // balek
+// rewiremock('./createComment.sendMattermostNotification').with(sendMattermostNotification); // balek
+// rewiremock('./createComment.sendMailNotifications').with(sendMailNotifications);
+// rewiremock('./enrichCommentsAttachments').with(enrichCommentsAttachments); // balek
+// rewiremock('#server/services/attachment/scanAttachmentErrors').with(scanAttachmentErrors); // balek
+// import validator from 'validator';
+// import actionModel from '#server/models/actionModel';
+// import userModel from '#server/models/userModel';
+// import mails from '#server/mails/mails';
+// import permissionUtils from '#server/utils/permission';
+// import dateUtils from '#server/utils/date';
+// import ServiceError from '#server/errors/ServiceError';
+// import { Location } from '#server/models/geoModel/Location.d';
+// rewiremock('#server/models/actionModel').with(actionModel);
+// rewiremock('#server/models/userModel').with(userModel);
+// rewiremock('#server/mails/mails').with(mails);
+// rewiremock('#server/utils/permission').with(permissionUtils);
+// rewiremock('#server/utils/date').with(dateUtils);
+// rewiremock('#server/errors/ServiceError').with(ServiceError);
+// rewiremock('#server/models/geoModel/Location').with({ Location });
+rewiremock('#server/models/actionModel/deleteComment/deleteComment').with(deleteComment);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+// import deleteActionComment from './deleteComment';
+rewiremock.disable();
+
+describe('services/action.deleteComment()', () => {
+    // beforeEach(() => {
+    //     sequelize.transaction.resolves(transaction);
+    // });
+    let stubs;
+    const user = { id: 0 };
+    const author = { id: 1 };
+    const shantytownId = 0;
+    const commentId = 0;
+    const comment = fakeActionComment;
+    const deletionMessage = 'deletionMessage';
+    const town = {
+        region: null,
+        departement: null,
+        epci: null,
+        city: 0,
+        comments: [comment],
+    };
+    beforeEach(() => {
+        stubs = {
+            actionModelfetch: sinon.stub(actionModel, 'fetch'),
+            userModelFindOne: sinon.stub(userModel, 'findOne'),
+            userModelGetNationalAdmins: sinon.stub(userModel, 'getNationalAdmins'),
+            can: sinon.stub(permissionUtils, 'can'),
+            do: sinon.stub(),
+            on: sinon.stub(),
+            trim: sinon.stub(validator, 'trim'),
+            sendUserCommentDeletion: sinon.stub(mails, 'sendUserCommentDeletion'),
+        };
+        stubs.can.returns({
+            do: stubs.do,
+        });
+        stubs.do.returns({
+            on: stubs.on,
+        });
+
+        stubs.shantytownModelfindOne.resolves(town);
+        stubs.userModelFindOne.resolves(author);
+    });
+
+    afterEach(() => {
+        sandbox.reset();
+    });
+
+    it('supprime le commentaire en base de données', async () => {
+        // fetchCommentsModel.resolves([fakeActionCommentRow()]);
+        console.log('req.user:', 1, 'comment ID:', fakeAction());
+        const action = fakeAction();
+        // console.log(fakeActionComment());
+
+        // req.user, req.params.id, req.params.commentId, req.body.message
+        await deleteActionComment(
+            1,
+            action.id,
+            action.comments[0].id,
+            'message de suppression',
+        );
+
+        // expect(createCommentModel).to.have.been.calledOnce;
+        // expect(createCommentModel).to.have.been.calledOnceWith(1, {
+        //     description: 'description',
+        //     created_by: 1,
+        // }, transaction);
+        expect(deleteComment).to.have.been.calledOnceWith(1, 1, 1, 'message de suppression');
+    });
+
+    // it('en cas d\'échec d\'insertion du commentaire, rollback la transaction', async () => {
+    //     createCommentModel.rejects(new Error('fake error'));
+
+    //     try {
+    //         await createComment(1, fakeAction(), { description: 'description', files: [] });
+    //     } catch (e) {
+    //         // ignore
+    //     }
+
+    //     expect(transaction.rollback).to.have.been.calledOnce;
+    // });
+
+    // it('en cas d\'échec d\'insertion du commentaire, lance un ServiceError avec le code insert_failed', async () => {
+    //     const nativeError = new Error('fake error');
+    //     createCommentModel.rejects(nativeError);
+
+    //     let caughtError;
+    //     try {
+    //         await createComment(1, fakeAction(), { description: 'description', files: [] });
+    //     } catch (error) {
+    //         caughtError = error;
+    //     }
+
+    //     expect(caughtError).to.be.an.instanceOf(ServiceError);
+    //     expect(caughtError.code).to.be.eql('insert_failed');
+    //     expect(caughtError.nativeError).to.be.eql(nativeError);
+    // });
+
+    // it('enregistre les pièces-jointes', async () => {
+    //     createCommentModel.resolves(42);
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+    //     const files = [fakeFile(), fakeFile()];
+    //     await createComment(
+    //         1,
+    //         fakeAction(),
+    //         {
+    //             description: 'description',
+    //             files,
+    //         },
+    //     );
+
+    //     expect(uploadAttachments).to.have.been.calledOnce;
+    //     expect(uploadAttachments).to.have.been.calledOnceWith('action_comment', 42, 1, files, transaction);
+    // });
+
+    // it('ne lance pas d\'erreur si aucune pièce-jointe n\'est fournie', async () => {
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+
+    //     let caughtError;
+    //     try {
+    //         await createComment(
+    //             1,
+    //             fakeAction(),
+    //             {
+    //                 description: 'description',
+    //                 files: [],
+    //             },
+    //         );
+    //     } catch (error) {
+    //         caughtError = error;
+    //     }
+
+    //     expect(caughtError).to.be.eql(undefined);
+    //     expect(uploadAttachments).to.not.have.been.called;
+    // });
+
+    // it('en cas d\'échec d\'enregistrement des pièces-jointes, rollback la transaction', async () => {
+    //     uploadAttachments.rejects(new Error('fake error'));
+
+    //     try {
+    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
+    //     } catch (e) {
+    //         // ignore
+    //     }
+
+    //     expect(transaction.rollback).to.have.been.calledOnce;
+    // });
+
+    // it('en cas d\'échec d\'enregistrement des pièces-jointes, lance un ServiceError avec le code upload_failed', async () => {
+    //     const nativeError = new Error('fake error');
+    //     uploadAttachments.rejects(new Error('fake error'));
+
+    //     let caughtError;
+    //     try {
+    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
+    //     } catch (error) {
+    //         caughtError = error;
+    //     }
+
+    //     expect(caughtError).to.be.an.instanceOf(ServiceError);
+    //     expect(caughtError.code).to.be.eql('upload_failed');
+    //     expect(caughtError.nativeError).to.be.eql(nativeError);
+    // });
+
+    // it('commit la transaction une fois toutes les requêtes effectuées', async () => {
+    //     createCommentModel.resolves(42);
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+    //     await createComment(
+    //         1,
+    //         fakeAction(),
+    //         {
+    //             description: 'description',
+    //             files: [],
+    //         },
+    //     );
+
+    //     expect(transaction.commit).to.have.been.calledOnce;
+    //     expect(transaction.commit).to.have.been.calledAfter(fetchCommentsModel);
+    // });
+
+    // it('en cas d\'échec dans le fetch des commentaires, rollback la transaction', async () => {
+    //     fetchCommentsModel.rejects(new Error('fake error'));
+
+    //     try {
+    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
+    //     } catch (e) {
+    //         // ignore
+    //     }
+
+    //     expect(transaction.rollback).to.have.been.calledOnce;
+    // });
+
+    // it('en cas d\'échec dans le fetch des commentaires, lance un ServiceError avec le code commit_failed', async () => {
+    //     const nativeError = new Error('fake error');
+    //     fetchCommentsModel.rejects(new Error('fake error'));
+
+    //     let caughtError;
+    //     try {
+    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
+    //     } catch (error) {
+    //         caughtError = error;
+    //     }
+
+    //     expect(caughtError).to.be.an.instanceOf(ServiceError);
+    //     expect(caughtError.code).to.be.eql('commit_failed');
+    //     expect(caughtError.nativeError).to.be.eql(nativeError);
+    // });
+
+    // it('en cas d\'échec de commit, rollback la transaction', async () => {
+    //     transaction.commit.rejects(new Error('fake error'));
+
+    //     try {
+    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
+    //     } catch (e) {
+    //         // ignore
+    //     }
+
+    //     expect(transaction.rollback).to.have.been.calledOnce;
+    // });
+
+    // it('en cas d\'échec de commit, lance un ServiceError avec le code commit_failed', async () => {
+    //     const nativeError = new Error('fake error');
+    //     transaction.commit.rejects(new Error('fake error'));
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+
+    //     let caughtError;
+    //     try {
+    //         await createComment(1, fakeAction(), { description: 'description', files: [fakeFile()] });
+    //     } catch (error) {
+    //         caughtError = error;
+    //     }
+
+    //     expect(caughtError).to.be.an.instanceOf(ServiceError);
+    //     expect(caughtError.code).to.be.eql('commit_failed');
+    //     expect(caughtError.nativeError).to.be.eql(nativeError);
+    // });
+
+    // it('envoie une notification mattermost', async () => {
+    //     const action = fakeAction();
+    //     const comment = fakeActionComment();
+    //     serializeComment.returns(comment);
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+
+    //     await createComment(
+    //         1,
+    //         action,
+    //         {
+    //             description: 'description',
+    //             files: [],
+    //         },
+    //     );
+
+    //     expect(sendMattermostNotification).to.have.been.calledOnce;
+    //     expect(sendMattermostNotification).to.have.been.calledOnceWith(
+    //         action,
+    //         comment,
+    //     );
+    // });
+
+    // it('ne lance pas d\'erreur en cas d\'échec d\'envoi de la notification mattermost', async () => {
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+    //     sendMattermostNotification.rejects(new Error('fake error'));
+
+    //     let caughtError;
+    //     try {
+    //         await createComment(
+    //             1,
+    //             fakeAction(),
+    //             {
+    //                 description: 'description',
+    //                 files: [],
+    //             },
+    //         );
+    //     } catch (error) {
+    //         caughtError = error;
+    //     }
+
+    //     expect(caughtError).to.be.eql(undefined);
+    // });
+
+    // it('envoie une notification mail aux personnes concernées', async () => {
+    //     const action = fakeAction();
+    //     const comment = fakeActionComment();
+    //     serializeComment.returns(comment);
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+
+    //     await createComment(
+    //         1,
+    //         action,
+    //         {
+    //             description: 'description',
+    //             files: [],
+    //         },
+    //     );
+
+    //     expect(sendMailNotifications).to.have.been.calledOnce;
+    //     expect(sendMailNotifications).to.have.been.calledOnceWith(
+    //         action,
+    //         comment,
+    //     );
+    // });
+    // it('ne lance pas d\'erreur en cas d\'échec d\'envoi de la notification mail', async () => {
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+    //     sendMailNotifications.rejects(new Error('fake error'));
+
+    //     let caughtError;
+    //     try {
+    //         await createComment(
+    //             1,
+    //             fakeAction(),
+    //             {
+    //                 description: 'description',
+    //                 files: [],
+    //             },
+    //         );
+    //     } catch (error) {
+    //         caughtError = error;
+    //     }
+
+    //     expect(caughtError).to.be.eql(undefined);
+    // });
+
+    // it('retourne le commentaire fraîchement créé', async () => {
+    //     const comment = fakeActionComment();
+    //     serializeComment.returns(comment);
+    //     enrichCommentsAttachments.resolves(comment);
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+
+    //     const response = await createComment(
+    //         1,
+    //         fakeAction(),
+    //         {
+    //             description: 'description',
+    //             files: [],
+    //         },
+    //     );
+
+    //     expect(enrichCommentsAttachments).to.have.been.calledOnce;
+    //     expect(response).to.be.an('object');
+    //     expect(response).to.have.property('comment');
+    //     expect(response.comment).to.be.eql(comment);
+    // });
+
+    // it('retourne le nombre de personnes notifiées par mail', async () => {
+    //     fetchCommentsModel.resolves([fakeActionCommentRow()]);
+    //     sendMailNotifications.resolves(42);
+
+    //     const response = await createComment(
+    //         1,
+    //         fakeAction(),
+    //         {
+    //             description: 'description',
+    //             files: [],
+    //         },
+    //     );
+
+    //     expect(response).to.be.an('object');
+    //     expect(response).to.have.property('numberOfObservers');
+    //     expect(response.numberOfObservers).to.be.eql(42);
+    // });
+});

--- a/packages/api/server/services/action/deleteComment.spec.ts
+++ b/packages/api/server/services/action/deleteComment.spec.ts
@@ -108,7 +108,6 @@ describe('services/action.deleteComment()', () => {
         }
         expect(stubs.can).to.have.been.calledOnceWith(fakeTestUser);
         expect(stubs.do).to.have.been.calledOnceWith('moderate', 'data');
-        // eslint-disable-next-line no-unused-expressions
         expect(stubs.on).to.have.been.calledOnce;
     });
 

--- a/packages/api/server/services/action/deleteComment.ts
+++ b/packages/api/server/services/action/deleteComment.ts
@@ -15,7 +15,7 @@ import enrichCommentsAttachments from './enrichCommentsAttachments';
 
 const { fromTsToFormat: tsToString } = dateUtils;
 
-export default async (user, actionId, commentId, deletionMessage) => {
+export default async (user, actionId, commentId, deletionMessage): Promise<{ comments: ActionEnrichedComment[] }> => {
     let actions: Action[];
     try {
         actions = await actionModel.fetch(user, [actionId]);

--- a/packages/api/server/services/action/deleteComment.ts
+++ b/packages/api/server/services/action/deleteComment.ts
@@ -48,7 +48,7 @@ export default async (user, actionId, commentId, deletionMessage) => {
 
     let message: string;
     if (!isOwner) {
-        message = validator.trim(deletionMessage || '');
+        message = validator.trim(deletionMessage ?? '');
         if (message === '') {
             throw new ServiceError('data_incomplete', new Error('Vous devez préciser le motif de suppression du commentaire'));
         }

--- a/packages/api/server/services/action/deleteComment.ts
+++ b/packages/api/server/services/action/deleteComment.ts
@@ -90,7 +90,8 @@ export default async (user, actionId, commentId, deletionMessage) => {
             }
         }
     } catch (error) {
-        // ignore
+        // eslint-disable-next-line no-console
+        console.log(error);
     }
 
     return true;

--- a/packages/api/server/services/action/deleteComment.ts
+++ b/packages/api/server/services/action/deleteComment.ts
@@ -1,0 +1,92 @@
+import validator from 'validator';
+import actionModel from '#server/models/actionModel';
+import userModel from '#server/models/userModel';
+import mails from '#server/mails/mails';
+import permissionUtils from '#server/utils/permission';
+import dateUtils from '#server/utils/date';
+import ServiceError from '#server/errors/ServiceError';
+import { Location } from '#server/models/geoModel/Location.d';
+import deleteComment from '#server/models/actionModel/deleteComment/deleteComment';
+
+const { fromTsToFormat: tsToString } = dateUtils;
+
+export default async (user, actionId, commentId, deletionMessage) => {
+    let action;
+    try {
+        action = await actionModel.fetch(user, actionId);
+    } catch (error) {
+        throw new ServiceError('fetch_failed', error);
+    }
+
+    const comment = action[0].comments.find(({ id }) => id === parseInt(commentId, 10));
+
+    if (comment === undefined) {
+        throw new ServiceError('fetch_failed', new Error('Le commentaire à supprimer n\'a pas été retrouvé en base de données'));
+    }
+    let author;
+    try {
+        author = await userModel.findOne(comment.createdBy.id);
+    } catch (error) {
+        throw new ServiceError('fetch_failed', error);
+    }
+    const location: Location = {
+        type: 'city',
+        region: action.region,
+        departement: action.departement,
+        epci: action.epci,
+        city: action.city,
+    };
+
+    const isOwner = author.id === user.id;
+    if (!isOwner && !permissionUtils.can(user).do('moderate', 'data').on(location)) {
+        throw new ServiceError('permission_denied', new Error('Vous n\'avez pas accès à ces données'));
+    }
+
+    let message;
+    if (!isOwner) {
+        message = validator.trim(deletionMessage || '');
+        if (message === '') {
+            throw new ServiceError('data_incomplete', new Error('Vous devez préciser le motif de suppression du commentaire'));
+        }
+    }
+
+    try {
+        await deleteComment(commentId);
+    } catch (error) {
+        throw new ServiceError('delete_failed', error);
+    }
+
+    try {
+        if (!isOwner) {
+            const nationalAdmins = await userModel.getNationalAdmins();
+            const mailVariables = {
+                town: {
+                    usename: action.usename,
+                    city: {
+                        name: action.city.name,
+                    },
+                },
+                comment: {
+                    description: comment.description,
+                    created_at: tsToString(comment.createdAt, 'd/m/Y'),
+                },
+                message,
+            };
+            if (author.status === 'active') {
+                await mails.sendUserCommentDeletion(author, {
+                    variables: mailVariables,
+                    bcc: nationalAdmins,
+                });
+            } else {
+                await Promise.all(nationalAdmins.map(nationalAdmin => mails.sendAdminCommentDeletion(nationalAdmin, {
+                    variables: mailVariables,
+                    preserveRecipient: false,
+                })));
+            }
+        }
+    } catch (error) {
+        // ignore
+    }
+
+    return true;
+};

--- a/packages/api/server/services/question/findOne.spec.ts
+++ b/packages/api/server/services/question/findOne.spec.ts
@@ -6,7 +6,6 @@ import { rewiremock } from '#test/rewiremock';
 import { serialized as serializedQuestion } from '#test/utils/question';
 import { serialized as fakeUser } from '#test/utils/userSimplified';
 import ServiceError from '#server/errors/ServiceError';
-import findOne from './findOne';
 
 const { expect } = chai;
 chai.use(sinonChai);
@@ -17,6 +16,11 @@ const sandbox = sinon.createSandbox();
 const enrichQuestion = sandbox.stub();
 
 rewiremock('#server/services/question/common/enrichQuestion').withDefault(enrichQuestion);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import findOne from './findOne';
+rewiremock.disable();
 
 const question = serializedQuestion({
     answers: [

--- a/packages/api/server/services/shantytown/deleteComment.ts
+++ b/packages/api/server/services/shantytown/deleteComment.ts
@@ -58,10 +58,11 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
     try {
         if (!isOwner) {
             const nationalAdmins = await userModel.getNationalAdmins();
-            const mailVariables = {
-                town: {
-                    usename: town.usename,
-                    city: {
+            const mailVariables: { [key: string]: any } = {
+                entity: {
+                    type: 'le site',
+                    name: town.usename,
+                    location: {
                         name: town.city.name,
                     },
                 },
@@ -84,7 +85,8 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
             }
         }
     } catch (error) {
-        // ignore
+        // eslint-disable-next-line no-console
+        console.log(error);
     }
 
     // on retourne la liste mise à jour des commentaires du site
@@ -94,7 +96,8 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
         const rawComments = town.comments.filter(({ id }) => id !== parseInt(commentId, 10));
         commentsWithEnrichedAttachments = await Promise.all(rawComments.map(async rawComment => enrichCommentsAttachments(rawComment)));
     } catch (error) {
-        // ignore
+        // eslint-disable-next-line no-console
+        console.log(error);
     }
 
     return {

--- a/packages/api/server/services/shantytown/deleteComment.ts
+++ b/packages/api/server/services/shantytown/deleteComment.ts
@@ -92,7 +92,6 @@ export default async (user, shantytownId, commentId, deletionMessage) => {
     // on retourne la liste mise à jour des commentaires du site
     let commentsWithEnrichedAttachments = [];
     try {
-        // comments = await shantytownModel.getComments(author, [shantytown.id]);
         const rawComments = town.comments.filter(({ id }) => id !== parseInt(commentId, 10));
         commentsWithEnrichedAttachments = await Promise.all(rawComments.map(async rawComment => enrichCommentsAttachments(rawComment)));
     } catch (error) {

--- a/packages/api/test/utils/action.ts
+++ b/packages/api/test/utils/action.ts
@@ -75,7 +75,21 @@ export function serialized(override = {}): Action {
             },
         ],
         metrics: [],
-        comments: [],
+        comments: [
+            {
+                attachments: [],
+                createdAt: (new Date(2022, 0, 1)).getTime(),
+                createdBy: {
+                    id: 1,
+                    first_name: 'Jean',
+                    last_name: 'Dupont',
+                    organization: 'structure',
+                    organization_id: 1,
+                },
+                description: 'Un commentaire',
+                id: 1,
+            },
+        ],
         created_at: (new Date(2022, 0, 1)).getTime(),
         created_by: {
             id: 1,

--- a/packages/frontend/ui/src/composables/useFocusTrap.js
+++ b/packages/frontend/ui/src/composables/useFocusTrap.js
@@ -7,6 +7,7 @@ const useFocusTrap = () => {
     let focusableElements = [];
     let $firstFocusable;
     let $lastFocusable;
+    let hasFocused = false;
     const trapRef = customRef((track, trigger) => {
         let $trapEl = null;
         return {
@@ -51,7 +52,12 @@ const useFocusTrap = () => {
         $firstFocusable = focusableElements[0];
         $lastFocusable = focusableElements[focusableElements.length - 1];
         document.addEventListener("keydown", keyHandler);
-        $firstFocusable.focus();
+
+        // Si aucun focus n'a été initialisé, on focus le premier élément
+        if (!hasFocused && $firstFocusable) {
+            $firstFocusable.focus();
+            hasFocused = true;
+        }
     }
 
     function clearFocusTrap() {

--- a/packages/frontend/webapp/src/api/actions.api.js
+++ b/packages/frontend/webapp/src/api/actions.api.js
@@ -17,6 +17,15 @@ export function addComment(actionId, comment, attachments) {
     });
 }
 
+export function deleteComment(actionId, commentId, message) {
+    return axios.delete(
+        `/actions/${encodeURI(actionId)}/comments/${encodeURI(commentId)}`,
+        {
+            data: { message },
+        }
+    );
+}
+
 export function create(data) {
     return axios.post(`/actions`, data);
 }

--- a/packages/frontend/webapp/src/components/CarteCommentaire/CarteCommentaireAction.vue
+++ b/packages/frontend/webapp/src/components/CarteCommentaire/CarteCommentaireAction.vue
@@ -2,7 +2,9 @@
     <CarteCommentaire
         :id="`message${comment.id}`"
         :comment="comment"
+        showModeration
         allowAttachmentDeletion
+        @moderate="openModerationModal"
         @deleteAttachment="onDeleteAttachment"
     />
 </template>
@@ -10,7 +12,9 @@
 <script setup>
 import { toRefs } from "vue";
 import CarteCommentaire from "./CarteCommentaire.vue";
+import ModaleModerationCommentaire from "@/components/ModaleModerationCommentaire/ModaleModerationCommentaire.vue";
 import { useAttachmentsStore } from "@/stores/attachments.store";
+import { useModaleStore } from "@/stores/modale.store";
 
 const props = defineProps({
     actionId: {
@@ -23,6 +27,14 @@ const props = defineProps({
     },
 });
 const { actionId, comment } = toRefs(props);
+
+function openModerationModal() {
+    const modaleStore = useModaleStore();
+    modaleStore.open(ModaleModerationCommentaire, {
+        comment: { ...comment.value, actionId: actionId.value },
+        commentType: "action",
+    });
+}
 
 // on définit la méthode pour supprimer un attachment
 function onDeleteAttachment(file) {

--- a/packages/frontend/webapp/src/components/CarteCommentaire/CarteCommentaireSite.vue
+++ b/packages/frontend/webapp/src/components/CarteCommentaire/CarteCommentaireSite.vue
@@ -30,7 +30,10 @@ const { townId, comment } = toRefs(props);
 
 function openModerationModal() {
     const modaleStore = useModaleStore();
-    modaleStore.open(ModaleModerationCommentaire, { comment: comment.value });
+    modaleStore.open(ModaleModerationCommentaire, {
+        comment: comment.value,
+        commentType: "shantytown",
+    });
 }
 
 function onDeleteAttachment(file) {

--- a/packages/frontend/webapp/src/components/ModaleModerationCommentaire/ModaleModerationCommentaire.vue
+++ b/packages/frontend/webapp/src/components/ModaleModerationCommentaire/ModaleModerationCommentaire.vue
@@ -20,7 +20,10 @@
         </template>
 
         <template v-slot:footer>
-            <Button variant="primaryText" @click="() => modale.close()"
+            <Button
+                variant="primaryText"
+                class="!border-2 !border-primary hover:!bg-primaryDark hover:!text-white"
+                @click="() => modale.close()"
                 >Annuler</Button
             >
             <Button class="ml-5" :loading="loading" @click="remove"
@@ -35,7 +38,7 @@ import { defineProps, toRefs, ref, computed } from "vue";
 import { useUserStore } from "@/stores/user.store";
 import { useNotificationStore } from "@/stores/notification.store";
 import { useTownsStore } from "@/stores/towns.store";
-import { useActionsStore } from "@/stores/actions.store"; // Assuming this store exists for action comments
+import { useActionsStore } from "@/stores/actions.store";
 import {
     Button,
     ErrorSummary,
@@ -66,17 +69,17 @@ const isOwner = computed(() => {
     return comment.value.createdBy.id === userStore.user.id;
 });
 
-function reset() {
+const reset = () => {
     loading.value = false;
     error.value = null;
     reason.value = "";
-}
+};
 
-function onClose() {
+const onClose = () => {
     reset();
-}
+};
 
-async function remove() {
+const remove = async () => {
     if (loading.value === true) {
         return;
     }
@@ -86,14 +89,15 @@ async function remove() {
 
     try {
         const notificationStore = useNotificationStore();
-        const selectedStore =
-            commentType.value === "shantytown"
-                ? useTownsStore()
-                : useActionsStore();
-        const sourceId =
-            commentType.value === "shantytown"
-                ? comment.value.shantytown
-                : comment.value.actionId;
+        let selectedStore;
+        let sourceId;
+        if (commentType.value === "shantytown") {
+            selectedStore = useTownsStore();
+            sourceId = comment.value.shantytown;
+        } else {
+            selectedStore = useActionsStore();
+            sourceId = comment.value.actionId;
+        }
 
         await selectedStore.deleteComment(
             sourceId,
@@ -113,5 +117,10 @@ async function remove() {
     }
 
     loading.value = false;
-}
+};
 </script>
+<style scoped>
+button {
+    border: inherit;
+}
+</style>

--- a/packages/frontend/webapp/src/components/ModaleModerationCommentaire/ModaleModerationCommentaire.vue
+++ b/packages/frontend/webapp/src/components/ModaleModerationCommentaire/ModaleModerationCommentaire.vue
@@ -35,6 +35,7 @@ import { defineProps, toRefs, ref, computed } from "vue";
 import { useUserStore } from "@/stores/user.store";
 import { useNotificationStore } from "@/stores/notification.store";
 import { useTownsStore } from "@/stores/towns.store";
+import { useActionsStore } from "@/stores/actions.store"; // Assuming this store exists for action comments
 import {
     Button,
     ErrorSummary,
@@ -48,8 +49,12 @@ const props = defineProps({
     comment: {
         type: Object,
     },
+    commentType: {
+        type: String,
+        default: "shantytown",
+    },
 });
-const { comment } = toRefs(props);
+const { comment, commentType } = toRefs(props);
 
 const modale = ref(null);
 const loading = ref(false);
@@ -78,11 +83,20 @@ async function remove() {
 
     loading.value = true;
     error.value = null;
+
     try {
         const notificationStore = useNotificationStore();
-        const townsStore = useTownsStore();
-        await townsStore.deleteComment(
-            comment.value.shantytown,
+        const selectedStore =
+            commentType.value === "shantytown"
+                ? useTownsStore()
+                : useActionsStore();
+        const sourceId =
+            commentType.value === "shantytown"
+                ? comment.value.shantytown
+                : comment.value.actionId;
+
+        await selectedStore.deleteComment(
+            sourceId,
             comment.value.id,
             reason.value
         );

--- a/packages/frontend/webapp/src/components/ModaleModerationQuestion/ModaleModerationQuestion.vue
+++ b/packages/frontend/webapp/src/components/ModaleModerationQuestion/ModaleModerationQuestion.vue
@@ -13,6 +13,7 @@
             <Button
                 variant="primaryText"
                 :loading="loading"
+                class="!border-2 !border-primary hover:!bg-primaryDark hover:!text-white"
                 @click="() => modale.close()"
                 >Annuler</Button
             >
@@ -92,3 +93,8 @@ async function remove() {
     return true;
 }
 </script>
+<style scoped>
+button {
+    border: inherit;
+}
+</style>

--- a/packages/frontend/webapp/src/components/ModaleModerationReponse/ModaleModerationReponse.vue
+++ b/packages/frontend/webapp/src/components/ModaleModerationReponse/ModaleModerationReponse.vue
@@ -24,7 +24,10 @@
         </template>
 
         <template v-slot:footer>
-            <Button variant="primaryText" @click="() => modale.close()"
+            <Button
+                variant="primaryText"
+                class="!border-2 !border-primary hover:!bg-primaryDark hover:!text-white"
+                @click="() => modale.close()"
                 >Annuler</Button
             >
             <Button class="ml-5" :loading="loading" @click="remove"
@@ -112,3 +115,8 @@ async function remove() {
     loading.value = false;
 }
 </script>
+<style scoped>
+button {
+    border: inherit;
+}
+</style>

--- a/packages/frontend/webapp/src/stores/actions.store.js
+++ b/packages/frontend/webapp/src/stores/actions.store.js
@@ -207,9 +207,6 @@ export const useActionsStore = defineStore("actions", () => {
         async deleteComment(actionId, commentId, reason = "") {
             const activitiesStore = useActivitiesStore();
             const dashboardActivitiesStore = useDashboardActivitiesStore();
-            console.log(
-                `Deleting comment ${commentId} from action ${actionId} for reason: ${reason}`
-            );
 
             const { comments } = await deleteComment(
                 actionId,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/2nQEzyeE/2402-journal-des-actions-permettre-au-r%C3%A9dacteur-de-supprimer-son-message-dans-le-journal-des-actions

## 🛠 Description de la PR
Cette PR ajoute la possibilité de supprimer un commentaire du journal de l'action:
- Suppression par le propriétaire du message
- Modération par un administrateur

## 📸 Captures d'écran
Suppression de message: 
![image](https://github.com/user-attachments/assets/b514d5a4-729e-43f0-a745-fd33ef5d9fd6)
Modération de message: 
![image](https://github.com/user-attachments/assets/04a3b869-e211-4976-94a8-fa0ce273043b)

## 🚨 Notes pour la mise en production
RàS