### PR TITLE
#patch: (2432) Correction de la route utilisée pour accéder aux données personnelles

### DIFF
--- a/packages/frontend/webapp/src/helpers/router.js
+++ b/packages/frontend/webapp/src/helpers/router.js
@@ -247,14 +247,14 @@ const router = createRouter({
         {
             path: "/mon-compte",
             redirect: "/mon-compte/informations-personnelles",
-        },
-        {
-            path: "/mon-compte/:tab(informations-personnelles|identifiants|abonnements|desactiver-compte|domaines-competence)",
-            component: () => import("@/views/MonCompteView.vue"),
             meta: {
                 title: "Modifier les informations liées à mon compte",
                 displayOrderOnSiteMap: 3,
             },
+        },
+        {
+            path: "/mon-compte/:tab(informations-personnelles|identifiants|abonnements|desactiver-compte|domaines-competence)",
+            component: () => import("@/views/MonCompteView.vue"),
         },
         {
             path: "/nouvel-utilisateur",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/SHzka7ji/2432-bugplan-du-site-le-lien-vers-la-page-de-modification-des-info-du-compte-sort-en-erreur

## 🛠 Description de la PR
La PR corrige le lien utilisé depuis la page "Plan du site" pour accéder au compte utilisateur.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS