### PR TITLE
#patch (2474) Correction du build PROD de l'API

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -47,13 +47,13 @@ RUN apk update && apk upgrade \
     && mkdir -p /home/node/app/packages/api
 
 COPY packages/api/package.json /home/node/app/packages/api/
-COPY --from=build /home/node/app/packages/api/dist /home/node/app/packages/api/dist
+COPY --from=build /home/node/app/packages/api/dist /home/node/app/packages/
 
 RUN chown -R root:root /home/node/app && \
     chmod -R 755 /home/node/app && \
-    chmod -R 550 /home/node/app/packages/api/dist && \
+    chmod -R 550 /home/node/app/packages && \
     chmod 440 /home/node/app/packages/api/package.json && \
-    chown -R node:node /home/node/app/packages/api/dist && \
+    chown -R node:node /home/node/app/packages && \
     chown node:node /home/node/app/packages/api/package.json && \
     mkdir -p /home/node/app/packages/api/node_modules && \
     chown node:node /home/node/app/packages/api/node_modules && \

--- a/packages/api/pm2.config.js
+++ b/packages/api/pm2.config.js
@@ -2,7 +2,7 @@ module.exports = {
     apps: [
         {
             name: 'api',
-            script: 'dist/api/server/index.js',
+            script: 'server/index.js',
             instances: 1,
             exec_mode: 'fork',
             watch: false,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/nCCWxKBT/2474-bug-correction-du-build-api

## 🛠 Description de la PR
Cette PR corrige les chemins créés lors du build de PROD de l'API afin de réactiver les seeders et migrations (bloqués depuis le passage en Node22).

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS