### PR TITLE
#patch: (2430) Correction du bouton "Voir toutes les activités" et de l'affichage des dernières activités

### DIFF
--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordActivites/TableauDeBordActivites.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordActivites/TableauDeBordActivites.vue
@@ -24,11 +24,13 @@
             </template>
         </ViewErrorInline>
 
-        <section v-else class="flex">
-            <div class="sticky self-start top-28">
-                <TableauDeBordFiltres class="w-48 pt-0 -mt-0" />
+        <section v-else class="flex flex-col md:flex-row">
+            <div class="sticky top-[120px] w-full md:w-auto self-start top-64">
+                <TableauDeBordFiltres class="w-full md:w-48 pt-0 -mt-0" />
             </div>
-            <TableauDeBordActivitesListe class="ml-24 -mt-1 flex-1" />
+            <TableauDeBordActivitesListe
+                class="overflow-auto ml-24 -mt-1 flex-1"
+            />
         </section>
     </div>
 </template>

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordActivites/TableauDeBordActivitesListe.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBordActivites/TableauDeBordActivitesListe.vue
@@ -27,10 +27,6 @@
             :key="`${activity.entity}-${activity.action}-${activity.date}`"
             :activity="activity"
         />
-
-        <footer class="mt-10 text-center">
-            <Link to="/activites"> Voir toutes les activités </Link>
-        </footer>
     </div>
 </template>
 
@@ -38,7 +34,6 @@
 import { computed } from "vue";
 import { useDashboardStore } from "@/stores/dashboard.store";
 
-import { Link } from "@resorptionbidonvilles/ui";
 import TableauDeBordActivite from "./TableauDeBordActivite.vue";
 
 const dashboardStore = useDashboardStore();

--- a/packages/frontend/webapp/src/views/HistoriqueActivitesView.vue
+++ b/packages/frontend/webapp/src/views/HistoriqueActivitesView.vue
@@ -10,9 +10,9 @@
         <ContentWrapper class="pt-8">
             <FilArianne :items="ariane" class="mb-8" />
             <HistoriqueActivitesHeader
-                class="sticky top-0 bg-white pt-2 pb-10 !mb-0"
+                class="sticky top-0 bg-white pt-2 pb-10 !mb-0 z-10"
             />
-            <TableauDeBordActivites class="mt-8" />
+            <TableauDeBordActivites class="mt-8 md:mt-2 z-[9]" />
         </ContentWrapper>
     </LayoutSearch>
 </template>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/RuAuCsHe/2430-activit%C3%A9s-le-clic-sur-voir-toutes-les-activit%C3%A9s-est-inop%C3%A9rant

## 🛠 Description de la PR
La PR supprime le bouton inutile "Voir toutes les activités" qui renvoyait sur la même page. De plus, elle corrige un élément de design qui ne s'affichait pas correctement. Maintenant, les filtres ne passent plus par dessus la bannière mais sont cachés par elle lorsque l'on scroll jusqu'au bas de la page.

## 📸 Captures d'écran
Avant:
![image](https://github.com/user-attachments/assets/fa82610a-8140-43b6-a6fa-a2133ccbcfa6)
Après:
![image](https://github.com/user-attachments/assets/1aa1a32c-da1f-47fb-8427-8d980770ade2)


## 🚨 Notes pour la mise en production
RàS