### PR TITLE
#patch: (2507-6) Modification de l'envoie des variables pour la création du template

### DIFF
--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -992,31 +992,30 @@ export default {
         } as SortedQuestions);
 
         const utm = generateTrackingUTM(SUMMARY_CAMPAIGN, variables.campaign);
-        const sentVariables = {
-            from: variables.from,
-            to: variables.to,
-            recipientName: formatName(recipient),
-            connexionUrl: `${connexionUrl}?${utm}`,
-            showDetails: variables.showDetails ?? false,
-            summaries: variables.summaries,
-            show_question_summary: sortedQuestions.questions_with_answers.length > 0 || sortedQuestions.questions_without_answers.length > 0,
-            questions_with_answers_length: sortedQuestions.questions_with_answers.length,
-            questions_with_answers: sortedQuestions.questions_with_answers,
-            questions_without_answers_length: sortedQuestions.questions_without_answers.length,
-            questions_without_answers: sortedQuestions.questions_without_answers,
-            backUrl,
-            wwwUrl,
-            webappUrl,
-            utm,
-            blogUrl,
-        };
         if (logInProd) {
             // eslint-disable-next-line no-console
             console.log('Envoi du récap hebdo au mailservice');
         }
         return mailService.send('activity_summary', {
             recipient,
-            sentVariables,
+            variables: {
+                from: variables.from,
+                to: variables.to,
+                recipientName: formatName(recipient),
+                connexionUrl: `${connexionUrl}?${utm}`,
+                showDetails: variables.showDetails ?? false,
+                summaries: variables.summaries,
+                show_question_summary: sortedQuestions.questions_with_answers.length > 0 || sortedQuestions.questions_without_answers.length > 0,
+                questions_with_answers_length: sortedQuestions.questions_with_answers.length,
+                questions_with_answers: sortedQuestions.questions_with_answers,
+                questions_without_answers_length: sortedQuestions.questions_without_answers.length,
+                questions_without_answers: sortedQuestions.questions_without_answers,
+                backUrl,
+                wwwUrl,
+                webappUrl,
+                utm,
+                blogUrl,
+            },
             preserveRecipient,
         });
     },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/N6BWNwTP/2507-bug-les-mails-automatiques-de-r%C3%A9cap-hebdo-ne-sont-plus-envoy%C3%A9s

## 🛠 Description de la PR
La PR corrige la création du template de récap' hebdo.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS