### PR TITLE
#patch: (2434) Amélioration du process de déploiement PROD

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag }}
+          key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag || 'latest' }}
           restore-keys: |
             ${{ runner.os }}-api-buildx
 
@@ -42,7 +42,7 @@ jobs:
           context: .
           file: Dockerfile.api
           push: true
-          tags: resorptionbidonvilles/api:qa-${{ github.event.inputs.tag }}
+          tags: resorptionbidonvilles/api:qa-${{ github.event.inputs.tag || 'latest' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag }}
+          key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag || 'latest' }}
           restore-keys: |
             ${{ runner.os }}-api-buildx
 
@@ -81,7 +81,7 @@ jobs:
           context: .
           file: Dockerfile.www
           push: true
-          tags: resorptionbidonvilles/www:qa-${{ github.event.inputs.tag }}
+          tags: resorptionbidonvilles/www:qa-${{ github.event.inputs.tag || 'latest' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag }}
+          key: ${{ runner.os }}-api-buildx-qa-${{ github.event.inputs.tag || 'latest' }}
           restore-keys: |
             ${{ runner.os }}-api-buildx
 
@@ -120,7 +120,7 @@ jobs:
           context: .
           file: Dockerfile.webapp
           push: true
-          tags: resorptionbidonvilles/frontend:qa-${{ github.event.inputs.tag }}
+          tags: resorptionbidonvilles/frontend:qa-${{ github.event.inputs.tag || 'latest' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,6 +1,7 @@
 name: qa
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  prebuild-qa:
+    uses: ./.github/workflows/qa.yml
+    secrets: inherit
+
   upgrade-version:
+    needs: prebuild-qa
     runs-on: ubuntu-24.04
     outputs:
       new_tag: ${{ steps.version.outputs.new_tag }}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/qtwoNpOn/2434-am%C3%A9lioration-du-processus-de-d%C3%A9ploiement-preprod-prod

## 🛠 Description de la PR
Cette PR apporte un changement dans le process de PROD (release) pour éviter les erreurs de builds impliquant auparavant un changement de numéro de version inutile. De plus, cela créé une release spécifique de QA nommée `qa-latest` qui peut être utilisée pour passer la PREPROD en ISO-PROD.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS