### PR TITLE
#patch (2461) Suppression du "v" en trop et remplacement de WITH_V par TAG_PREFIX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: 'develop'
           DRY_RUN: true
-          WITH_V: true
+          TAG_PREFIX: 'v'
       - name: Update version in api package.json
         uses: jossef/action-set-json-field@v2.2
         with:
@@ -54,8 +54,8 @@ jobs:
         run: |
           git config --local user.email "admin@resorption-bidonvilles.beta.gouv.fr"
           git config --local user.name "GitHub Action"
-          git commit -m "📦 Release v${{ steps.version.outputs.new_tag }}" -a
-          git tag v${{ steps.version.outputs.new_tag }}
+          git commit -m "📦 Release ${{ steps.version.outputs.new_tag }}" -a
+          git tag ${{ steps.version.outputs.new_tag }}
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0
         with:
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-www-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}
+          key: ${{ runner.os }}-www-buildx-${{ needs['upgrade-version'].outputs.new_tag }}
           restore-keys: |
             ${{ runner.os }}-www-buildx
           fail-on-cache-miss: false
@@ -100,7 +100,7 @@ jobs:
           context: .
           file: Dockerfile.www
           push: true
-          tags: resorptionbidonvilles/www:v${{ needs['upgrade-version'].outputs.new_tag }}
+          tags: resorptionbidonvilles/www:${{ needs['upgrade-version'].outputs.new_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Image digest
@@ -120,7 +120,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-webapp-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}
+          key: ${{ runner.os }}-webapp-buildx-${{ needs['upgrade-version'].outputs.new_tag }}
           restore-keys: |
             ${{ runner.os }}-webapp-buildx
           fail-on-cache-miss: false
@@ -136,7 +136,7 @@ jobs:
           context: .
           file: Dockerfile.webapp
           push: true
-          tags: resorptionbidonvilles/frontend:v${{ needs['upgrade-version'].outputs.new_tag }}
+          tags: resorptionbidonvilles/frontend:${{ needs['upgrade-version'].outputs.new_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Image digest
@@ -156,7 +156,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-api-buildx-v${{ needs['upgrade-version'].outputs.new_tag }}
+          key: ${{ runner.os }}-api-buildx-{{ needs['upgrade-version'].outputs.new_tag }}
           restore-keys: |
             ${{ runner.os }}-api-buildx
           fail-on-cache-miss: false
@@ -172,7 +172,7 @@ jobs:
           context: .
           file: Dockerfile.api
           push: true
-          tags: resorptionbidonvilles/api:v${{ needs['upgrade-version'].outputs.new_tag }}
+          tags: resorptionbidonvilles/api:${{ needs['upgrade-version'].outputs.new_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Image digest


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/PoK9cE8q/2461-remplacer-with-v-par-tag-prefix-dans-releaseyml

## 🛠 Description de la PR
Les modifications apportées suite aux montées de versions des scripts d'action (particulièrement `anothrNick/github-tag-action`) dans la github action `release.yml` ont généré des effets de bord.
Pour correctement calculer la dernière release, nous avons passé le paramètre `WITH_V` à `true`. Ainsi, l'action a pu trouver le dernier tag valide. Mais le "v" a été intégré à la variable `steps.version.outputs.new_tag`, ce qui a rendu inutile le "v" ajouté manuellement avant chaque appel à la variable.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS