### PR TITLE
#patch (2461-4) Suppression du "v" dans la variable de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,13 @@ jobs:
           DEFAULT_BUMP: patch
           RELEASE_BRANCHES: 'develop'
           DRY_RUN: true
+          TAG_PREFIX: 'v'
+      - name: Strip "v" prefix from tag
+        id: version_no_v
+        run: |
+          echo "tag=${steps_version_outputs_new_tag#v}" >> $GITHUB_OUTPUT
+        env:
+          steps_version_outputs_new_tag: ${{ steps.version.outputs.new_tag }}
       - name: Update version in api package.json
         uses: jossef/action-set-json-field@v2.2
         with:


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/PoK9cE8q/2461-remplacer-with-v-par-tag-prefix-dans-releaseyml

## 🛠 Description de la PR
Modification de la variable pour en supprimer le "v".

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS