### PR TITLE
#patch (2487) Correction de l'affichage permanent de l'alerte de fermeture de site

### DIFF
--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
@@ -1,5 +1,5 @@
 <template>
-    <DsfrAlert class="my-8" small title="Titre alerte" type="warning">
+    <DsfrAlert class="my-8" small title="Titre alerte" type="warning" v-if="mode === 'fix'>
         Ce site ayant déjà été déclaré comme fermé, ce formulaire ne vous permet
         que de corriger la déclaration de résorption. Pour toute autre
         modification,

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
@@ -1,5 +1,11 @@
 <template>
-    <DsfrAlert class="my-8" small title="Titre alerte" type="warning" v-if="mode === 'fix'>
+    <DsfrAlert
+        v-if="mode === 'fix'"
+        class="my-8"
+        small
+        title="Titre alerte"
+        type="warning"
+    >
         Ce site ayant déjà été déclaré comme fermé, ce formulaire ne vous permet
         que de corriger la déclaration de résorption. Pour toute autre
         modification,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/A149QkdD/2487-bug-corriger-laffichage-permanent-de-lalerte-sur-la-page-fermer-un-site

## 🛠 Description de la PR
La PR corrige l'affichage permanent de l'alerte de fermeture de site induite dans la PR #1266 

## 📸 Captures d'écran
<img width="997" height="90" alt="image" src="https://github.com/user-attachments/assets/8f344946-cbbf-4dd0-a9f3-b18829c7bc71" />

## 🚨 Notes pour la mise en production
RàS