### PR TITLE
#patch (2457) Ajouter le nombre de sites mis à jour depuis moins de 6 mois

### DIFF
--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
@@ -16,7 +16,7 @@
                     {{ formatStat(townsStore.filteredTowns.length) }}
                     site<template v-if="townsStore.filteredTowns.length > 1"
                         >s</template
-                    ><template v-if="updatedSitesInTheLastSixMonths > 0">
+                    ><template v-if="updatedSitesInTheLastSixMonths !== null">
                         <DsfrBadge
                             class="ml-1"
                             small
@@ -137,7 +137,7 @@ const badgeLabel = computed(() => {
             updatedSitesInTheLastSixMonths.value
         }) mis à jour dans les 6 derniers mois`;
     }
-    return "";
+    return "Aucun site mis à jour au cours des 6 derniers mois";
 });
 
 const badgeVariant = computed(() => {

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
@@ -16,7 +16,21 @@
                     {{ formatStat(townsStore.filteredTowns.length) }}
                     site<template v-if="townsStore.filteredTowns.length > 1"
                         >s</template
-                    >
+                    ><template v-if="updatedSitesInTheLastSixMonths > 0">
+                        <DsfrBadge
+                            class="ml-1"
+                            small
+                            :type="badgeVariant"
+                            :label="badgeLabel"
+                            noIcon
+                        >
+                            dont {{ updatedSitesPercentage }}% de site{{
+                                updatedSitesInTheLastSixMonths > 1 ? "s" : ""
+                            }}
+                            ({{ updatedSitesInTheLastSixMonths }}) mis à jour
+                            dans les 6 derniers mois
+                        </DsfrBadge>
+                    </template>
                 </p>
                 <p v-if="userStore.hasJusticePermission">
                     {{ formatStat(justiceTotal) }} site<template
@@ -51,6 +65,7 @@ import { useUserStore } from "@/stores/user.store";
 import computeLocationSearchTitle from "@/utils/computeLocationSearchTitle";
 import MiniCarte from "@/components/MiniCarte/MiniCarte.vue";
 import formatStat from "@common/utils/formatStat";
+import getSince from "@/utils/getSince";
 
 const townsStore = useTownsStore();
 const userStore = useUserStore();
@@ -84,5 +99,54 @@ const insalubrityOrderTotal = computed(() => {
     return townsStore.filteredTowns.filter(
         ({ insalubrityOrder }) => insalubrityOrder === true
     ).length;
+});
+
+const updatedSitesInTheLastSixMonths = computed(() => {
+    return townsStore.filteredTowns.filter((town) => {
+        if (!town.lastUpdatedAt) {
+            return false;
+        }
+
+        // Utiliser getSince pour obtenir les mois écoulés
+        const { months } = getSince(town.lastUpdatedAt);
+
+        // Un site est considéré comme mis à jour récemment si moins de 6 mois se sont écoulés
+        return months < 6;
+    }).length;
+});
+
+// Pourcentage de sites mis à jour dans les 6 derniers mois
+const updatedSitesPercentage = computed(() => {
+    const totalSites = townsStore.filteredTowns.length;
+    if (totalSites === 0) {
+        return 0; // Éviter la division par zéro
+    }
+
+    const percentage =
+        (updatedSitesInTheLastSixMonths.value / totalSites) * 100;
+
+    // Arrondir à 1 décimale
+    return Math.round(percentage * 10) / 10;
+});
+
+const badgeLabel = computed(() => {
+    if (updatedSitesInTheLastSixMonths.value > 0) {
+        return `dont ${updatedSitesPercentage.value}% de site${
+            updatedSitesInTheLastSixMonths.value > 1 ? "s" : ""
+        } (${
+            updatedSitesInTheLastSixMonths.value
+        }) mis à jour dans les 6 derniers mois`;
+    }
+    return "";
+});
+
+const badgeVariant = computed(() => {
+    if (updatedSitesPercentage.value >= 80) {
+        return "success";
+    } else if (updatedSitesPercentage.value >= 60) {
+        return "warning";
+    } else {
+        return "error";
+    }
 });
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/k6VgZepO/2457

## 🛠 Description de la PR
Dans l'entête de la liste des sites, indiquer, après le nombre de sites, le pourcentage et le nombre de sites mis à jour depuis moins de 6 mois, selon le format suivant : **"dont XX % des sites (YY) mis à jour depuis moins de 6 mois"**

- Si le pourcentage est supérieur ou égal à 80%, le mettre en vert
- Si le pourcentage est inférieur à 80% et supérieur ou égale à 60 % en orange
- Si le pourcentage est inférieur à 60% en rouge

Utiliser le composant "DsfrBadge"

## 📸 Captures d'écran
![{107A1CD5-A6A6-4B65-84A3-64735BAB5387}](https://github.com/user-attachments/assets/d2ed9691-f732-4c4b-a85a-6a3bae947e2d)

## 🚨 Notes pour la mise en production
- ràs