### PR TITLE
#minor (2482) Ajouter une pagination sur les messages du journal du site

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournal.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournal.vue
@@ -37,7 +37,7 @@
             </template>
         </FicheJournalLayout>
 
-        <FicheJournalLayout>
+        <FicheJournalLayout id="messages_du_site">
             <template v-slot:aside
                 ><div
                     class="flex sticky justify-center top-8 py-2 mb-2 bg-orange200"

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournal.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournal.vue
@@ -5,7 +5,7 @@
                 <h2 class="text-3xl text-secondary mb-8">
                     <Icon icon="comment" /> Journal du site
                     <span
-                        >— {{ comments.length }} message{{
+                        >- {{ comments.length }} message{{
                             comments.length > 1 ? "s" : ""
                         }}</span
                     >

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournalListeDesMessages.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournalListeDesMessages.vue
@@ -1,5 +1,12 @@
 <template>
     <section>
+        <DsfrPagination
+            v-if="comments.length > itemsPerPage"
+            v-model:current-page="currentPage"
+            :pages="pages"
+            :trunc-limit="4"
+            class="mt-4"
+        />
         <CarteCommentaireSite
             v-for="comment in paginatedResults"
             :key="comment.id"
@@ -7,6 +14,7 @@
             :comment="comment"
         />
         <DsfrPagination
+            v-if="comments.length > itemsPerPage"
             v-model:current-page="currentPage"
             :pages="pages"
             :trunc-limit="4"
@@ -25,7 +33,7 @@ const props = defineProps({
 });
 const { comments, townId } = toRefs(props);
 const currentPage = ref(0);
-const itemsPerPage = 5;
+const itemsPerPage = 10;
 const totalPages = computed(() => {
     return Math.ceil(comments.value.length / itemsPerPage);
 });
@@ -49,7 +57,7 @@ const paginatedResults = computed(() => {
 });
 
 watch(currentPage, () => {
-    const element = document.getElementById("journal_du_site");
+    const element = document.getElementById("messages_du_site");
     if (element) {
         element.scrollIntoView({ behavior: "smooth" });
     }

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournalListeDesMessages.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteJournal/FicheSiteJournalListeDesMessages.vue
@@ -1,16 +1,22 @@
 <template>
     <section>
         <CarteCommentaireSite
-            v-for="comment in comments"
+            v-for="comment in paginatedResults"
             :key="comment.id"
             :townId="townId"
             :comment="comment"
+        />
+        <DsfrPagination
+            v-model:current-page="currentPage"
+            :pages="pages"
+            :trunc-limit="4"
+            class="mt-4"
         />
     </section>
 </template>
 
 <script setup>
-import { defineProps, toRefs } from "vue";
+import { computed, defineProps, ref, toRefs, watch } from "vue";
 import CarteCommentaireSite from "@/components/CarteCommentaire/CarteCommentaireSite.vue";
 
 const props = defineProps({
@@ -18,4 +24,34 @@ const props = defineProps({
     townId: Number,
 });
 const { comments, townId } = toRefs(props);
+const currentPage = ref(0);
+const itemsPerPage = 5;
+const totalPages = computed(() => {
+    return Math.ceil(comments.value.length / itemsPerPage);
+});
+const pages = computed(() => {
+    let results = [];
+
+    for (let i = 1; i < totalPages.value + 1; i++) {
+        results.push({
+            title: `${i}`,
+            href: `${i}`,
+            label: i,
+        });
+    }
+    return results;
+});
+const paginatedResults = computed(() => {
+    const start = currentPage.value * itemsPerPage;
+    const end = start + itemsPerPage;
+
+    return comments.value.slice(start, end);
+});
+
+watch(currentPage, () => {
+    const element = document.getElementById("journal_du_site");
+    if (element) {
+        element.scrollIntoView({ behavior: "smooth" });
+    }
+});
 </script>

--- a/packages/frontend/webapp/src/helpers/dsfr.js
+++ b/packages/frontend/webapp/src/helpers/dsfr.js
@@ -6,6 +6,7 @@ import {
     DsfrCheckbox,
     DsfrInput,
     DsfrNotice,
+    DsfrPagination,
     DsfrSearchBar,
     DsfrSegmented,
     DsfrSegmentedSet,
@@ -26,6 +27,7 @@ export function useDsfr(app) {
     app.component("DsfrCheckbox", DsfrCheckbox);
     app.component("DsfrInput", DsfrInput);
     app.component("DsfrNotice", DsfrNotice);
+    app.component("DsfrPagination", DsfrPagination);
     app.component("DsfrSearchBar", DsfrSearchBar);
     app.component("DsfrSegmented", DsfrSegmented);
     app.component("DsfrSegmentedSet", DsfrSegmentedSet);


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/JIY11gW1/2482

## 🛠 Description de la PR
Ajoute les éléments permettant la pagination sur la liste des messages, afin de simplifier le parcours de l’usager au sein de cette liste.
Les éléments de pagination ont été placés en bas de liste, comme le préconise le Dsfr.
La désactivation des éléments permettant 
  - d'accéder à la première page ou à la page précédente lorsqu'on se trouve déjà sur la première page et
  - d'accéder à la dernière page ou à la page suivante lorsqu'on se trouve déjà sur la dernière page
ne peuvent être désactivé en raison d'un bug dans le composant vue-dsfr.

## 📸 Captures d'écran
<img width="962" height="616" alt="{802609A0-C671-4436-87D5-25F714D42CAA}" src="https://github.com/user-attachments/assets/db925774-759c-4285-b474-f64f6ec6dce0" />

## 🚨 Notes pour la mise en production
- ràs