### PR TITLE
#patch (2464-2) Uniformité des boutons de la liste des sites et de la liste des actions

### DIFF
--- a/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
@@ -89,6 +89,7 @@ import CarteActionDetailleeColonneDepartement from "./CarteActionDetailleeColonn
 import CarteActionDetailleeColonneLocalisation from "./CarteActionDetailleeColonneLocalisation.vue";
 import CarteActionDetailleeColonnePilote from "./CarteActionDetailleeColonnePilote.vue";
 import CarteActionDetailleeColonneOperateur from "./CarteActionDetailleeColonneOperateur.vue";
+import router from "@/helpers/router";
 
 const props = defineProps({
     action: {
@@ -127,6 +128,16 @@ const attachmentsLabel = computed(() => {
         ? null
         : `${commentsAttachments} Document partagé`;
 });
+
+const navigateTo = (target) => {
+    if (action.value && action.value.id) {
+        let path = `/action/${action.value.id}`;
+        if (target) {
+            path += `/${target}`;
+        }
+        router.push(path);
+    }
+};
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/74cLV49e/2464-liste-des-actions-normalisation-des-boutons-dsfr-pour-actions

## 🛠 Description de la PR
Cette PR apporte un correctif de routage à la PR #1273 

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS