### PR TITLE
#patch (2469) Ajout des compteurs sur la liste des actions

### DIFF
--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActions.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActions.vue
@@ -33,10 +33,23 @@ import ListeDesActionsVide from "./ListeDesActionsVide.vue";
 
 const actionsStore = useActionsStore();
 
-const tabs = [
-    { id: "open", label: "Actions en cours" },
-    { id: "closed", label: "Actions terminées" },
-];
+const tabs = computed(() => {
+    const initialTabs = [
+        {
+            id: "open",
+            label: "Actions en cours",
+            total: actionsCount.value.open,
+        },
+        {
+            id: "closed",
+            label: "Actions terminées",
+            total: actionsCount.value.closed,
+        },
+    ];
+
+    return initialTabs;
+});
+
 const currentTab = computed({
     get() {
         return actionsStore.filters.status;
@@ -65,4 +78,16 @@ const getUniqueYears = (actionsData) => {
 
 // Liste des années uniques extraites des dates de début et de fin d'action
 const years = computed(() => getUniqueYears(actionsStore.filteredActions));
+
+const actionsCount = computed(() => {
+    let actions = { open: 0, closed: 0 };
+    actionsStore.actions.map((action) => {
+        if (action.ended_at === null || new Date() < action.ended_at) {
+            actions.open++;
+        } else {
+            actions.closed++;
+        }
+    });
+    return actions;
+});
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/cluFIUiy/2469-liste-des-actions-ajouter-les-compteurs-des-actions-comme-pour-les-sites

## 🛠 Description de la PR
La PR ajoute les compteurs d'actions en cours et fermées sur la liste des actions.

## 📸 Captures d'écran
<img width="645" height="180" alt="image" src="https://github.com/user-attachments/assets/facc6415-ffc7-4ea1-be62-68b4b1e35d17" />

## 🚨 Notes pour la mise en production
RàS