### PR TITLE
#patch: (2427) Modification du pointeur de souris au survol du mot "retirer"

### DIFF
--- a/packages/frontend/webapp/src/components/FormInvitation/FormInvitationInvite.vue
+++ b/packages/frontend/webapp/src/components/FormInvitation/FormInvitationInvite.vue
@@ -5,7 +5,7 @@
         </div>
         <div class="flex-1 flex flex-col justify-center px-4 relative">
             <a
-                class="absolute right-2 top-2 text-primary text-sm hover:underline cursor-pointer"
+                class="absolute right-2 top-2 text-primary text-sm hover:underline !cursor-pointer"
                 @click="$emit('remove')"
                 ><Icon icon="fa-regular fa-trash-alt" /> Retirer</a
             >


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/LlP0Xmso/2427-bug-le-bouton-retirer-dune-invitation-de-contact-est-interdit-mais-op%C3%A9rant

## 🛠 Description de la PR
La PR corrige l'affichage de la souris au survol du terme "retirer" pour supprimer un contact à inviter sur la plateforme. La souris passe de 🚫 à 👆

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS