### PR TITLE
#patch (2455) Préciser la création de site si c'est la dernière activité 

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatus.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderStatus.vue
@@ -20,7 +20,7 @@
             :town="town"
         />
         <div v-else>
-            <p class="font-semibold text-black">
+            <p class="text-black">
                 Site déclaré le
                 {{ formatDate(town.createdAt, "d M y") }}
             </p>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JUvincsj/2455

## 🛠 Description de la PR
Si le site a été déclaré, mais qu'aucune autre activité n'est enregistrée, on n'avait jusqu'à présent aucune indication relative à la dernière activité
Désormais, en cas d'absence d'autre activité que la déclaration de site, c'est la déclaration de site qui est affiché, mentionnant la date de création de la fiche site

## 📸 Captures d'écran
![{F54FD4CE-D84D-48DD-ADE2-1CFBBE8F6262}](https://github.com/user-attachments/assets/f8f7878a-8848-4a78-8506-7c0bd2422b87)

## 🚨 Notes pour la mise en production
ràs