### PR TITLE
#patch: (2423) Indiquer le chargement des données/statistiques sur la page de mesure d'impacts

### DIFF
--- a/packages/frontend/webapp/src/components/StatistiquesPubliques/StatistiquesPubliques.vue
+++ b/packages/frontend/webapp/src/components/StatistiquesPubliques/StatistiquesPubliques.vue
@@ -33,28 +33,60 @@
             <h2 class="text-display-lg font-bold text-secondary mt-16">
                 Répartition des utilisateurs
             </h2>
-            <div class="grid grid-cols-1 xl:grid-cols-2 mt-4">
-                <div>
+            <div class="grid grid-cols-1 xl:grid-cols-2 mt-4 gap-4">
+                <div
+                    class="flex justify-center content-center"
+                    :class="{
+                        'grid animate-pulse bg-gray-300 rounded-lg h-32':
+                            numberOfPublicEstablishmentUsers === '...',
+                    }"
+                >
                     <RepartitionUtilisateurs
                         v-if="numberOfPublicEstablishmentUsers !== '...'"
                         :data="organizationRepartitionData"
                     />
-                    <span class="text-display-lg font-bold" v-else>...</span>
+                    <span class="text-display-lg font-bold" v-else
+                        ><Spinner
+                    /></span>
                 </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-16">
-                    <StatsBlock
-                        :title="numberOfDepartements"
-                        icon="flag"
-                        subtitle="départements"
-                    />
-                    <StatsBlock
-                        :title="numberOfNewUsers.total"
-                        icon="user-plus"
-                        :subtitle="
-                            'nouveaux utilisateurs en ' +
-                            numberOfNewUsers.month.toLowerCase()
-                        "
-                    />
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <StatsBlock
+                            v-if="
+                                numberOfTerritorialCollectivitieUsers !== '...'
+                            "
+                            :title="numberOfDepartements"
+                            icon="flag"
+                            subtitle="départements"
+                            class="flex justify-center content-center p-2"
+                            :class="{
+                                'grid animate-pulse bg-gray-300 rounded-lg h-32':
+                                    numberOfDepartements === '...',
+                            }"
+                        />
+                        <span
+                            class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                            v-else
+                            ><Spinner
+                        /></span>
+                    </div>
+                    <div>
+                        <StatsBlock
+                            v-if="numberOfNewUsers.total !== '...'"
+                            :title="numberOfNewUsers.total"
+                            icon="user-plus"
+                            :subtitle="
+                                'nouveaux utilisateurs en ' +
+                                numberOfNewUsers.month.toLowerCase()
+                            "
+                            class="flex justify-center content-center p-2"
+                        />
+                        <span
+                            class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                            v-else
+                            ><Spinner
+                        /></span>
+                    </div>
                 </div>
             </div>
 
@@ -68,7 +100,11 @@
                         v-if="numberOfNewUsersPerMonth !== null"
                         class="h-60 w-full"
                     />
-                    <span class="text-display-lg font-bold" v-else>...</span>
+                    <span
+                        class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                        v-else
+                        ><Spinner
+                    /></span>
                 </div>
             </div>
 
@@ -82,29 +118,57 @@
                         v-if="wauData !== null"
                         class="h-60 w-full"
                     />
-                    <span class="text-display-lg font-bold" v-else>...</span>
+                    <span
+                        class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                        v-else
+                        ><Spinner
+                    /></span>
                 </div>
             </div>
 
             <StatsSection title="Usage" class="mt-16">
-                <StatsBlock
-                    :title="numberOfExports"
-                    icon="file-download"
-                    subtitle="extractions de données réalisées"
-                    info="Les exports Excel permettent aux acteurs locaux d'utiliser et d'analyser les données afin de suivre, communiquer et optimiser les actions de résorption depuis le 15/11/2019."
-                />
-                <StatsBlock
-                    :title="numberOfComments"
-                    icon="comment"
-                    subtitle="commentaires créés"
-                    info="Au delà du suivi des chiffrés, les commentaires permettent de suivre et de partager des informations qualitative utiles dans une action multi-partenariale."
-                />
-                <StatsBlock
-                    :title="numberOfDirectoryViews"
-                    icon="address-book"
-                    subtitle="fiches contact consultées"
-                    info="L'annuaire permet d'accéder aux coordonnées de tous les utilisateurs de la plateforme. Son utilisation participe à la mise en réseau partenaires locaux ou des pairs depuis le 15/11/2019"
-                />
+                <div>
+                    <StatsBlock
+                        v-if="numberOfExports !== '...'"
+                        :title="numberOfExports"
+                        icon="file-download"
+                        subtitle="extractions de données réalisées"
+                        info="Les exports Excel permettent aux acteurs locaux d'utiliser et d'analyser les données afin de suivre, communiquer et optimiser les actions de résorption depuis le 15/11/2019."
+                    />
+                    <span
+                        class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                        v-else
+                        ><Spinner
+                    /></span>
+                </div>
+                <div>
+                    <StatsBlock
+                        v-if="numberOfComments !== '...'"
+                        :title="numberOfComments"
+                        icon="comment"
+                        subtitle="commentaires créés"
+                        info="Au delà du suivi des chiffrés, les commentaires permettent de suivre et de partager des informations qualitative utiles dans une action multi-partenariale."
+                    />
+                    <span
+                        class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                        v-else
+                        ><Spinner
+                    /></span>
+                </div>
+                <div>
+                    <StatsBlock
+                        v-if="numberOfDirectoryViews !== '...'"
+                        :title="numberOfDirectoryViews"
+                        icon="address-book"
+                        subtitle="fiches contact consultées"
+                        info="L'annuaire permet d'accéder aux coordonnées de tous les utilisateurs de la plateforme. Son utilisation participe à la mise en réseau partenaires locaux ou des pairs depuis le 15/11/2019"
+                    />
+                    <span
+                        class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                        v-else
+                        ><Spinner
+                    /></span>
+                </div>
             </StatsSection>
 
             <StatsSection title="Fréquence de mise à jour" class="mt-16">
