### PR TITLE
#patch (2467) [Liste des actions] Ajouter le bouton Mettre à jour

### DIFF
--- a/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
@@ -64,15 +64,24 @@
                 />
             </div>
 
-            <div class="flex justify-end px-4 py-4">
-                <div>
-                    <Link
-                        :to="`/action/${action.id}`"
-                        :aria-label="`Voir la fiche de l'action ${action.name}`"
-                    >
-                        <Icon icon="arrow-right" /> Voir la fiche de l'action
-                    </Link>
-                </div>
+            <div
+                class="flex justify-end h-14 items-center mr-4 space-x-4 print:hidden"
+            >
+                <DsfrButton
+                    v-if="hasUpdateShantytownPermission"
+                    size="sm"
+                    label="Mettre à jour"
+                    icon="fr-icon-pencil-line"
+                    secondary
+                    @click.prevent.stop="navigateTo('mise-a-jour')"
+                />
+                <DsfrButton
+                    size="sm"
+                    label="Voir la fiche de l'action"
+                    icon="fr-icon-arrow-right-line"
+                    primary
+                    @click="navigate"
+                />
             </div>
         </div>
     </RouterLink>
@@ -84,12 +93,14 @@ import formatDate from "@common/utils/formatDate";
 import focusClasses from "@common/utils/focus_classes";
 
 import { RouterLink } from "vue-router";
-import { Icon, Link, Tag } from "@resorptionbidonvilles/ui";
+import { Icon, Tag } from "@resorptionbidonvilles/ui";
 import CarteActionColonneChampsIntervention from "./CarteActionColonneChampsIntervention.vue";
 import CarteActionDetailleeColonneDepartement from "./CarteActionDetailleeColonneDepartement.vue";
 import CarteActionDetailleeColonneLocalisation from "./CarteActionDetailleeColonneLocalisation.vue";
 import CarteActionDetailleeColonnePilote from "./CarteActionDetailleeColonnePilote.vue";
 import CarteActionDetailleeColonneOperateur from "./CarteActionDetailleeColonneOperateur.vue";
+import { useUserStore } from "@/stores/user.store";
+import { useRouter } from "vue-router";
 
 const props = defineProps({
     action: {
@@ -98,6 +109,8 @@ const props = defineProps({
 });
 
 const { action } = toRefs(props);
+const userStore = useUserStore();
+const router = useRouter();
 
 const isHover = ref(false);
 
@@ -116,6 +129,21 @@ const actionPeriod = computed(() => {
         );
     }
 });
+
+const hasUpdateShantytownPermission = computed(() => {
+    return userStore.hasUpdateShantytownPermission(action.value);
+});
+
+const navigateTo = (target) => {
+    console.log("shantytown.value = ", action.value);
+    if (action.value && action.value.id) {
+        let path = `/action/${action.value.id}`;
+        if (target) {
+            path += `/${target}`;
+        }
+        router.push(path);
+    }
+};
 
 const attachmentsLabel = computed(() => {
     const commentsAttachments = action.value.comments.reduce((sum, comment) => {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/PeI16Mjz

## 🛠 Description de la PR
La pr a pour objectif d'ajouter le bouton mettre a jour sur les cartes d'actions de la liste des actions.
Cela permet d'homogénéiser le comportement de la liste des sites et des actions.

## 📸 Captures d'écran
<img width="950" height="184" alt="{4E721A9D-D956-4AC2-9275-4030CA12DB93}" src="https://github.com/user-attachments/assets/866efe44-ad01-47a2-8a7a-7c843332d8d7" />

## 🚨 Notes pour la mise en production
RAS