### PR TITLE
#patch (2431) Envoyer un mel d'activation du compte la veille de la date d'expiration

### DIFF
--- a/packages/api/server/loaders/agendaJobsLoader.ts
+++ b/packages/api/server/loaders/agendaJobsLoader.ts
@@ -84,6 +84,14 @@ export default (agenda) => {
     );
 
     agenda.define(
+        'access_is_about_to_expire',
+        (job) => {
+            const { accessId, hoursBeforeExpirationDate } = job.attrs.data;
+            accessRequestService.handleAccessAboutToExpire(parseInt(accessId, 10), hoursBeforeExpirationDate);
+        },
+    );
+
+    agenda.define(
         'access_is_expired',
         (job) => {
             const { accessId } = job.attrs.data;

--- a/packages/api/server/mails/dist/user_access_pending.html
+++ b/packages/api/server/mails/dist/user_access_pending.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
   <head>
-    <title>[Résorption-bidonvilles] - Votre lien expire dans 48h</title>
+    <title>[Résorption-bidonvilles] - Votre lien expire dans {{var:whenDoesExpirationOccurs}}</title>
     <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!--<![endif]-->
@@ -167,7 +167,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:bold;line-height:1.5em;text-align:left;color:#000000;">Le lien expirera dans 48h ({{var:activationUrlExpDate}}).</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:bold;line-height:1.5em;text-align:left;color:#000000;">Le lien expirera dans {{var:whenDoesExpirationOccurs}} ({{var:activationUrlExpDate}}).</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/user_access_pending.subject.text
+++ b/packages/api/server/mails/dist/user_access_pending.subject.text
@@ -1,1 +1,1 @@
-[Résorption-bidonvilles] - Votre lien expire dans 48h
+[Résorption-bidonvilles] - Votre lien expire dans {{var:whenDoesExpirationOccurs}}

--- a/packages/api/server/mails/dist/user_access_pending.text
+++ b/packages/api/server/mails/dist/user_access_pending.text
@@ -4,7 +4,8 @@ Bonjour {{var:recipientName}},
 Sauf erreur de notre part, vous n’avez pas encore activé votre lien d’accès à la
 plateforme Résorption-bidonvilles [{{var:wwwUrl}}].
 Nous vous invitons à l'activer dès maintenant.
-Le lien expirera dans 48h ({{var:activationUrlExpDate}}).
+Le lien expirera dans {{var:whenDoesExpirationOccurs}}
+({{var:activationUrlExpDate}}).
 
 Activer mon compte [{{var:activationUrl}}]
 

--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -564,9 +564,18 @@ export default {
     sendUserAccessPending: (recipient, options: MailOptions = {}) => {
         const { variables, preserveRecipient } = options;
 
+        const { hoursBeforeExpirationDate } = variables;
+
+        let whenDoesExpirationOccurs = '48 heures';
+        if (hoursBeforeExpirationDate !== undefined && hoursBeforeExpirationDate === '24 heures') {
+            whenDoesExpirationOccurs = '24 heures';
+        }
+
         const utm = generateTrackingUTM(
             REQUESTER_CAMPAIGN,
-            'activer-mon-compte-48h',
+            hoursBeforeExpirationDate !== undefined && hoursBeforeExpirationDate === '24 heures'
+                ? 'activer-mon-compte-24h'
+                : 'activer-mon-compte-48h"',
         );
 
         return mailService.send('user_access_pending', {
@@ -579,11 +588,11 @@ export default {
                 wwwUrl: `${wwwUrl}?${utm}`,
                 backUrl,
                 blogUrl,
+                whenDoesExpirationOccurs,
             },
             preserveRecipient,
         });
     },
-
 
     /**
    * @param {User} recipient  Recipient of the email (must includes first_name, last_name, email)

--- a/packages/api/server/mails/src/user_access_pending.mjml
+++ b/packages/api/server/mails/src/user_access_pending.mjml
@@ -1,6 +1,6 @@
 <mjml>
     <mj-head>
-        <mj-title>[Résorption-bidonvilles] - Votre lien expire dans 48h</mj-title>
+        <mj-title>[Résorption-bidonvilles] - Votre lien expire dans {{var:whenDoesExpirationOccurs}}</mj-title>
         <mj-include path='common/attributes.mjml' />
         <mj-include path='common/styles.mjml' />
     </mj-head>
@@ -20,7 +20,7 @@
                     Nous vous invitons à l'activer dès maintenant.
                 </mj-text>
                 <mj-text mj-class="font-bold">
-                    Le lien expirera dans 48h ({{var:activationUrlExpDate}}).
+                    Le lien expirera dans {{var:whenDoesExpirationOccurs}} ({{var:activationUrlExpDate}}).
                 </mj-text>
                 <mj-button mj-class="button-primary" href="{{var:activationUrl}}" rel="noopener noreferrer">
                     Activer mon compte

--- a/packages/api/server/services/accessRequest/accessRequestService.ts
+++ b/packages/api/server/services/accessRequest/accessRequestService.ts
@@ -36,6 +36,7 @@ export default {
             await Promise.all([
                 cancelEvent.accessPending(user.user_accesses[0].id),
                 cancelEvent.accessExpired(user.user_accesses[0].id),
+                cancelEvent.accessAboutToExpire(user.user_accesses[0].id),
             ]);
         }
     },
@@ -125,18 +126,36 @@ export default {
      *
      * @param {Number} accessId
      */
-    async handleAccessPending(accessId) {
-        // fetch data
+    async handleAccessPending(accessId: number) {
         const user = await userModel.findOneByAccessId(accessId);
         if (user === null || !isAccessPending(user)) {
             return;
         }
 
-        // notify the user
         await sendEmail.toUser.accessPending(
             user,
             getAccountActivationLink(user.user_accesses[0].id),
             new Date(user.user_accesses[0].expires_at * 1000),
+            null,
+        );
+    },
+
+    /**
+     * Handle access is about to expire
+     *
+     * @param {Number} accessId
+     */
+    async handleAccessAboutToExpire(accessId: number, hoursBeforeExpirationDate) {
+        const user = await userModel.findOneByAccessId(accessId);
+        if (user === null || !isAccessPending(user)) {
+            return;
+        }
+
+        await sendEmail.toUser.accessPending(
+            user,
+            getAccountActivationLink(user.user_accesses[0].id),
+            new Date(user.user_accesses[0].expires_at * 1000),
+            hoursBeforeExpirationDate,
         );
     },
 
@@ -196,6 +215,7 @@ export default {
         await Promise.all([
             cancelEvent.accessPending(user.user_accesses[0].id),
             cancelEvent.accessExpired(user.user_accesses[0].id),
+            cancelEvent.accessAboutToExpire(user.user_accesses[0].id),
         ]);
     },
 };

--- a/packages/api/server/services/accessRequest/accessRequestService.ts
+++ b/packages/api/server/services/accessRequest/accessRequestService.ts
@@ -64,7 +64,7 @@ export default {
      * @param {Boolean} firstNotification Wether this is the first or the second pending notification
      * @param {Number}  userId
      */
-    async handleAccessRequestPending(firstNotification, userId) {
+    async handleAccessRequestPending(firstNotification: boolean, userId: number) {
         // fetch data
         const user = await userModel.findOne(userId, {
             extended: true,

--- a/packages/api/server/services/accessRequest/mailer.ts
+++ b/packages/api/server/services/accessRequest/mailer.ts
@@ -103,11 +103,14 @@ export default {
             });
         },
 
-        accessPending(user, activationLink, expiracyDate) {
+        accessPending(user, activationLink, expiracyDate, hoursBeforeExpirationDate?) {
             return sendUserAccessPending(user, {
                 variables: {
                     activationUrl: activationLink,
                     activationUrlExpDate: dateToString(expiracyDate, true),
+                    hoursBeforeExpirationDate: hoursBeforeExpirationDate !== undefined
+                        ? `${hoursBeforeExpirationDate} heures`
+                        : undefined,
                 },
             });
         },

--- a/packages/api/server/services/accessRequest/scheduler.ts
+++ b/packages/api/server/services/accessRequest/scheduler.ts
@@ -22,6 +22,13 @@ export default {
             });
         },
 
+        async accessAboutToExpire(accessId, oneDayBeforeExpirationDate, hoursBeforeExpirationDate) {
+            await agenda.schedule(oneDayBeforeExpirationDate, 'access_is_about_to_expire', {
+                accessId,
+                hoursBeforeExpirationDate,
+            });
+        },
+
         async accessExpired(accessId) {
             await agenda.schedule('in 8 days', 'access_is_expired', {
                 accessId,
@@ -70,18 +77,21 @@ export default {
         async accessPending(accessId) {
             await agenda.cancel({
                 name: 'access_is_pending',
-                attrs: {
-                    accessId,
-                },
+                'data.accessId': accessId,
             });
         },
 
         async accessExpired(accessId) {
             await agenda.cancel({
                 name: 'access_is_expired',
-                attrs: {
-                    accessId,
-                },
+                'data.accessId': accessId,
+            });
+        },
+
+        async accessAboutToExpire(accessId) {
+            await agenda.cancel({
+                name: 'access_is_about_to_expire',
+                'data.accessId': accessId,
             });
         },
     },

--- a/packages/api/server/services/user/create.ts
+++ b/packages/api/server/services/user/create.ts
@@ -11,11 +11,9 @@ const { generateSalt } = authUtils;
 export default async (data, createdBy: number = null): Promise<User> => {
     try {
         const userId = await sequelize.transaction(async (t) => {
-            // get fk_type from organization_types to initialize fk_role_regular field
             const fk_role_regular = await organizationTypeModel.findRoleByOrganizationId(parseInt(data.organization, 10), t);
             Object.assign(data, { fk_role_regular });
 
-            // create the user himself
             return userModel.create(Object.assign(data, {
                 created_by: createdBy,
                 salt: generateSalt(),

--- a/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyDeactivate.vue
+++ b/packages/frontend/webapp/src/components/FicheAcces/FicheAccesBody/FicheAccesBodyDeactivate.vue
@@ -112,7 +112,6 @@ async function deactivate() {
     if (isLoading.value) {
         return;
     }
-    console.log("Anonymization?", anonymizationRequested.value);
 
     isLoading.value = true;
     error.value = null;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ODpRe645/2431

## 🛠 Description de la PR
- Programmation d'un rappel pour l'activation du compte 24H avant la date d'expiration du lien d'activation lorsqu'un administrateur valide une demande d'accès et envoie le lien d'activation
- Suppression du job programmé pour l'envoi de ce lien
- Correction de l'annulation des jobs pour le rappel 5 jours après l'envoi du 1er mail pour demander l'activation et du job envoyant le mail d'expiration du lien

## 📸 Captures d'écran

## 🚨 Notes pour la mise en production
Rien à signaker