### PR TITLE
#patch: (2520) Suppression de la notice sur l'alerte canicule

### DIFF
--- a/packages/frontend/webapp/src/components/BandeauNotice/BandeauNotice.vue
+++ b/packages/frontend/webapp/src/components/BandeauNotice/BandeauNotice.vue
@@ -16,7 +16,7 @@
     </div>
 </template>
 <script setup>
-import { ref, toRefs } from "vue";
+import { computed, toRefs } from "vue";
 
 const props = defineProps({
     type: {
@@ -57,10 +57,17 @@ const props = defineProps({
         required: false,
         default: "w-full",
     },
+    enabled: {
+        type: Boolean,
+        required: false,
+        default: true,
+    },
 });
-const { type, title, description, closeable } = toRefs(props);
+const { type, title, description, closeable, enabled } = toRefs(props);
 
-const isClosed = ref(false);
+const isClosed = computed(() => {
+    return !enabled.value || false;
+});
 const closeNotice = () => {
     isClosed.value = true;
 };

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSite.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSite.vue
@@ -5,6 +5,7 @@
         title="Prévenir les risques lors des vagues de chaleur"
         description='Pensez à identifier les sites nécessitant une intervention urgente via le bouton "Alerte canicule" sur la liste des sites, et suivez les actions mises en œuvre via le journal du site.'
         width="w-3/4"
+        :enabled="false"
     />
     <FicheSiteHeader
         :town="town"

--- a/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBord.vue
+++ b/packages/frontend/webapp/src/components/TableauDeBord/TableauDeBord.vue
@@ -5,6 +5,7 @@
             description='Pensez à identifier les sites nécessitant une intervention urgente via le bouton "Alerte canicule" sur la liste des sites, et suivez les actions mises en œuvre via le journal du site.'
             type="warning"
             fullWidth
+            :enabled="false"
         />
         <TableauDeBordGrille :cards="cards" />
     </ContentWrapper>

--- a/packages/frontend/webapp/src/views/ListeDesSitesView.vue
+++ b/packages/frontend/webapp/src/views/ListeDesSitesView.vue
@@ -12,6 +12,7 @@
                 type="warning"
                 title="Prévenir les risques lors des vagues de chaleur"
                 description='Pensez à identifier les sites nécessitant une intervention urgente via le bouton "Alerte canicule" sur la liste des sites, et suivez les actions mises en œuvre via le journal du site.'
+                :enabled="false"
             />
             <FilArianne :items="ariane" class="mb-8" />
         </ContentWrapper>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/St8v7yd8/2520-retrait-bandeau-canicule

## 🛠 Description de la PR
Cette PR modifie le fonctionnement du BandeauNotice pour permettre de choisir si l'on veut l'afficher ou non afin de ne pas en supprimer les appels actuels et pouvoir les réutiliser.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS