### PR TITLE
#patch (2488) Correction de l'affichage des icônes DSFR du DsfrSegmetnedSet

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/FiltrageTemporel.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/FiltrageTemporel.vue
@@ -6,32 +6,32 @@
                 {
                     label: 'Les 2 années écoulées',
                     value: '2-annees-ecoulees',
-                    icon: 'chart-simple',
+                    icon: 'fr-icon-bar-chart-box-line',
                 },
                 {
                     label: 'L\'année écoulée',
                     value: 'annee-ecoulee',
-                    icon: 'chart-simple',
+                    icon: 'fr-icon-bar-chart-box-line',
                 },
                 {
                     label: 'Le mois passé',
                     value: 'mois-passe',
-                    icon: 'chart-simple',
+                    icon: 'fr-icon-bar-chart-box-line',
                 },
                 {
                     label: 'Les 7 derniers jours',
                     value: '7-derniers-jours',
-                    icon: 'chart-simple',
+                    icon: 'fr-icon-bar-chart-box-line',
                 },
                 {
                     label: 'Période personnalisée',
                     value: 'periode-personnalisee',
-                    icon: 'chart-simple',
+                    icon: 'fr-icon-bar-chart-box-line',
                 },
                 {
                     label: 'Situation à date',
                     value: 'situation-a-date',
-                    icon: 'table-list',
+                    icon: 'fr-icon-table-line',
                 },
             ]"
             v-model="selectedOption"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/aJG74aT7/2488-bug-ic%C3%B4nes-du-dsfrsegmentedset-disparus-suite-%C3%A0-lupdate-du-composant

## 🛠 Description de la PR
La PR corrige l'affichage des icônes officielles DSFR dans le composant DsfrSegmentedSet de la Visu de Données.

## 📸 Captures d'écran
<img width="1045" height="45" alt="image" src="https://github.com/user-attachments/assets/beee99b7-f33d-4811-a13a-49041085a014" />

## 🚨 Notes pour la mise en production
RàS