### PR TITLE
 #patch: (2458) Modification du bouton annuler dans l'espace d'entraide 

### DIFF
--- a/packages/frontend/webapp/src/views/MiseAJourDeQuestionView.vue
+++ b/packages/frontend/webapp/src/views/MiseAJourDeQuestionView.vue
@@ -24,7 +24,11 @@
     <LayoutForm v-else size="large">
         <template v-slot:title>Mise à jour de la question</template>
         <template v-slot:buttons>
-            <Button variant="primaryOutline" type="button" @click="back"
+            <Button
+                variant="primaryOutline"
+                type="button"
+                @click="back"
+                class="!border-2 !border-primary hover:!bg-primary"
                 >Annuler</Button
             >
             <Button @click="submit" :loading="form?.isSubmitting"
@@ -91,3 +95,9 @@ function back() {
     }
 }
 </script>
+
+<style scoped>
+button {
+    border: inherit;
+}
+</style>

--- a/packages/frontend/webapp/src/views/NouvelleQuestionCommunauteView.vue
+++ b/packages/frontend/webapp/src/views/NouvelleQuestionCommunauteView.vue
@@ -8,7 +8,11 @@
             J'ai besoin de l'aide de la communauté.
         </template>
         <template v-slot:buttons>
-            <Button variant="primaryOutline" type="button" @click="back"
+            <Button
+                variant="primaryOutline"
+                type="button"
+                @click="back"
+                class="!border-2 !border-primary hover:!bg-primary"
                 >Annuler</Button
             >
             <Button @click="submit" :loading="form?.isSubmitting"
@@ -46,3 +50,9 @@ function back() {
     router.back();
 }
 </script>
+
+<style scoped>
+button {
+    border: inherit;
+}
+</style>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/BT2hDu4I/2458-dsfr-bouton-annuler-mal-affich%C3%A9-sur-demande-dentraide

## 🛠 Description de la PR
Le style du bouton annuler a été modifié pour le rendre plus visible et similaire aux autre bouton annuler du site 

## 📸 Captures d'écran
<img width="247" alt="{E54CB665-C847-4328-8256-AEBA5204E692}" src="https://github.com/user-attachments/assets/63ea7c7e-5459-4019-9859-170ba8594a2c" />
<img width="959" alt="{D9164A18-6A74-4702-81DB-BBD990982D66}" src="https://github.com/user-attachments/assets/ed8b2da9-aee5-4725-9e57-0823440096d6" />
<img width="960" alt="{688C7EED-6A3F-4C49-8394-C4626D19FC29}" src="https://github.com/user-attachments/assets/c9f6291d-6d91-4a78-b0ee-8d9f8a2b5506" />
<img width="960" alt="{E0F7C9EB-E7F3-4257-8648-F37E59EA530D}" src="https://github.com/user-attachments/assets/a34a5ed9-a582-48e0-9cc2-a7a239d67142" />



## 🚨 Notes pour la mise en production
RAS