### PR TITLE
#patch: (2507-5) Suppression de la limite du lundi pour l'envoie des récap' hebdo

### DIFF
--- a/packages/api/server/app.ts
+++ b/packages/api/server/app.ts
@@ -4,7 +4,7 @@ import config from '#server/config';
 import PrometheusMetricsHandler from '#server/middlewares/prometheusMiddleware';
 
 const {
-    port, sendActivitySummary, sendActionAlerts, checkInactiveUsers, cleanAttachmentsArchives, anonymizeOwners, anonymizeInactiveUsers, logInProd,
+    port, sendActivitySummary, sendActionAlerts, checkInactiveUsers, cleanAttachmentsArchives, anonymizeOwners, anonymizeInactiveUsers, logInProd, recapHebdoCron,
 } = config;
 
 const sentryContextHandlers = (app) => {
@@ -73,7 +73,7 @@ export default {
             if (sendActivitySummary) {
                 // eslint-disable-next-line no-console
                 console.log('Activity summary job is enabled');
-                await agenda.every('0 30 14 * * 2', 'send_activity_summary'); // every monday at 3PM
+                await agenda.every(recapHebdoCron, 'send_activity_summary'); // every monday at 3PM
             }
 
             if (checkInactiveUsers) {

--- a/packages/api/server/services/activitySummary/sendAll.ts
+++ b/packages/api/server/services/activitySummary/sendAll.ts
@@ -19,14 +19,14 @@ export default async (day: number, month: number, year: number): Promise<void> =
     sunday.setDate(sunday.getDate() + 6);
 
     // ensure the given date is actually a monday
-    if (monday.getDay() !== 1) {
-        if (logInProd) {
-            // eslint-disable-next-line no-console
-            console.error("Le jour donné n'est pas un lundi:", monday);
-        }
+    // if (monday.getDay() !== 1) {
+    //     if (logInProd) {
+    //         // eslint-disable-next-line no-console
+    //         console.error("Le jour donné n'est pas un lundi:", monday);
+    //     }
 
-        throw new Error('Veuillez donner une date correspondant à un Lundi');
-    }
+    //     throw new Error('Veuillez donner une date correspondant à un Lundi');
+    // }
 
     // ensure the given date is not part of current week, or future
     const today = new Date();


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/N6BWNwTP/2507-bug-les-mails-automatiques-de-r%C3%A9cap-hebdo-ne-sont-plus-envoy%C3%A9s

## 🛠 Description de la PR
La PR enlève (temporairement) le blocage au lundi pour l'envoie des récap' hebdo et réactive l'utilisation de la variable d'environnement pour spécifier l'interval.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
Réactiver la variable d'environnement.