### PR TITLE
#minor (2454) Mettre en avant la dernière activité sur la fiche site

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSite.menu.js
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSite.menu.js
@@ -53,7 +53,7 @@ export default [
         iconColor: "secondary",
     },
     {
-        id: "procedures",
+        id: "procedure",
         label: () => "Procédures",
         route: "#procedure",
         postIcon: "paperclip",

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatusLastEvent.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatusLastEvent.vue
@@ -4,7 +4,7 @@
             v-if="lastEvent.type === 'comment'"
             :to="`/site/${town.id}#journal_du_site`"
         >
-            <span class="inline-ink text-primary">
+            <span class="text-primary">
                 {{ lastEvent.data }}
             </span>
             <span> le {{ formatDate(lastEvent.date, "d M y") }}</span>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatusLastEvent.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatusLastEvent.vue
@@ -4,7 +4,7 @@
             v-if="lastEvent.type === 'comment'"
             :to="`/site/${town.id}#journal_du_site`"
         >
-            <span class="font-semibold">
+            <span class="inline-ink text-primary">
                 {{ lastEvent.data }}
             </span>
             <span> le {{ formatDate(lastEvent.date, "d M y") }}</span>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatusLastEvent.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatusLastEvent.vue
@@ -4,16 +4,46 @@
             v-if="lastEvent.type === 'comment'"
             :to="`/site/${town.id}#journal_du_site`"
         >
-            <span class="font-semibold text-primary">
+            <span class="font-semibold">
                 {{ lastEvent.data }}
             </span>
-            <span> le {{ formatDate(lastEvent.date, "d M y à h:i") }}</span>
+            <span> le {{ formatDate(lastEvent.date, "d M y") }}</span>
         </RouterLink>
         <template v-else>
-            <span class="font-semibold text-primary">
-                {{ lastEvent.data }}
-            </span>
-            <span> le {{ formatDate(lastEvent.date, "d M y à h:i") }}</span>
+            <template
+                v-if="lastEvent.categories && lastEvent.categories.length === 1"
+            >
+                <span>Mise à jour de la rubrique </span>
+                <span class="inline-link-wrapper">
+                    <Link
+                        :to="`/site/${town.id}${getAnchorForCategory(
+                            lastEvent.categories[0]
+                        )}`"
+                        class="inline-link"
+                    >
+                        "{{ lastEvent.categories[0] }}"
+                    </Link>
+                </span>
+            </template>
+            <template v-else>
+                <span>Mise à jour des rubriques </span>
+                <span class="inline-link-wrapper">
+                    <Link
+                        v-for="(category, index) in lastEvent.categories"
+                        :key="index"
+                        :to="`/site/${town.id}${getAnchorForCategory(
+                            category
+                        )}`"
+                        class="inline-link"
+                    >
+                        "{{ category }}"
+                        <span v-if="index < lastEvent.categories.length - 1"
+                            >,
+                        </span>
+                    </Link>
+                </span>
+            </template>
+            <span> le {{ formatDate(lastEvent.date, "d M y") }}</span>
         </template>
     </p>
 </template>
@@ -21,6 +51,7 @@
 import { computed, toRefs } from "vue";
 import { RouterLink } from "vue-router";
 import formatDate from "@common/utils/formatDate";
+import { Link } from "@resorptionbidonvilles/ui";
 
 const props = defineProps({
     town: Object,
@@ -107,6 +138,7 @@ function getLatestEvent(townEvents, comments) {
             return {
                 type: "townEvent",
                 data: "Mise à jour des informations",
+                categories: [],
                 date: new Date(townEvent.date),
             };
         }
@@ -119,12 +151,7 @@ function getLatestEvent(townEvents, comments) {
 
         return {
             type: "townEvent",
-            data:
-                categories.length === 1
-                    ? `Mise à jour de la rubrique "${categories[0]}"`
-                    : `Mise à jour des rubriques : "${categories
-                          .map((c) => c)
-                          .join(", ")}"`,
+            categories: categories,
             date: new Date(townEvent.date),
         };
     });
@@ -132,6 +159,7 @@ function getLatestEvent(townEvents, comments) {
     const normalizedComments = comments.map((comment) => ({
         type: "comment",
         data: "Message dans le journal du site",
+        categories: [],
         date: new Date(comment.createdAt),
     }));
 
@@ -146,7 +174,26 @@ function getLatestEvent(townEvents, comments) {
     }, allEvents[0]);
 }
 
+function getAnchorForCategory(category) {
+    const categoryToAnchor = {
+        "Caractéristiques du site": "#caracteristiques",
+        Habitants: "#habitants",
+        "Conditions de vie": "#conditions_de_vie",
+        Procédures: "#procedure",
+        Localisation: "#localisation",
+    };
+
+    return categoryToAnchor[category] || "";
+}
+
 const lastEvent = computed(() => {
     return getLatestEvent(town.value.changelog, town.value.comments);
 });
 </script>
+<style scoped>
+.inline-link-wrapper :deep(p) {
+    display: inline;
+    margin: 0;
+    padding: 0;
+}
+</style>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteProcedures/FicheSiteProcedures.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteProcedures/FicheSiteProcedures.vue
@@ -236,12 +236,13 @@ const policeStatus = computed(() => {
     );
 });
 
+const existingLitigationText =
+    town.value.existingLitigation === true ? "oui" : "non";
+
 const existingLitigationStatus = computed(() => {
     return town.value.existingLitigation === null
         ? "non communiqué"
-        : town.value.existingLitigation
-        ? "oui"
-        : "non";
+        : existingLitigationText;
 });
 
 const administrativeOrderStatus = computed(() => {

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -189,7 +189,7 @@ watch(address, async () => {
                 address.value.data.citycode
             );
         } catch (e) {
-            console.log("Failed fetching more information about the city");
+            console.log("Failed fetching more information about the city", e);
         }
     }
 });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/2r4aSsz4/2454

## 🛠 Description de la PR
- Rendre la rubrique associée à la dernière modification cliquable
- Si la dernière modification concerne plusieurs rubriques, chaque rubrique faisant l’objet d’une modification est un lien cliquable
- Supprimer l’heure de mise à jour
- Corriger deux alertes SonarQube
  - Conditions ternaires imbriquées
  - Erreur levée non exploitée

## 📸 Captures d'écran
![{B388D9F9-DE61-420D-8D44-968B5B96D203}](https://github.com/user-attachments/assets/1296d497-24f0-4171-9217-53555a53900a)
![{5BD3FEDD-F088-45AE-87C3-9F0624DE733B}](https://github.com/user-attachments/assets/5cf55f02-670e-451c-8409-68ca144958f8)

## 🚨 Notes pour la mise en production
- Ràs