### PR TITLE
#patch: (2428) Normalisation des boutons de fiche site (liste des sites)

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
@@ -10,8 +10,7 @@
             :aria-label="`Fiche site ${shantytown.addressSimple} ${
                 shantytown.name ? shantytown.name : ''
             } ${shantytown.city.name}`"
-            tabindex="0"
-            @click="navigate"
+            @click="(event) => handleClickOnCard(event, navigate)"
             @mouseenter="isHover = true"
             @mouseleave="isHover = false"
         >
@@ -114,6 +113,22 @@ const displayPhasesPreparatoiresResorption = computed(() => {
 const nbCol = computed(() => {
     return userStore.hasJusticePermission ? "5" : "4";
 });
+
+function handleClickOnCard(event, navigateFunction) {
+    // On vérifie si le clic vient d'un bouton du footer ou d'un click sur intervenant ou sur la tuile complète
+    let targetElement = event.target;
+    while (targetElement && targetElement !== event.currentTarget) {
+        if (
+            targetElement.tagName === "BUTTON" ||
+            targetElement.tagName === "A" ||
+            targetElement.closest(".carte-site-detaillee-footer-wrapper")
+        ) {
+            return; // Ne pas naviguer si le clic vient d'un bouton du footer
+        }
+        targetElement = targetElement.parentElement;
+    }
+    navigateFunction();
+}
 </script>
 
 <style scoped lang="scss">

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -1,42 +1,36 @@
 <template>
     <div class="flex justify-end h-14 items-center mr-4 space-x-4 print:hidden">
-        <Button
-            variant="primaryOutline"
-            icon="temperature-high"
-            iconPosition="left"
-            type="button"
+        <DsfrButton
+            v-if="isOpen"
             size="sm"
-            :loading="heatwaveRequestStatus?.loading === true"
-            @click.prevent="toggleHeatwave"
-            class="!border-2 !border-primary hover:!bg-primary"
-        >
-            <template v-if="heatwaveStatus === false">Alerte Canicule</template>
-            <template v-else>Supprimer l'alerte Canicule</template>
-        </Button>
-        <Button
+            :label="
+                heatwaveStatus
+                    ? 'Supprimer l\'alerte Canicule'
+                    : 'Alerte Canicule'
+            "
+            icon="fr-icon-thermometer-line"
+            class="fr-secondary-btn !border-1 !border-secondary !text-secondary hover:!bg-secondary hover:!text-white"
+            tertiary
+            no-outline
+            :disabled="heatwaveRequestStatus?.loading"
+            @click.prevent.stop="toggleHeatwave"
+        />
+        <DsfrButton
             v-if="isOpen && hasUpdateShantytownPermission"
-            variant="primaryOutline"
             size="sm"
-            icon="pencil-alt"
-            iconPosition="left"
-            :href="`/site/${shantytown.id}/mise-a-jour`"
-            class="!border-2 !border-primary hover:!bg-primary"
-            >Mettre à jour</Button
-        >
-        <Link :to="`/site/${shantytown.id}`">
-            <Icon
-                :aria-label="`Voir la fiche du site ${
-                    shantytown.addressSimple
-                } ${shantytown.name ? shantytown.name : ''} ${
-                    shantytown.city.name
-                }
-                }`"
-                icon="arrow-right"
-            />
-            <span class="ml-2" aria-hidden="true"
-                >Voir la fiche du site</span
-            ></Link
-        >
+            label="Mettre à jour"
+            icon="fr-icon-pencil-line"
+            secondary
+            class="hover:!text-white"
+            @click.prevent.stop="navigateTo('mise-a-jour')"
+        />
+        <DsfrButton
+            size="sm"
+            label="Voir la fiche du site"
+            icon="fr-icon-arrow-right-line"
+            primary
+            @click.prevent.stop="navigateTo(null)"
+        />
     </div>
 </template>
 
@@ -46,7 +40,7 @@ import { useUserStore } from "@/stores/user.store";
 import { useNotificationStore } from "@/stores/notification.store";
 import { useTownsStore } from "@/stores/towns.store";
 
-import { Icon, Button, Link } from "@resorptionbidonvilles/ui";
+import router from "@/helpers/router";
 
 const props = defineProps({
     shantytown: Object,
@@ -77,6 +71,9 @@ async function toggleHeatwave() {
             !heatwaveStatus.value
         );
     } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log("Erreur lors de la modification du statut canicule :", e);
+
         notificationStore.error(
             "Risque canicule",
             "Une erreur inconnue est survenue"
@@ -98,10 +95,22 @@ async function toggleHeatwave() {
         );
     }
 }
+
+const navigateTo = (target) => {
+    console.log("Navigate to:", `/site/${shantytown.value.id}/${target}`);
+
+    if (shantytown.value && shantytown.value.id) {
+        router.push(`/site/${shantytown.value.id}/${target}`);
+    }
+};
 </script>
 
 <style scoped>
 button {
     border: inherit;
+}
+
+button.fr-secondary-btn:hover {
+    background-color: var(--warning-425-625-hover) !important;
 }
 </style>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -98,7 +98,11 @@ async function toggleHeatwave() {
 
 const navigateTo = (target) => {
     if (shantytown.value && shantytown.value.id) {
-        router.push(`/site/${shantytown.value.id}/${target}`);
+        let path = `/site/${shantytown.value.id}`;
+        if (target) {
+            path += `/${target}`;
+        }
+        router.push(path);
     }
 };
 </script>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -9,7 +9,7 @@
                     : 'Alerte Canicule'
             "
             icon="fr-icon-thermometer-line"
-            class="fr-secondary-btn !border-1 !border-secondary !text-secondary hover:!bg-secondary hover:!text-white"
+            class="fr-secondary-btn !border-1 !border-secondary !text-secondary hover:!text-white"
             tertiary
             no-outline
             :disabled="heatwaveRequestStatus?.loading"
@@ -113,6 +113,6 @@ button {
 }
 
 button.fr-secondary-btn:hover {
-    background-color: var(--warning-425-625-hover) !important;
+    background-color: rgb(191, 83, 57) !important;
 }
 </style>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -97,8 +97,6 @@ async function toggleHeatwave() {
 }
 
 const navigateTo = (target) => {
-    console.log("Navigate to:", `/site/${shantytown.value.id}/${target}`);
-
     if (shantytown.value && shantytown.value.id) {
         router.push(`/site/${shantytown.value.id}/${target}`);
     }

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -9,8 +9,8 @@
                     : 'Alerte Canicule'
             "
             icon="fr-icon-thermometer-line"
-            class="fr-secondary-btn !border-1 !border-secondary !text-secondary hover:!text-white"
-            tertiary
+            class="hover:!text-white"
+            secondary
             no-outline
             :disabled="heatwaveRequestStatus?.loading"
             @click.prevent.stop="toggleHeatwave"
@@ -110,9 +110,5 @@ const navigateTo = (target) => {
 <style scoped>
 button {
     border: inherit;
-}
-
-button.fr-secondary-btn:hover {
-    background-color: rgb(191, 83, 57) !important;
 }
 </style>

--- a/packages/frontend/webapp/src/helpers/dsfr.js
+++ b/packages/frontend/webapp/src/helpers/dsfr.js
@@ -4,10 +4,14 @@ import {
     DsfrSearchBar,
     DsfrInput,
     DsfrCheckbox,
+    DsfrButton,
+    DsfrButtonGroup,
 } from "@gouvminint/vue-dsfr";
 
 import "@gouvfr/dsfr/dist/dsfr.min.css";
 import "@gouvminint/vue-dsfr/styles";
+import "@gouvfr/dsfr/dist/utility/utility.main.min.css";
+import "@gouvfr/dsfr/dist/component/component.main.min.css";
 
 export function useDsfr(app) {
     app.component("DsfrCard", DsfrCard);
@@ -15,4 +19,6 @@ export function useDsfr(app) {
     app.component("DsfrSearchBar", DsfrSearchBar);
     app.component("DsfrInput", DsfrInput);
     app.component("DsfrCheckbox", DsfrCheckbox);
+    app.component("DsfrButton", DsfrButton);
+    app.component("DsfrButtonGroup", DsfrButtonGroup);
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/VDeZwzMD/2428-liste-des-sites-normalisation-des-boutons

## 🛠 Description de la PR
Cette PR apporte la normalisation des boutons de fiche de site (dans la liste des sites) en intégrant les `DsfrButton`. De fait, pour que le fonctionnement reste le même pour l'utilisateur, la PR applique un correctif sur la `CarteSiteDetaillee`. Ainsi, le comportement reste le même et la propagation de l'évènement est gérée.

## 📸 Captures d'écran
Avant:
![image](https://github.com/user-attachments/assets/1bd33ee5-549b-4b49-9131-24fd269a5a46)
Après:
![image](https://github.com/user-attachments/assets/ff665292-042f-4d19-8343-6600f3227386)

## 🚨 Notes pour la mise en production
RàS