### PR TITLE
#patch: (2507) Modification de la version de cron utilisée par Agenda

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -98,6 +98,9 @@
     "sinon-express-mock": "^2.1.0",
     "ts-node-dev": "^2.0.0"
   },
+  "resolutions": {
+    "agenda/cron": "1.8.2"
+  },
   "husky": {
     "hooks": {
       "pre-push": "yarn test:unit"

--- a/packages/api/server/app.ts
+++ b/packages/api/server/app.ts
@@ -73,7 +73,7 @@ export default {
             if (sendActivitySummary) {
                 // eslint-disable-next-line no-console
                 console.log('Activity summary job is enabled');
-                await agenda.every('0 0 8 * * 2', 'send_activity_summary'); // every monday at 7AM
+                await agenda.every('0 30 14 * * 2', 'send_activity_summary'); // every monday at 3PM
             }
 
             if (checkInactiveUsers) {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/N6BWNwTP/2507-bug-les-mails-automatiques-de-r%C3%A9cap-hebdo-ne-sont-plus-envoy%C3%A9s

## 🛠 Description de la PR
La PR modifie la version de cron utilisée par Agenda pour forcer la version fonctionnelle en DEV (1.8.2).

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS