### PR TITLE
#patch (2463) Impossible d'enregistrer les modifications d'une action

### DIFF
--- a/packages/api/server/controllers/action/_common/action.write.validator.ts
+++ b/packages/api/server/controllers/action/_common/action.write.validator.ts
@@ -221,8 +221,13 @@ export default (mode: 'create' | 'update') => [
         .trim()
         .notEmpty().withMessage('Vous devez préciser où se déroule l\'action'),
     body('location_autre')
-        .customSanitizer(value => value ?? null),
-
+        .customSanitizer((value) => {
+            // Convertit les chaînes vides, null ou undefined en null
+            if (value === '' || value === null || value === undefined) {
+                return null;
+            }
+            return value;
+        }),
     body('managers')
         .customSanitizer((value, { req }) => {
             // en cas de mise à jour, si l'utilisateur n'a pas le droit de modifier les managers


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/31gRlAGY/2463

## 🛠 Description de la PR
Message d’erreur affiché: "une erreur est survenue lors de l'écriture en base de données."
Le message précis est: **error: new row for relation "actions" violates check constraint "check_actions_location_columns"**
Raison: le validateur retourne une chaine vide plutôt qu’une valeur nulle au service, qui transfère au modèle, qui finalement lève une erreur en raison du non respect de la règle indiquée plus haut.

Le validateur a été corrigé.

## 📸 Captures d'écran
SO

## 🚨 Notes pour la mise en production
Ràs