### PR TITLE
#patch (2477) [Tracking] Ajouter un tracking sur le fait de positionner/retirer une alerte canicule

### DIFF
--- a/packages/api/server/config.ts
+++ b/packages/api/server/config.ts
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 export default {
+    environnement: process.env.NODE_ENV || 'production',
     assetsSrc: path.resolve(__dirname, '../assets'),
     wwwUrl: `https://${process.env.RB_API_FRONT_DOMAIN}`,
     webappUrl: `https://app.${process.env.RB_API_FRONT_DOMAIN}`,

--- a/packages/api/server/utils/mattermost.ts
+++ b/packages/api/server/utils/mattermost.ts
@@ -19,6 +19,503 @@ const formatDate = ((dateToFormat: Date): string => {
     return `${day}/${month}/${year}`;
 });
 
+async function triggerActorInvitedAlert(town: Shantytown, host: User, invited: string): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const actorInvitedAlert = new IncomingWebhook(mattermost);
+    const townLink = formatTownLink(town.id, town.usename);
+
+    const username = formatUsername(host);
+    const usernameLink = `<${webappUrl}/nouvel-utilisateur/${host.id}|${username}>`;
+
+    const mattermostMessage = {
+        channel: '#notif-invitations-intervenants',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: Intervenant invité sur le site ${townLink} par ${usernameLink}`,
+        attachments: [
+            {
+                color: '#f2c744',
+                fields: [
+                    {
+                        short: false,
+                        value: `*Personne invitée*: ${invited}`,
+                    },
+                ],
+            }],
+    };
+
+    await actorInvitedAlert.send(mattermostMessage);
+}
+
+export async function triggerAttachmentArchiveCleanup(deleteRequestsCount: number, errorsCount: number): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const webhook = new IncomingWebhook(mattermost);
+    const mattermostMessage = {
+        channel: '#notif-nettoyage-piecesjointes',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: Un nettoyage automatique des fichiers vient d'être effectué pour un total de ${deleteRequestsCount} fichiers à supprimer et ${errorsCount} erreurs rencontrées`,
+        fields: [],
+    };
+
+    await webhook.send(mattermostMessage);
+}
+
+export async function triggerAttachmentArchiveCleanupError(): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const webhook = new IncomingWebhook(mattermost);
+    const mattermostMessage = {
+        channel: '#notif-nettoyage-piecesjointes',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: ':rotating_light: Une erreur est survenue lors du DELETE en base de données',
+        fields: [],
+    };
+
+    await webhook.send(mattermostMessage);
+}
+
+async function triggerDeclaredActor(town: Shantytown, user: User): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const declaredActor = new IncomingWebhook(mattermost);
+
+    const address = formatAddress(town);
+    const username = formatUsername(user);
+    const townLink = formatTownLink(town.id, address);
+
+    const mattermostMessage = {
+        channel: '#notif-intervenants-declares',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: ${username} s'est déclaré comme intervenant sur le site ${townLink}`,
+        fields: [],
+    };
+
+    await declaredActor.send(mattermostMessage);
+}
+
+const triggerHeatwaveStatusChange = async (user: User, town: Shantytown, heatwaveStatus: boolean): Promise<void> => {
+    if (!mattermost) {
+        return;
+    }
+
+    const webhook = new IncomingWebhook(mattermost);
+
+    const username = formatUsername(user);
+    const usernameLink = `<${webappUrl}/acces/${user.id}|${username}>`;
+
+    const alertColor: string = heatwaveStatus === true ? '#d63232' : '#f2c744';
+    const alertStatus: string = heatwaveStatus === true ? '**activée** :high_brightness:' : '**désactivée** :negative_squared_cross_mark:';
+
+    const mattermostMessage = {
+        channel: `#notif-canicule${config.environnement === 'development' ? '-test' : ''}`,
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:thermometer: Une alerte canicule a été ${alertStatus} par ${usernameLink} <${user.email}>`,
+        attachments: [
+            {
+                color: alertColor,
+                fields: [
+                    {
+                        short: false,
+                        value: `*Site*: ${formatTownLink(town.id, town.usename)} *(ID du site: #${town.id})*`,
+                    },
+                    {
+                        short: false,
+                        value: `*Organisation*: ${user.organization.name} ${user.organization.abbreviation ? `(${user.organization.abbreviation})` : ''}`,
+                    },
+                    {
+                        short: false,
+                        value: `*Rôle*: ${user.position}`,
+                    },
+                    {
+                        short: false,
+                        value: `*Statut de l'alerte*: ${alertStatus}`,
+                    },
+                ],
+            },
+        ],
+    };
+
+    await webhook.send(mattermostMessage);
+};
+
+async function triggerInvitedActor(town: Shantytown, host: User, guest: User): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const invitedActor = new IncomingWebhook(mattermost);
+
+    const address = formatAddress(town);
+    const hostUsername = formatUsername(host);
+    const guestUsername = formatUsername(guest);
+    const townLink = formatTownLink(town.id, address);
+
+    const mattermostMessage = {
+        channel: '#notif-intervenants-declares',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: ${hostUsername} a invité ${guestUsername} à se déclarer comme intervenant sur le site ${townLink}`,
+        fields: [],
+    };
+
+    await invitedActor.send(mattermostMessage);
+}
+
+async function triggerLandRegistryRequest(user: User, parcel: string, dataYear: string): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const newLandRegistryEnquiryAlert = new IncomingWebhook(mattermost);
+
+    const username = formatUsername(user);
+    const usernameLink = `<${webappUrl}/acces/${user.id}|${username}>`;
+
+    let locationText = 'Inconnu';
+    if (user.intervention_areas.is_national) {
+        locationText = 'National';
+    } else {
+        const area = user.intervention_areas.areas.find(a => a.is_main_area && a.type !== 'nation');
+        if (area !== undefined) {
+            locationText = area[area.type].name;
+        }
+    }
+
+    const mattermostMessage = {
+        channel: '#notif-requetes-cadastre',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:world_map: Demande d'information cadastre de: ${usernameLink} <${user.email}>`,
+        attachments: [
+            {
+                color: '#f2c744',
+                fields: [
+                    {
+                        short: false,
+                        value: `*Territoire de rattachement*: ${locationText}`,
+                    },
+                    {
+                        short: false,
+                        value: `*Organisation*: ${user.organization.name}`,
+                    },
+                    {
+                        short: false,
+                        value: `*Fonction*: ${user.position}`,
+                    },
+                    {
+                        short: false,
+                        value: `*Parcelle concernée*: ${parcel}`,
+                    },
+                    {
+                        short: false,
+                        value: `*Millésime des données du cadastre*: ${dataYear}`,
+                    },
+                ],
+            },
+        ],
+    };
+
+    await newLandRegistryEnquiryAlert.send(mattermostMessage);
+}
+
+async function triggerNewActionComment(comment: string, action: Action, author: CommentAuthor): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const newCommentAlert = new IncomingWebhook(mattermost);
+
+    const username = formatUsername(author);
+    const actionLink = formatActionLink(action.id, action.name);
+
+    const mattermostMessage = {
+        channel: '#notif-action-nouveau-commentaire',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: Commentaire sur l'action: ${actionLink} par ${username}`,
+        attachments: [
+            {
+                color: '#f2c744',
+                fields: [
+                    {
+                        short: false,
+                        value: `*Commentaire*: ${comment}`,
+                    },
+                ],
+            },
+        ],
+    };
+
+    await newCommentAlert.send(mattermostMessage);
+}
+
+async function triggerNewComment(commentDescription: string, tagLabels: string[], town: Shantytown, author: User): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const newCommentAlert = new IncomingWebhook(mattermost);
+
+    const address = formatAddress(town);
+    const username = formatUsername(author);
+    const townLink = formatTownLink(town.id, address);
+
+    const fields = [{
+        short: false,
+        value: `*Commentaire*: ${commentDescription}`,
+    }];
+
+    if (tagLabels.length > 0) {
+        fields.push({
+            short: false,
+            value: `*Qualification${tagLabels.length > 1 ? 's' : ''} du commentaire*: ${tagLabels.join(', ')}.`,
+        });
+    }
+    const mattermostMessage = {
+        channel: '#notif-nouveau-commentaire',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: Commentaire sur le site: ${townLink} par ${username}`,
+        attachments: [
+            {
+                color: '#f2c744',
+                fields,
+            },
+        ],
+    };
+
+    await newCommentAlert.send(mattermostMessage);
+}
+
+async function triggerNewUserAlert(user: User): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const newUserAlert = new IncomingWebhook(mattermost);
+
+    const username = formatUsername(user);
+    const usernameLink = `<${webappUrl}/nouvel-utilisateur/${user.id}|${username}>`;
+
+    let locationText = 'Inconnu';
+    if (user.intervention_areas.is_national) {
+        locationText = 'National';
+    } else {
+        const area = user.intervention_areas.areas.find(a => a.is_main_area && a.type !== 'nation');
+        if (area !== undefined) {
+            locationText = area[area.type].name;
+        }
+    }
+
+    const mattermostMessage = {
+        channel: '#notif-nouveaux-utilisateurs',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: Nouvel utilisateur: ${usernameLink} <${user.email}>`,
+        attachments: [
+            {
+                color: '#f2c744',
+                fields: [
+                    {
+                        short: false,
+                        value: `*Territoire de rattachement*: ${locationText}`,
+                    },
+                    {
+                        short: false,
+                        value: `*Organisation*: ${user.organization.name}`,
+                    },
+                    {
+                        short: false,
+                        value: `*Fonction*: ${user.position}`,
+                    },
+                ],
+            },
+        ],
+    };
+
+    await newUserAlert.send(mattermostMessage);
+}
+
+async function triggerNotifyNewUserFromRectorat(user: User): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const webhook = new IncomingWebhook(mattermost);
+    const username = formatUsername(user);
+
+    const mattermostMessage = {
+        channel: '#tech',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: L'utilisateur(ice) ${username}, membre de Rectorat, a été créé(e). Merci de lui étendre ses droits d'accès à toute son académie`,
+        fields: [],
+    };
+
+    await webhook.send(mattermostMessage);
+}
+
+async function triggerNotifyNewUserSelfDeactivation(user: User): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const webhook = new IncomingWebhook(mattermost);
+    const username = formatUsername(user);
+
+    const mattermostMessage = {
+        channel: '#notif-auto-desactivations',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: L'utilisateur(ice) ${username} vient de désactiver son accès à la plateforme`,
+        fields: [],
+    };
+
+    await webhook.send(mattermostMessage);
+}
+
+async function triggerNotifyOwnersAnonymization(shantytownLines: number, shantytownHistoryLines: number): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const webhook = new IncomingWebhook(mattermost);
+
+    const createLinesMessage = (count: number): string => {
+        if (count <= 0) {
+            return 'Aucune ligne';
+        }
+        return count === 1 ? `${count} ligne` : `${count} lignes`;
+    };
+
+    const shantytownLinesMessage = createLinesMessage(shantytownLines);
+    const shantytownHistoryLinesMessage = createLinesMessage(shantytownHistoryLines);
+
+    const mattermostMessage = {
+        channel: '#notif-anonymisation',
+        username: 'Information Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: ':rotating_light: Une anonymisation automatique des propriétaires vient d\'être lancée:',
+        attachments: [
+            {
+                color: '#f2c744',
+                fields: [
+                    {
+                        short: false,
+                        value: `*${shantytownLinesMessage} ${shantytownLines > 1 ? ' traitées ' : ' traitée '} dans la table des sites`,
+                    },
+                    {
+                        short: false,
+                        value: `*${shantytownHistoryLinesMessage} ${shantytownHistoryLines > 1 ? ' traitées ' : ' traitée '} dans l'historique des sites`,
+                    },
+                ],
+            },
+        ],
+    };
+
+    await webhook.send(mattermostMessage);
+}
+
+export async function triggerNotifyOwnersAnonymizationError(message: string): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const webhook = new IncomingWebhook(mattermost);
+    const mattermostMessage = {
+        channel: '#notif-anonymisation',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: ':rotating_light: Une erreur est survenue lors de l\'anonymisation des propriétaires en base de données',
+        attachments: [
+            {
+                color: '#d63232',
+                fields: [
+                    {
+                        short: false,
+                        value: `*Erreur: * ${message}`,
+                    },
+                ],
+            },
+        ],
+    };
+
+    await webhook.send(mattermostMessage);
+}
+
+async function triggerPeopleInvitedAlert(guest: User, greeter: User, msg: string): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const peopleInvitedAlert = new IncomingWebhook(mattermost);
+
+    const guestName = formatUsernameWithEmailLink(guest);
+
+    let greeterName = '';
+    if (greeter.id) {
+        greeterName = formatUsername(greeter);
+    } else {
+        greeterName = formatUsernameWithEmailLink(greeter);
+    }
+
+    const mattermostMessage = {
+        // Don't initialize the channel name because the incoming webhook has been designed for this one
+        // channel: '#notif-personnes-invitées',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg || ''}`,
+        attachments: [
+            {
+                color: '#f2c744',
+                fields: [
+                    {
+                        short: 'false',
+                        value: `*Personne invitée*: ${guestName}`,
+                    },
+                ],
+            }],
+    };
+
+    await peopleInvitedAlert.send(mattermostMessage);
+}
+
+async function triggerRemoveDeclaredActor(town: Shantytown, user: User): Promise<void> {
+    if (!mattermost) {
+        return;
+    }
+
+    const removeDeclaredActor = new IncomingWebhook(mattermost);
+
+    const address = formatAddress(town);
+    const username = formatUsername(user);
+    const townLink = formatTownLink(town.id, address);
+
+    const mattermostMessage = {
+        channel: '#notif-intervenants-declares',
+        username: 'Alerte Résorption Bidonvilles',
+        icon_emoji: ':robot:',
+        text: `:rotating_light: ${username} a cessé d'intervenir sur le site ${townLink}`,
+        fields: [],
+    };
+
+    await removeDeclaredActor.send(mattermostMessage);
+}
+
 async function triggerShantytownCloseAlert(town: Shantytown, user: User): Promise<void> {
     if (!mattermost) {
         return;
@@ -132,474 +629,23 @@ export async function triggerShantytownCreationAlert(town: Shantytown, user: Use
     await shantytownCreationAlert.send(mattermostMessage);
 }
 
-async function triggerNewUserAlert(user: User): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const newUserAlert = new IncomingWebhook(mattermost);
-
-    const username = formatUsername(user);
-    const usernameLink = `<${webappUrl}/nouvel-utilisateur/${user.id}|${username}>`;
-
-    let locationText = 'Inconnu';
-    if (user.intervention_areas.is_national) {
-        locationText = 'National';
-    } else {
-        const area = user.intervention_areas.areas.find(a => a.is_main_area && a.type !== 'nation');
-        if (area !== undefined) {
-            locationText = area[area.type].name;
-        }
-    }
-
-    const mattermostMessage = {
-        channel: '#notif-nouveaux-utilisateurs',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: Nouvel utilisateur: ${usernameLink} <${user.email}>`,
-        attachments: [
-            {
-                color: '#f2c744',
-                fields: [
-                    {
-                        short: false,
-                        value: `*Territoire de rattachement*: ${locationText}`,
-                    },
-                    {
-                        short: false,
-                        value: `*Organisation*: ${user.organization.name}`,
-                    },
-                    {
-                        short: false,
-                        value: `*Fonction*: ${user.position}`,
-                    },
-                ],
-            },
-        ],
-    };
-
-    await newUserAlert.send(mattermostMessage);
-}
-
-async function triggerActorInvitedAlert(town: Shantytown, host: User, invited: string): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const actorInvitedAlert = new IncomingWebhook(mattermost);
-    const townLink = formatTownLink(town.id, town.usename);
-
-    const username = formatUsername(host);
-    const usernameLink = `<${webappUrl}/nouvel-utilisateur/${host.id}|${username}>`;
-
-    const mattermostMessage = {
-        channel: '#notif-invitations-intervenants',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: Intervenant invité sur le site ${townLink} par ${usernameLink}`,
-        attachments: [
-            {
-                color: '#f2c744',
-                fields: [
-                    {
-                        short: false,
-                        value: `*Personne invitée*: ${invited}`,
-                    },
-                ],
-            }],
-    };
-
-    await actorInvitedAlert.send(mattermostMessage);
-}
-
-async function triggerNewComment(commentDescription: string, tagLabels: string[], town: Shantytown, author: User): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const newCommentAlert = new IncomingWebhook(mattermost);
-
-    const address = formatAddress(town);
-    const username = formatUsername(author);
-    const townLink = formatTownLink(town.id, address);
-
-    const fields = [{
-        short: false,
-        value: `*Commentaire*: ${commentDescription}`,
-    }];
-
-    if (tagLabels.length > 0) {
-        fields.push({
-            short: false,
-            value: `*Qualification${tagLabels.length > 1 ? 's' : ''} du commentaire*: ${tagLabels.join(', ')}.`,
-        });
-    }
-    const mattermostMessage = {
-        channel: '#notif-nouveau-commentaire',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: Commentaire sur le site: ${townLink} par ${username}`,
-        attachments: [
-            {
-                color: '#f2c744',
-                fields,
-            },
-        ],
-    };
-
-    await newCommentAlert.send(mattermostMessage);
-}
-
-async function triggerNewActionComment(comment: string, action: Action, author: CommentAuthor): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const newCommentAlert = new IncomingWebhook(mattermost);
-
-    const username = formatUsername(author);
-    const actionLink = formatActionLink(action.id, action.name);
-
-    const mattermostMessage = {
-        channel: '#notif-action-nouveau-commentaire',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: Commentaire sur l'action: ${actionLink} par ${username}`,
-        attachments: [
-            {
-                color: '#f2c744',
-                fields: [
-                    {
-                        short: false,
-                        value: `*Commentaire*: ${comment}`,
-                    },
-                ],
-            },
-        ],
-    };
-
-    await newCommentAlert.send(mattermostMessage);
-}
-
-async function triggerPeopleInvitedAlert(guest: User, greeter: User, msg: string): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const peopleInvitedAlert = new IncomingWebhook(mattermost);
-
-    const guestName = formatUsernameWithEmailLink(guest);
-
-    let greeterName = '';
-    if (greeter.id) {
-        greeterName = formatUsername(greeter);
-    } else {
-        greeterName = formatUsernameWithEmailLink(greeter);
-    }
-
-    const mattermostMessage = {
-        // Don't initialize the channel name because the incoming webhook has been designed for this one
-        // channel: '#notif-personnes-invitées',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: Personne invitée sur la plateforme par ${greeterName} ${msg || ''}`,
-        attachments: [
-            {
-                color: '#f2c744',
-                fields: [
-                    {
-                        short: 'false',
-                        value: `*Personne invitée*: ${guestName}`,
-                    },
-                ],
-            }],
-    };
-
-    await peopleInvitedAlert.send(mattermostMessage);
-}
-
-async function triggerDeclaredActor(town: Shantytown, user: User): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const declaredActor = new IncomingWebhook(mattermost);
-
-    const address = formatAddress(town);
-    const username = formatUsername(user);
-    const townLink = formatTownLink(town.id, address);
-
-    const mattermostMessage = {
-        channel: '#notif-intervenants-declares',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: ${username} s'est déclaré comme intervenant sur le site ${townLink}`,
-        fields: [],
-    };
-
-    await declaredActor.send(mattermostMessage);
-}
-
-async function triggerInvitedActor(town: Shantytown, host: User, guest: User): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const invitedActor = new IncomingWebhook(mattermost);
-
-    const address = formatAddress(town);
-    const hostUsername = formatUsername(host);
-    const guestUsername = formatUsername(guest);
-    const townLink = formatTownLink(town.id, address);
-
-    const mattermostMessage = {
-        channel: '#notif-intervenants-declares',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: ${hostUsername} a invité ${guestUsername} à se déclarer comme intervenant sur le site ${townLink}`,
-        fields: [],
-    };
-
-    await invitedActor.send(mattermostMessage);
-}
-
-async function triggerRemoveDeclaredActor(town: Shantytown, user: User): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const removeDeclaredActor = new IncomingWebhook(mattermost);
-
-    const address = formatAddress(town);
-    const username = formatUsername(user);
-    const townLink = formatTownLink(town.id, address);
-
-    const mattermostMessage = {
-        channel: '#notif-intervenants-declares',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: ${username} a cessé d'intervenir sur le site ${townLink}`,
-        fields: [],
-    };
-
-    await removeDeclaredActor.send(mattermostMessage);
-}
-
-async function triggerNotifyNewUserFromRectorat(user: User): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const webhook = new IncomingWebhook(mattermost);
-    const username = formatUsername(user);
-
-    const mattermostMessage = {
-        channel: '#tech',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: L'utilisateur(ice) ${username}, membre de Rectorat, a été créé(e). Merci de lui étendre ses droits d'accès à toute son académie`,
-        fields: [],
-    };
-
-    await webhook.send(mattermostMessage);
-}
-
-async function triggerNotifyNewUserSelfDeactivation(user: User): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const webhook = new IncomingWebhook(mattermost);
-    const username = formatUsername(user);
-
-    const mattermostMessage = {
-        channel: '#notif-auto-desactivations',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: L'utilisateur(ice) ${username} vient de désactiver son accès à la plateforme`,
-        fields: [],
-    };
-
-    await webhook.send(mattermostMessage);
-}
-
-export async function triggerAttachmentArchiveCleanup(deleteRequestsCount: number, errorsCount: number): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const webhook = new IncomingWebhook(mattermost);
-    const mattermostMessage = {
-        channel: '#notif-nettoyage-piecesjointes',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:rotating_light: Un nettoyage automatique des fichiers vient d'être effectué pour un total de ${deleteRequestsCount} fichiers à supprimer et ${errorsCount} erreurs rencontrées`,
-        fields: [],
-    };
-
-    await webhook.send(mattermostMessage);
-}
-
-export async function triggerAttachmentArchiveCleanupError(): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const webhook = new IncomingWebhook(mattermost);
-    const mattermostMessage = {
-        channel: '#notif-nettoyage-piecesjointes',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: ':rotating_light: Une erreur est survenue lors du DELETE en base de données',
-        fields: [],
-    };
-
-    await webhook.send(mattermostMessage);
-}
-
-async function triggerNotifyOwnersAnonymization(shantytownLines: number, shantytownHistoryLines: number): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const webhook = new IncomingWebhook(mattermost);
-
-    const createLinesMessage = (count: number): string => {
-        if (count <= 0) {
-            return 'Aucune ligne';
-        }
-        return count === 1 ? `${count} ligne` : `${count} lignes`;
-    };
-
-    const shantytownLinesMessage = createLinesMessage(shantytownLines);
-    const shantytownHistoryLinesMessage = createLinesMessage(shantytownHistoryLines);
-
-    const mattermostMessage = {
-        channel: '#notif-anonymisation',
-        username: 'Information Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: ':rotating_light: Une anonymisation automatique des propriétaires vient d\'être lancée:',
-        attachments: [
-            {
-                color: '#f2c744',
-                fields: [
-                    {
-                        short: false,
-                        value: `*${shantytownLinesMessage} ${shantytownLines > 1 ? ' traitées ' : ' traitée '} dans la table des sites`,
-                    },
-                    {
-                        short: false,
-                        value: `*${shantytownHistoryLinesMessage} ${shantytownHistoryLines > 1 ? ' traitées ' : ' traitée '} dans l'historique des sites`,
-                    },
-                ],
-            },
-        ],
-    };
-
-    await webhook.send(mattermostMessage);
-}
-
-export async function triggerNotifyOwnersAnonymizationError(message: string): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const webhook = new IncomingWebhook(mattermost);
-    const mattermostMessage = {
-        channel: '#notif-anonymisation',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: ':rotating_light: Une erreur est survenue lors de l\'anonymisation des propriétaires en base de données',
-        attachments: [
-            {
-                color: '#d63232',
-                fields: [
-                    {
-                        short: false,
-                        value: `*Erreur: * ${message}`,
-                    },
-                ],
-            },
-        ],
-    };
-
-    await webhook.send(mattermostMessage);
-}
-
-async function triggerLandRegistryRequest(user: User, parcel: string, dataYear: string): Promise<void> {
-    if (!mattermost) {
-        return;
-    }
-
-    const newLandRegistryEnquiryAlert = new IncomingWebhook(mattermost);
-
-    const username = formatUsername(user);
-    const usernameLink = `<${webappUrl}/acces/${user.id}|${username}>`;
-
-    let locationText = 'Inconnu';
-    if (user.intervention_areas.is_national) {
-        locationText = 'National';
-    } else {
-        const area = user.intervention_areas.areas.find(a => a.is_main_area && a.type !== 'nation');
-        if (area !== undefined) {
-            locationText = area[area.type].name;
-        }
-    }
-
-    const mattermostMessage = {
-        channel: '#notif-requetes-cadastre',
-        username: 'Alerte Résorption Bidonvilles',
-        icon_emoji: ':robot:',
-        text: `:world_map: Demande d'information cadastre de: ${usernameLink} <${user.email}>`,
-        attachments: [
-            {
-                color: '#f2c744',
-                fields: [
-                    {
-                        short: false,
-                        value: `*Territoire de rattachement*: ${locationText}`,
-                    },
-                    {
-                        short: false,
-                        value: `*Organisation*: ${user.organization.name}`,
-                    },
-                    {
-                        short: false,
-                        value: `*Fonction*: ${user.position}`,
-                    },
-                    {
-                        short: false,
-                        value: `*Parcelle concernée*: ${parcel}`,
-                    },
-                    {
-                        short: false,
-                        value: `*Millésime des données du cadastre*: ${dataYear}`,
-                    },
-                ],
-            },
-        ],
-    };
-
-    await newLandRegistryEnquiryAlert.send(mattermostMessage);
-}
-
 export default {
-    triggerShantytownCloseAlert,
-    triggerShantytownCreationAlert,
-    triggerNewUserAlert,
     triggerActorInvitedAlert,
     triggerAttachmentArchiveCleanup,
     triggerAttachmentArchiveCleanupError,
-    triggerPeopleInvitedAlert,
-    triggerNewComment,
-    triggerNewActionComment,
     triggerDeclaredActor,
+    triggerHeatwaveStatusChange,
     triggerInvitedActor,
-    triggerRemoveDeclaredActor,
+    triggerLandRegistryRequest,
+    triggerNewActionComment,
+    triggerNewComment,
+    triggerNewUserAlert,
     triggerNotifyNewUserFromRectorat,
     triggerNotifyNewUserSelfDeactivation,
     triggerNotifyOwnersAnonymization,
     triggerNotifyOwnersAnonymizationError,
-    triggerLandRegistryRequest,
-
+    triggerPeopleInvitedAlert,
+    triggerRemoveDeclaredActor,
+    triggerShantytownCloseAlert,
+    triggerShantytownCreationAlert,
 };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/zGNwhMmb/2477-tracking-ajouter-un-tracking-sur-le-fait-de-positionner-retirer-une-alerte-canicule

## 🛠 Description de la PR
Cette PR ajoute une notification sur Mattermost lors de l'activation ou désactivation d'une alerte canicule sur un site.

## 📸 Captures d'écran
Activation de l'alerte canicule:
<img width="2785" height="525" alt="image" src="https://github.com/user-attachments/assets/ccf62f73-40c4-4efb-95ff-4baf6a898f2b" />
Désactivation de l'alerte canicule:
<img width="2785" height="523" alt="image" src="https://github.com/user-attachments/assets/36b45021-9f6c-418a-b3b1-77a5b7c76402" />

## 🚨 Notes pour la mise en production
RàS