### PR TITLE
#patch (2459-2) Correction de l'action de "release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: 'develop'
           DRY_RUN: true
-          WITH_V: false
+          WITH_V: true
       - name: Update version in api package.json
         uses: jossef/action-set-json-field@v2.2
         with:


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QC0JnBiW/2459-tech-supprimer-les-alertes-%C3%A9mises-par-laction-releaseyml

## 🛠 Description de la PR
Une erreur de calcule de nouvelle version empêche le build de nouvelle release. La montée de version de `anothrNick/github-tag-action` de la v1.36.0 à 1.73.0 a rendu la détection du dernier tag valide plus stricte. Il est maintenant nécessaire de passer le paramètre `WITH_V` à true pour qu'il tienne compte des tags commençants par "v" *(comme v2.34.0)*

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS