### PR TITLE
#patch: (2513) Gestion de l'affichage du badge indiquant le pourcentage de MAJ < 6 mois

### DIFF
--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.vue
@@ -7,7 +7,7 @@
         <ListeDesSitesErreur v-else-if="townsStore.error" />
 
         <template v-else>
-            <ListeDesSitesStatistiques />
+            <ListeDesSitesStatistiques :currentTab="currentTab" />
             <ListeDesSitesFiltres class="mt-4" />
             <ListeDesSitesListe
                 class="mt-4"

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
@@ -18,6 +18,7 @@
                         >s</template
                     ><template v-if="updatedSitesInTheLastSixMonths !== null">
                         <DsfrBadge
+                            v-if="currentTab !== 'close'"
                             class="ml-1"
                             small
                             :type="badgeVariant"
@@ -67,9 +68,15 @@ import MiniCarte from "@/components/MiniCarte/MiniCarte.vue";
 import formatStat from "@common/utils/formatStat";
 import getSince from "@/utils/getSince";
 
+const props = defineProps({
+    currentTab: {
+        type: String,
+    },
+});
 const townsStore = useTownsStore();
 const userStore = useUserStore();
 const { location, search } = toRefs(townsStore.filters);
+const { currentTab } = toRefs(props);
 
 const mapLocation = computed(() => {
     return location.value || { typeUid: "nation" };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/IZFYnwoQ/2513-liste-des-sites-ferm%C3%A9s-supprimer-lindicateur-de-sites-mis-%C3%A0-jour-depuis-de-6-mois

## 🛠 Description de la PR
La PR supprime l'affichage du badge DSFR indiquant le taux de sites mis à jour il y a moins de 6 mois sur la liste des sites fermés.

## 📸 Captures d'écran
<img width="675" height="330" alt="image" src="https://github.com/user-attachments/assets/41dc9d58-4031-4e60-9edd-e700b4e97d5c" />

## 🚨 Notes pour la mise en production
RàS