@@ -116,21 +180,45 @@
                     informations justes à tous les acteurs.</template
                 >
                 <template v-slot:default>
-                    <StatsBlock
-                        :title="medianTimeBeforeCreationDeclaration"
-                        subtitle="jours entre l'installation d'un bidonville ou squat et sa déclaration"
-                        info="Médiane depuis le 01/09/2019."
-                    />
-                    <StatsBlock
-                        :title="medianTimeBeforeClosingDeclaration"
-                        subtitle="jours entre la fermeture du site et sa déclaration"
-                        info="Médiane depuis le 01/09/2019."
-                    />
-                    <StatsBlock
-                        :title="numberOfShantytownOperations"
-                        subtitle="mises à jour de bidonvilles et squats"
-                        info="Toutes opérations confondues : création, modification, fermeture"
-                    />
+                    <div>
+                        <StatsBlock
+                            v-if="medianTimeBeforeCreationDeclaration !== '...'"
+                            :title="medianTimeBeforeCreationDeclaration"
+                            subtitle="jours entre l'installation d'un bidonville ou squat et sa déclaration"
+                            info="Médiane depuis le 01/09/2019."
+                        />
+                        <span
+                            class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                            v-else
+                            ><Spinner
+                        /></span>
+                    </div>
+                    <div>
+                        <StatsBlock
+                            v-if="medianTimeBeforeClosingDeclaration !== '...'"
+                            :title="medianTimeBeforeClosingDeclaration"
+                            subtitle="jours entre la fermeture du site et sa déclaration"
+                            info="Médiane depuis le 01/09/2019."
+                        />
+                        <span
+                            class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                            v-else
+                            ><Spinner
+                        /></span>
+                    </div>
+                    <div>
+                        <StatsBlock
+                            v-if="numberOfShantytownOperations !== '...'"
+                            :title="numberOfShantytownOperations"
+                            subtitle="mises à jour de bidonvilles et squats"
+                            info="Toutes opérations confondues : création, modification, fermeture"
+                        />
+                        <span
+                            class="flex justify-center content-center text-display-lg font-bold grid animate-pulse bg-gray-300 rounded-lg h-32"
+                            v-else
+                            ><Spinner
+                        /></span>
+                    </div>
                 </template>
             </StatsSection>
         </ContentWrapper>
@@ -140,7 +228,7 @@
 <script setup>
 import { ref, computed, onMounted } from "vue";
 import ENV from "@/helpers/env.js";
-import { ContentWrapper, Icon } from "@resorptionbidonvilles/ui";
+import { ContentWrapper, Icon, Spinner } from "@resorptionbidonvilles/ui";
 import StatsBlock from "./StatsBlock.vue";
 import StatsSection from "./StatsSection.vue";
 import RepartitionUtilisateurs from "./Graphs/RepartitionUtilisateurs.vue";


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/nBfOzwIT/2423-page-stat-publiques-longue-%C3%A0-charger-10s-sans-sablier

## 🛠 Description de la PR
La PR affiche des "cartes de chargement" en lieux et places des blocs de statistiques. Ces statistiques présentaient, auparavant, une donnée figée "..." pouvant induire l'utilisateur à penser que la page est figée.

## 📸 Captures d'écran
Avant:
![image](https://github.com/user-attachments/assets/50885344-0a34-43c1-ac24-b0d9d502bfda)
Après:
![image](https://github.com/user-attachments/assets/dcabcab7-98cd-4851-93ec-f21e72e24eec)

## 🚨 Notes pour la mise en production
RàS