### PR TITLE
#patch: (2426) Suppression des utilisateurs anonymisés dans les exports

### DIFF
--- a/packages/api/server/models/userModel/listExport.ts
+++ b/packages/api/server/models/userModel/listExport.ts
@@ -107,7 +107,8 @@ export default async (permission?: Permission): Promise<UserListExportRow[]> => 
             LEFT JOIN v_user_areas ON v_user_areas.user_id = u.user_id AND v_user_areas.is_main_area IS TRUE
             LEFT JOIN roles_regular rr ON rr.role_id = u.fk_role_regular
             LEFT JOIN user_last_connection ulc ON ulc.fk_user = u.user_id
-            ${where !== null ? `WHERE (${where})` : ''}
+            WHERE u.anonymized_at IS NULL
+            ${where !== null ? `AND (${where})` : ''}
             ORDER BY
                 "Statut calculé",
                 used_at ASC,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/InkCprl7/2426-annuaire-supprimer-les-comptes-anonymis%C3%A9s-de-lexport-des-utilisateurs

## 🛠 Description de la PR
Cette PR filtre les utilisateurs anonymisés dans les exports d'utilisateurs (accès) depuis l'interface admin.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS