### PR TITLE
#patch (2472) [Bug] Signaler un site renvoie une erreur liée aux phases préparatoire de la résorption

### DIFF
--- a/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
+++ b/packages/api/server/controllers/shantytown/_common/shantytown.write.validator.ts
@@ -1156,7 +1156,7 @@ export default mode => ([
 
             return value;
         })
-        .if((value, { req }) => req.user.isAllowedTo('access', 'shantytown_justice'))
+        .if((value, { req }) => req.user.isAllowedTo('access', 'shantytown_justice') && can(req.user).do(mode, 'shantytown').on(req.body.city))
         .exists({ checkNull: true }).bail().withMessage('Le champ "Existence d\'une procédure judiciaire" est obligatoire')
         .toInt()
         .isInt({ min: -1, max: 1 }).withMessage('Le champ "Existence d\'une procédure judiciaire" est invalide')


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/QBWjFmzv/2472-bug-signaler-un-site-renvoie-une-erreur

## 🛠 Description de la PR
Lors du signalement d'un site par un intervenant, celui-ci rencontrait toujours une erreur indiquant que les phases préparatoires à la résorption devaient être renseignées.
D'autre part, dans le cas où un intervenant sélectionnait une adresse hors de son territoire, la partie liée aux procédures judiciaires et administratives ne s'affichait pas, ce qui est normal. Cependant, lors de l'envoie du formulaire, 2 erreurs s'affichaient au lieu d'une seule.
En effet, les erreurs affichées étaient:
1. Le champ "Existence d'une procédure judiciaire" est obligatoire
2. Vous n'avez pas le droit d'informer d'un nouveau site sur ce territoire
Cette PR corrige donc la gestion de l'erreur liée aux phases préparatoires de la résorption ainsi que la gestion de l'affichage de l'erreur des procédures en fonction du territoire de l'utilisateur.

## 📸 Captures d'écran
<img width="862" height="175" alt="image" src="https://github.com/user-attachments/assets/9b0a94b7-4548-4bbd-8d8b-cb5c8d61972b" />

## 🚨 Notes pour la mise en production
RàS