### PR TITLE
#patch (2478) [Site] Indiquer si une alerte canicule est activée

### DIFF
--- a/packages/frontend/webapp/src/components/ArrangementLeftMenu/ArrangementLeftMenuColumn.vue
+++ b/packages/frontend/webapp/src/components/ArrangementLeftMenu/ArrangementLeftMenuColumn.vue
@@ -7,13 +7,13 @@
         </p>
 
         <template v-for="tab in tabs" :key="tab.id">
-            <Button
+            <DsfrButton
                 v-if="tab.action"
                 size="sm"
                 @click="tab.action"
                 class="self-start"
                 ><Icon v-if="tab.icon" :icon="tab.icon" />
-                {{ tab.label }}</Button
+                {{ tab.label }}</DsfrButton
             >
 
             <RouterLink
@@ -29,8 +29,12 @@
                 ]"
                 replace
                 ><Icon v-if="tab.icon" :icon="tab.icon" /> {{ tab.label }}
-                <Icon v-if="tab.postIcon" icon="paperclip"
-            /></RouterLink>
+                <Icon
+                    v-if="tab.postIcon"
+                    :icon="tab.postIcon"
+                    :class="tab.iconColor ? `text-${tab.iconColor}` : ''"
+                />
+            </RouterLink>
         </template>
     </nav>
 </template>
@@ -38,7 +42,7 @@
 <script setup>
 import { defineProps, toRefs } from "vue";
 import { RouterLink } from "vue-router";
