### PR TITLE
#patch: (2424) Bug DSFR sur le bouton "Copier le lien d'activation"

### DIFF
--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionCopyActivationLink.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionCopyActivationLink.vue
@@ -2,6 +2,7 @@
     <Button
         v-if="userStore.user?.is_superuser && hasPendingAccess"
         variant="primaryOutline"
+        class="!border-2 !border-primary hover:!text-white hover:!bg-primaryDark"
         :loading="isLoading"
         :disabled="disabled"
         >Copier le lien d'activation</Button
@@ -31,3 +32,8 @@ const hasPendingAccess = computed(() => {
     );
 });
 </script>
+<style scoped>
+button {
+    border: inherit;
+}
+</style>

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionSetIntervenant.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionSetIntervenant.vue
@@ -11,7 +11,7 @@
         variant="primaryOutline"
         :loading="isLoading"
         :disabled="disabled"
-        class="!border-2 !border-primary hover:!bg-primary"
+        class="!border-2 !border-primary hover:!bg-primaryDark"
         >Définir comme « Intervenant »
     </Button>
 </template>

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionSetRole.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionSetRole.vue
@@ -11,7 +11,7 @@
         :loading="isLoading"
         :disabled="disabled"
         @click="openChangeRoleModale"
-        class="!border-2 !border-primary hover:!bg-primary"
+        class="!border-2 !border-primary hover:!bg-primaryDark"
         >Changer le rôle</Button
     >
 </template>

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionUpgradeAdminLocal.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesActions/FicheAccesActionUpgradeAdminLocal.vue
@@ -9,7 +9,7 @@
         variant="primaryOutline"
         :loading="isLoading"
         :disabled="disabled"
-        class="!border-2 !border-primary hover:!bg-primary"
+        class="!border-2 !border-primary hover:!bg-primaryDark"
         >Définir comme « Administrateur local »
     </Button>
 </template>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/PaM6Ai91/2424-admin-bug-dsfr-sur-le-bouton-copier-le-lien-dactivation

## 🛠 Description de la PR
Cette PR corrige l'affichage du bouton "Copier le lien d'activation" ainsi que les boutons annexes de la zone d'administration pour homogénéiser les couleurs:
- contour bleu "primary"
- texte blanc et fond bleu "primaryDark" au survol de la souris

## 📸 Captures d'écran
Avant:
![image](https://github.com/user-attachments/assets/8152a7a5-dd69-4ac3-aeec-e45f532f6c99)
Après:
![image](https://github.com/user-attachments/assets/1e50cf20-fa2e-4b6a-ac0b-c56d3e1435b9)

## 🚨 Notes pour la mise en production
RàS