### PR TITLE
#patch: (2504) Prise en charge des dates vides pour afficher les graphiques en Visualisation de Données

### DIFF
--- a/packages/frontend/webapp/src/api/metrics.api.js
+++ b/packages/frontend/webapp/src/api/metrics.api.js
@@ -2,6 +2,9 @@ import { axios } from "@/helpers/axios";
 
 // Helper pour convertir Date en YYYY-MM-DD sans problème de timezone
 const toLocalDateString = (date) => {
+    if (!date) {
+        return null;
+    }
     const year = date.getFullYear();
     const month = (date.getMonth() + 1).toString().padStart(2, "0");
     const day = date.getDate().toString().padStart(2, "0");


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/5gO10SgK/2504-bugvisu-donn%C3%A9es-les-graphiques-ne-saffichent-pas-hors-%C3%A9volution

## 🛠 Description de la PR
La PR corrige l'accès aux statistiques graphiques en Visualisation de Données.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS