### PR TITLE
#patch: (2507-3) Rollback sur la fonctionnalité de modification douce de la date d'envoi du récap hebdo

### DIFF
--- a/packages/api/server/app.ts
+++ b/packages/api/server/app.ts
@@ -4,7 +4,7 @@ import config from '#server/config';
 import PrometheusMetricsHandler from '#server/middlewares/prometheusMiddleware';
 
 const {
-    port, sendActivitySummary, sendActionAlerts, checkInactiveUsers, cleanAttachmentsArchives, anonymizeOwners, anonymizeInactiveUsers, logInProd, recapHebdoCron,
+    port, sendActivitySummary, sendActionAlerts, checkInactiveUsers, cleanAttachmentsArchives, anonymizeOwners, anonymizeInactiveUsers, logInProd,
 } = config;
 
 const sentryContextHandlers = (app) => {
@@ -73,7 +73,7 @@ export default {
             if (sendActivitySummary) {
                 // eslint-disable-next-line no-console
                 console.log('Activity summary job is enabled');
-                await agenda.every(recapHebdoCron, 'send_activity_summary'); // every monday at 7AM
+                await agenda.every('0 0 8 * * 2', 'send_activity_summary'); // every monday at 7AM
             }
 
             if (checkInactiveUsers) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/N6BWNwTP/2507-bug-les-mails-automatiques-de-r%C3%A9cap-hebdo-ne-sont-plus-envoy%C3%A9s

## 🛠 Description de la PR
La PR force l'envoie du récap hebdo au mardi à 10h00 afin de générer des logs et éviter la mauvaise interprétation du `repeatInterval`.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS