### PR TITLE
#patch (2468) Intégration d'un bouton de suppression des filtres sur les actions

### DIFF
--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
@@ -3,14 +3,14 @@
         <article class="flex flex-col gap-2">
             <div>
                 <p>Filtrer par</p>
-                <div class="flex space-x-2">
+                <div class="flex flex-col xs:flex-row gap-2 flex-wrap shrink-0">
                     <Filter
                         v-for="filter in filters"
                         :key="filter.id"
                         :title="filter.label"
                         :options="filter.options"
                         v-model="actionsStore.filters.properties[filter.id]"
-                        class="border-1 !border-primary rounded hover:bg-blue200"
+                        class="!border-primary rounded hover:bg-blue200"
                     />
                 </div>
             </div>

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
@@ -1,15 +1,25 @@
 <template>
     <section class="flex items-end flex-wrap space-x-4">
-        <article>
-            <p>Filtrer par</p>
-            <div class="flex space-x-2">
-                <Filter
-                    v-for="filter in filters"
-                    :key="filter.id"
-                    :title="filter.label"
-                    :options="filter.options"
-                    v-model="actionsStore.filters.properties[filter.id]"
-                    class="border-1 !border-primary rounded hover:bg-blue200"
+        <article class="flex flex-col gap-2">
+            <div>
+                <p>Filtrer par</p>
+                <div class="flex space-x-2">
+                    <Filter
+                        v-for="filter in filters"
+                        :key="filter.id"
+                        :title="filter.label"
+                        :options="filter.options"
+                        v-model="actionsStore.filters.properties[filter.id]"
+                        class="border-1 !border-primary rounded hover:bg-blue200"
+                    />
+                </div>
+            </div>
+            <div>
+                <DsfrButton
+                    v-if="isFiltered"
+                    label="Effacer les filtres"
+                    size="sm"
+                    @click="actionsStore.resetFilters"
                 />
             </div>
         </article>
@@ -17,10 +27,19 @@
 </template>
 
 <script setup>
+import { computed } from "vue";
 import { useActionsStore } from "@/stores/actions.store";
 import filters from "./ListeDesActions.filtres";
 
 import { Filter } from "@resorptionbidonvilles/ui";
 
 const actionsStore = useActionsStore();
+
+const isFiltered = computed(() => {
+    const filterValues = Object.values(actionsStore.filters.properties);
+    const activeFiltersCount = filterValues.filter(
+        (value) => Array.isArray(value) && value.length > 0
+    ).length;
+    return activeFiltersCount >= 2;
+});
 </script>

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
@@ -10,7 +10,7 @@
                         :title="filter.label"
                         :options="filter.options"
                         v-model="actionsStore.filters.properties[filter.id]"
-                        class="!border-primary rounded hover:bg-blue200"
+                        class="!border !border-primary rounded hover:bg-blue200"
                     />
                 </div>
             </div>

--- a/packages/frontend/webapp/src/stores/actions.store.js
+++ b/packages/frontend/webapp/src/stores/actions.store.js
@@ -156,6 +156,7 @@ export const useActionsStore = defineStore("actions", () => {
         filteredActions,
         currentPage,
         hash,
+        resetFilters,
         numberOfPages: computed(() => {
             if (filteredActions.value.length === 0) {
                 return 0;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/63ac5xOH/2468-liste-des-actions-ajouter-un-bouton-pour-effacer-tous-les-filtres

## 🛠 Description de la PR
Cette PR intègre un bouton DSFR permettant de supprimer les filtres appliqués à la liste des actions. Ce bouton n'apparaît qu'à partir du moment où 2 filtres différents sont appliqués.

## 📸 Captures d'écran
<img width="647" height="385" alt="image" src="https://github.com/user-attachments/assets/35342965-cc26-494d-a61f-e12a9eb82702" />

## 🚨 Notes pour la mise en production
RàS