-import { Icon, Button } from "@resorptionbidonvilles/ui";
+import { Icon } from "@resorptionbidonvilles/ui";
 import focusClasses from "@common/utils/focus_classes";
 
 const props = defineProps({

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSite.menu.js
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSite.menu.js
@@ -49,6 +49,8 @@ export default [
         id: "conditions_de_vie",
         label: () => "Conditions de vie et environnement",
         route: "#conditions_de_vie",
+        postIcon: "warning",
+        iconColor: "secondary",
     },
     {
         id: "procedures",
@@ -72,6 +74,7 @@ export default [
         },
         route: "#journal_du_site",
         icon: "comment",
+        postIcon: "paperclip",
         variant: "secondary",
         condition(town) {
             const userStore = useUserStore();

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSite.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSite.vue
@@ -122,8 +122,10 @@ const tabs = computed(() => {
                 postIcon:
                     (item.id === "journal_du_site" &&
                         commentsAttachments > 0) ||
-                    (item.id === "procedures" && proceduresAttachments > 0)
-                        ? true
+                    (item.id === "procedures" && proceduresAttachments > 0) ||
+                    (item.id === "conditions_de_vie" &&
+                        town.value.heatwaveStatus)
+                        ? item.postIcon
                         : false,
             };
         });

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVie.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVie.vue
@@ -23,6 +23,15 @@
         </p>
 
         <FicheSiteConditionsDeVieRubrique
+            :border="true"
+            :marginTop="false"
+            title="Alerte canicule"
+            info="L'alerte canicule peut être déclenchée lorsque la température dépasse un seuil critique, mettant en danger la santé des populations vulnérables."
+            :status="heatwaveStatus"
+            :answers="[]"
+        />
+
+        <FicheSiteConditionsDeVieRubrique
             :border="false"
             :marginTop="false"
             title="Accès à l’eau"
@@ -115,5 +124,17 @@ const pestAnimalsWording = computed(() => {
     return town.value.livingConditions[key].status.status === "good"
         ? "Absence de nuisible"
         : "Présence de nuisibles";
+});
+
+const heatwaveStatus = computed(() => {
+    return {
+        negative: [],
+        positive: [],
+        unknown: [],
+        status:
+            town.value.heatwaveStatus === true
+                ? "activeHeatwave"
+                : "inactiveHeatwave",
+    };
 });
 </script>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVieRubrique.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteConditionsDeVie/FicheSiteConditionsDeVieRubrique.vue
@@ -135,18 +135,24 @@ const COLORS = {
     toImprove: "text-secondary",
     bad: "text-secondary",
     unknown: "text-secondary",
+    activeHeatwave: "text-warning",
+    inactiveHeatwave: "text-G700",
 };
 const ICONS = {
     good: "check",
     toImprove: "exclamation-triangle",
     bad: "times",
     unknown: "question",
+    activeHeatwave: "sun",
+    inactiveHeatwave: "temperature-half",
 };
 const TEXTS = {
     good: "oui",
     toImprove: "à améliorer",
     bad: "non",
     unknown: "inconnu",
+    activeHeatwave: "activée",
+    inactiveHeatwave: "désactivée",
 };
 const realStatus = computed(() => {
     let s = status.value.status;

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderBoutons.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderBoutons.vue
@@ -1,97 +1,124 @@
 <template>
-    <p class="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
-        <RouterLink
-            to="#journal_du_site"
-            v-if="
-                userStore.hasLocalizedPermission(
-                    'shantytown_comment.list',
-                    town
-                )
-            "
+    <div
+        class="flex flex-col justify-between items-start gap-2 sm:flex-row sm:items-center"
+    >
+        <div
+            class="flex flex-col items-start gap-2 sm:flex-row sm:items-center"
         >
+            <RouterLink
+                to="#journal_du_site"
+                v-if="
+                    userStore.hasLocalizedPermission(
+                        'shantytown_comment.list',
+                        town
+                    )
+                "
+            >
+                <Button
+                    size="sm"
+                    variant="primaryOutline"
+                    icon="comment"
+                    iconPosition="left"
+                    tabindex="-1"
+                    class="!border-2 !border-primary hover:!bg-primary"
+                    >Journal du site</Button
+                >
+            </RouterLink>
             <Button
                 size="sm"
-                variant="primaryOutline"
-                icon="comment"
+                icon="file-word"
                 iconPosition="left"
-                tabindex="-1"
+                variant="primaryOutline"
+                @click="openExportModal"
                 class="!border-2 !border-primary hover:!bg-primary"
-                >Journal du site</Button
+                >Exporter</Button
             >
-        </RouterLink>
-        <Button
-            size="sm"
-            icon="file-word"
-            iconPosition="left"
-            variant="primaryOutline"
-            @click="openExportModal"
-            class="!border-2 !border-primary hover:!bg-primary"
-            >Exporter</Button
-        >
-        <Button
-            v-if="
-                userStore.hasLocalizedPermission('shantytown.close', town) &&
-                town.status === 'open'
-            "
-            size="sm"
-            variant="primary"
-            icon="house-circle-xmark"
-            iconPosition="left"
-            :href="`/site/${town.id}/fermeture`"
-            class="hover:!bg-primaryDark"
-            >Fermer le site</Button
-        >
+            <Button
+                v-if="
+                    userStore.hasLocalizedPermission(
+                        'shantytown.close',
+                        town
+                    ) && town.status === 'open'
+                "
+                size="sm"
+                variant="primary"
+                icon="house-circle-xmark"
+                iconPosition="left"
+                :href="`/site/${town.id}/fermeture`"
+                class="hover:!bg-primaryDark"
+                >Fermer le site</Button
+            >
 
-        <Button
-            v-if="
-                userStore.hasLocalizedPermission(
-                    'shantytown.fix_status',
-                    town
-                ) && town.status !== 'open'
-            "
-            size="sm"
-            variant="primary"
-            icon="house-circle-xmark"
-            iconPosition="left"
-            :href="`/site/${town.id}/fermeture`"
-            class="hover:!bg-primaryDark"
-            >Corriger la fermeture du site</Button
-        >
-        <Button
-            size="sm"
-            variant="primary"
-            icon="pencil"
-            iconPosition="left"
-            v-if="
-                userStore.hasLocalizedPermission('shantytown.update', town) &&
-                town.status === 'open'
-            "
-            :href="`/site/${town.id}/mise-a-jour`"
-            class="hover:!bg-primaryDark"
-            >Mettre à jour</Button
-        >
-        <Button
-            v-if="displayStartResorptionButton"
-            size="sm"
-            variant="primary"
-            icon="fa-regular fa-play"
-            iconPosition="left"
-            @click="startResorption"
-            :loading="startResorptionIsLoading"
-            >Démarrer la résorption</Button
-        >
-        <Button
-            v-if="userStore.hasLocalizedPermission('shantytown.delete', town)"
-            size="sm"
-            variant="primary"
-            icon="fa-regular fa-trash-alt"
-            iconPosition="left"
-            @click="deleteTown"
-            :loading="deleteIsLoading"
-            class="!border-2 !border-primary hover:!bg-primaryDark"
-            >Supprimer le site</Button
-        >
-    </p>
+            <Button
+                v-if="
+                    userStore.hasLocalizedPermission(
+                        'shantytown.fix_status',
+                        town
+                    ) && town.status !== 'open'
+                "
+                size="sm"
+                variant="primary"
+                icon="house-circle-xmark"
+                iconPosition="left"
+                :href="`/site/${town.id}/fermeture`"
+                class="hover:!bg-primaryDark"
+                >Corriger la fermeture du site</Button
+            >
+            <Button
+                size="sm"
+                variant="primary"
+                icon="pencil"
+                iconPosition="left"
+                v-if="
+                    userStore.hasLocalizedPermission(
+                        'shantytown.update',
+                        town
+                    ) && town.status === 'open'
+                "
+                :href="`/site/${town.id}/mise-a-jour`"
+                class="hover:!bg-primaryDark"
+                >Mettre à jour</Button
+            >
+            <Button
+                v-if="displayStartResorptionButton"
+                size="sm"
+                variant="primary"
+                icon="fa-regular fa-play"
+                iconPosition="left"
+                @click="startResorption"
+                :loading="startResorptionIsLoading"
+                >Démarrer la résorption</Button
+            >
+            <Button
+                v-if="
+                    userStore.hasLocalizedPermission('shantytown.delete', town)
+                "
+                size="sm"
+                variant="primary"
+                icon="fa-regular fa-trash-alt"
+                iconPosition="left"
+                @click="deleteTown"
+                :loading="deleteIsLoading"
+                class="!border-2 !border-primary hover:!bg-primaryDark"
+                >Supprimer le site</Button
+            >
+        </div>
+        <div>
+            <DsfrButton
+                size="sm"
+                :label="
+                    heatwaveStatus
+                        ? 'Supprimer l\'alerte Canicule'
+                        : 'Activer l\'alerte Canicule'
+                "
+                icon="fr-icon-thermometer-line"
+                class="hover:!text-white"
+                secondary
+                :disabled="heatwaveRequestStatus?.loading"
+                @click.prevent.stop="toggleHeatwave"
+            />
+        </div>
+    </div>
 </template>
 
 <script setup>
@@ -114,6 +141,8 @@ const props = defineProps({
 });
 const { town } = toRefs(props);
 const userStore = useUserStore();
+const notificationStore = useNotificationStore();
+const townsStore = useTownsStore();
 
 const { displayPhasesPreparatoiresResorption } =
     usePhasesPreparatoiresResorption(town);
@@ -215,9 +244,6 @@ async function startResorption() {
 
     startResorptionIsLoading.value = true;
 
-    const notificationStore = useNotificationStore();
-    const townsStore = useTownsStore();
-
     nextTick(async () => {
         try {
             await townsStore.startResorption(town.value.id);
@@ -246,6 +272,46 @@ const displayStartResorptionButton = computed(() => {
         !townIsClosed.value
     );
 });
+
+const heatwaveStatus = computed(() => {
+    return town.value.heatwaveStatus;
+});
+
+const heatwaveRequestStatus = computed(() => {
+    return townsStore.heatwaveStatuses[town.value.id] || null;
+});
+
+async function toggleHeatwave() {
+    try {
+        await townsStore.setHeatwaveStatus(
+            town.value.id,
+            !town.value.heatwaveStatus
+        );
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log("Erreur lors de la modification du statut canicule :", e);
+
+        notificationStore.error(
+            "Risque canicule",
+            "Une erreur inconnue est survenue"
+        );
+        return;
+    }
+
+    if (heatwaveRequestStatus.value?.error !== null) {
+        notificationStore.error(
+            "Risque canicule",
+            heatwaveRequestStatus.value.error
+        );
+    } else {
+        notificationStore.success(
+            "Risque canicule",
+            town.value.heatwaveStatus === true
+                ? "Le site a été marqué comme particulièrement exposé à la canicule"
+                : "Le site n'est plus marqué comme à risque"
+        );
+    }
+}
 </script>
 
 <style scoped>

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderName.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHeader/FicheSiteHeaderName.vue
@@ -2,7 +2,14 @@
     <p class="text-sm font-normal">
         {{ town.city.name }}, {{ town.epci.name }} ({{ town.departement.name }})
     </p>
-    <h1>{{ town.addressSimple }}</h1>
+    <div class="flex flex-row gap-2 items-center">
+        <h1>{{ town.addressSimple }}</h1>
+        <DsfrBadge
+            v-if="town.heatwaveStatus"
+            label="Alerte canicule"
+            type="warning"
+        />
+    </div>
     <span v-if="town.name" class="text-md">&nbsp; « {{ town.name }} »</span>
 </template>
 

--- a/packages/frontend/webapp/src/helpers/dsfr.js
+++ b/packages/frontend/webapp/src/helpers/dsfr.js
@@ -1,5 +1,6 @@
 import {
     DsfrAlert,
+    DsfrBadge,
     DsfrButton,
     DsfrButtonGroup,
     DsfrCard,
@@ -20,6 +21,7 @@ import "@gouvfr/dsfr/dist/component/component.main.min.css";
 
 export function useDsfr(app) {
     app.component("DsfrAlert", DsfrAlert);
+    app.component("DsfrBadge", DsfrBadge);
     app.component("DsfrButton", DsfrButton);
     app.component("DsfrButtonGroup", DsfrButtonGroup);
     app.component("DsfrCard", DsfrCard);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JJsrxxsW/2478-site-indiquer-si-une-alerte-canicule-est-activ%C3%A9e

## 🛠 Description de la PR
Cette PR apporte des indications sur l'alerte canicule dans la fiche de site:
- Badge dans l'entête du site si l'alerte est activée
- Icône sur l'item "Conditions de vie" dans le menu de gauche si l'alerte est activée
- Affichage du statut de l'alerte canicule dans la rubrique "Conditions de vie"
- Bouton d'activation/désactivation de l'alerte canicule lié aux boutons d'actions du site

## 📸 Captures d'écran
Alerte activée:
<img width="1565" height="882" alt="image" src="https://github.com/user-attachments/assets/85596f87-3feb-4926-b533-25aa44aa0345" />
<img width="1565" height="345" alt="image" src="https://github.com/user-attachments/assets/d9c734d7-4744-445d-89c6-29ee2e8bdd71" />
Alerte désactivée:
<img width="1565" height="882" alt="image" src="https://github.com/user-attachments/assets/18f282c6-7423-4b8a-8c39-720c70e3ba96" />
<img width="1567" height="295" alt="image" src="https://github.com/user-attachments/assets/8cc310dc-5510-4910-885c-bdfabf9f2ada" />

## 🚨 Notes pour la mise en production
RàS