### PR TITLE
#patch (2483) Supprimer le chevron inopérant - tri inactif sur TB visu données

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiques/GrilleHeader.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/GrilleHeader.vue
@@ -7,7 +7,6 @@
             :class="separator ? 'border-r' : ''"
         >
             <p><slot /></p>
-            <Icon icon="chevron-down" v-if="$slots.default" />
         </div>
     </div>
 </template>

--- a/packages/frontend/webapp/src/components/DonneesStatistiques/GrilleHeader.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiques/GrilleHeader.vue
@@ -13,7 +13,6 @@
 
 <script setup>
 import { toRefs } from "vue";
-import { Icon } from "@resorptionbidonvilles/ui";
 
 const props = defineProps({
     separator: {


### PR DESCRIPTION
## 🧾 Ticket Trello
refers to https://trello.com/c/83N8ze1p/2483

## 🛠 Description de la PR
Supprimer le chevron inopérant - version "lazy" de la résolution du problème - voir [la PR 1295](https://github.com/MTES-MCT/resorption-bidonvilles/pull/1295)

## 📸 Captures d'écran
<img width="1534" height="316" alt="image" src="https://github.com/user-attachments/assets/90deb9d2-f77e-49a9-93a2-85ef9a90b7af" />

## 🚨 Notes pour la mise en production
ràs