### PR TITLE
#patch: (2515) [Site UX/UI] Modification du formulaire de fermeture

### DIFF
--- a/packages/frontend/ui/src/components/ErrorSummary.vue
+++ b/packages/frontend/ui/src/components/ErrorSummary.vue
@@ -1,10 +1,14 @@
 <template>
-    <div class="mb-6 bg-red200 px-4 py-3 relative" role="alert">
-        <span class="absolute -left-4 bg-error w-1 h-full top-0"></span>
-        <span class="font-bold">{{ message }}</span>
+    <div class="mb-6 bg-red200 text-error px-2 py-3 relative" role="alert">
+        <span class="absolute -left-4 bg-error w-0.5 h-full top-0"></span>
+        <div class="flex flex-row gap-1" v-if="message">
+        <span class="fr-icon-error-fill fr-icon--sm" aria-hidden="true"></span>
+        <span class="font-normal">{{ message }}</span>
+        </div>
         <ul v-if="summaryErrors.length > 0" class="mt-2 pl-5 list-disc">
-            <li v-for="error in summaryErrors" :key="error.key">
-                <Link :to="`#${error.key}`">{{ error.message }}</Link>
+            <li v-for="error in summaryErrors" :key="error.key" class="list-none flex flex-row gap-1">
+                <span class="fr-icon-error-fill fr-icon--xs" aria-hidden="true"></span>
+                <Link :to="`#${error.key}`" color="text-error">{{ error.message }}</Link>
             </li>
         </ul>
     </div>
@@ -17,7 +21,7 @@ import Link from "./Link.vue";
 const props = defineProps({
     message: {
         type: String,
-        required: true
+        required: true,
     },
     summary: {
         type: Object,

--- a/packages/frontend/ui/src/components/Input/DatepickerInput.vue
+++ b/packages/frontend/ui/src/components/Input/DatepickerInput.vue
@@ -6,9 +6,10 @@
             :inlineInfo="inlineInfo"
             :showMandatoryStar="showMandatoryStar"
             :for="`dp-input-${id}`"
+            :error="!!errors.length"
         />
 
-        <div :class="width">
+        <div :class="width" class="mt-3">
             <DatePicker
                 v-model="date"
                 locale="fr"

--- a/packages/frontend/ui/src/components/Input/utils/InputError.vue
+++ b/packages/frontend/ui/src/components/Input/utils/InputError.vue
@@ -1,5 +1,17 @@
 <template>
-    <div class="text-error mt-2" aria-live="assertive">
-        <slot />
+    <div v-if="hasContent" class="flex flex-row gap-1 text-xs !font-normal text-error mt-2 items-center" aria-live="assertive">
+        <span class="fr-icon-error-fill fr-icon--sm" aria-hidden="true"></span><slot />
     </div>
 </template>
+
+<script setup>
+import { useSlots, computed } from "vue";
+
+const slots = useSlots();
+
+// On évite d'afficher l'icône s'il n'y a rien dans le slot
+const hasContent = computed(() => {
+  const nodes = slots.default?.() || [];
+  return nodes.some(n => typeof n.children !== "string" || n.children.trim().length > 0);
+});
+</script>

--- a/packages/frontend/ui/src/components/Input/utils/InputLabel.vue
+++ b/packages/frontend/ui/src/components/Input/utils/InputLabel.vue
@@ -1,5 +1,5 @@
 <template>
-    <label v-if="label" class="font-bold" :class=" info && inlineInfo ? 'inline' : '' " :for="for">{{ label }}
+    <label v-if="label" class="font-bold" :class="[info && inlineInfo ? 'inline' : '', error ? '!text-error' : '']" :for="for">{{ label }}
         <MandatoryStar class="ml-1" v-if=" showMandatoryStar " />
     </label>
     <p v-if=" info " class="mb-3 text-G700" :class=" inlineInfo ? 'inline' : '' ">{{ info }}
@@ -29,6 +29,11 @@ export default {
         showMandatoryStar: {
             required: false,
             type: Boolean,
+            default: false
+        },
+        error: {
+            type: Boolean,
+            required: false,
             default: false
         }
     },

--- a/packages/frontend/ui/src/components/Input/utils/InputWrapper.vue
+++ b/packages/frontend/ui/src/components/Input/utils/InputWrapper.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="['relative', withoutMargin ? '' : 'mb-6']">
-        <div v-if="hasErrors" class="absolute inputWrapper-error w-1 h-full bg-red600"></div>
+        <div v-if="hasErrors" class="absolute ml-1 inputWrapper-error w-0.5 h-full bg-red700"></div>
         <slot />
     </div>
 </template>

--- a/packages/frontend/ui/tailwind.config.js
+++ b/packages/frontend/ui/tailwind.config.js
@@ -154,7 +154,7 @@ module.exports = {
                 success: "#008941",
                 info: "#0762C8",
                 warning: "#FA5C00",
-                error: "#E10600",
+                error: "#CE0500",
 
                 // UI colors /  text
                 G800: "#1E1E1E",

--- a/packages/frontend/webapp/src/components/ButtonContact/ButtonContact.vue
+++ b/packages/frontend/webapp/src/components/ButtonContact/ButtonContact.vue
@@ -1,16 +1,22 @@
 <template>
-    <Button
-        variant="primaryOutline"
-        class="!border-2 !border-primary hover:!bg-primaryDark"
-        :href="`mailto:${CONTACT_EMAIL}`"
-        >Contactez-nous</Button
-    >
+    <DsfrButton secondary @click.prevent="openMail">Contactez-nous</DsfrButton>
 </template>
 
 <script setup>
+import { computed } from "vue";
 import ENV from "@/helpers/env.js";
-import { Button } from "@resorptionbidonvilles/ui";
+
 const { CONTACT_EMAIL } = ENV;
+const mailtoHref = computed(() =>
+    CONTACT_EMAIL ? `mailto:${CONTACT_EMAIL}` : ""
+);
+
+const openMail = () => {
+    if (!mailtoHref.value) {
+        return;
+    }
+    window.location.href = mailtoHref.value;
+};
 </script>
 <style scoped>
 button {

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.schema.js
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.schema.js
@@ -9,15 +9,30 @@ export default (variant) => {
             .label(labels.closed_with_solutions),
     };
 
+    const formatDateFR = (d) =>
+        new Intl.DateTimeFormat("fr-FR", {
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+        }).format(d);
+
     if (variant === "declare") {
         const maxClosedAt = new Date();
         maxClosedAt.setDate(maxClosedAt.getDate() + 1);
         maxClosedAt.setHours(0, 0, 0, 0);
+        const displayMaxClosedAt = new Date(maxClosedAt);
+        displayMaxClosedAt.setDate(displayMaxClosedAt.getDate() - 1);
 
         schema.closed_at = date()
             .typeError(`${labels.closed_at} est obligatoire`)
             .required()
-            .max(new Date())
+            .max(
+                maxClosedAt,
+                ({ label }) =>
+                    `${label} ne peut pas être postérieure au ${formatDateFR(
+                        displayMaxClosedAt
+                    )}`
+            )
             .label(labels.closed_at);
         schema.status = string()
             .required()

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
@@ -21,7 +21,10 @@
 
         <FormFermetureDeSiteInputClosedAt :disabled="mode === 'fix'" />
         <FormFermetureDeSiteInputStatus :disabled="mode === 'fix'" />
-        <FormFermetureDeSiteInputClosingContext :disabled="mode === 'fix'" />
+        <FormFermetureDeSiteInputClosingContext
+            :disabled="mode === 'fix'"
+            class="mb-6"
+        />
         <FormFermetureDeSiteInputSolutions
             :disabled="mode === 'fix'"
             @update:solutions="handleSolutions"

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
@@ -120,7 +120,6 @@ const handleSolutions = (newValue) => {
         ) {
             error.value =
                 "Le nombre de personnes réorientées ne peut pas être supérieur à la population totale du site. Si besoin, avant de procéder à la fermeture du site, veuillez mettre à jour la population totale dans la rubrique habitants.";
-            return;
         } else {
             error.value = null;
         }
@@ -221,6 +220,8 @@ defineExpose({
         } catch (e) {
             error.value = e?.user_message || "Une erreur inconnue est survenue";
             if (e?.fields) {
+                console.log("Field errors: ", e.fields);
+
                 setErrors(e.fields);
             }
         }

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
@@ -9,7 +9,7 @@
                 ><span class="font-normal">
                     D'après les informations renseignées, environ
                     <span class="font-bold">{{ peopleWithSolutions }}%</span>
-                    des habitants du site ont été orienté·es vers une solution
+                    des habitants du site ont été orientés vers une solution
                     longue durée d’hébergement ou de logement adapté avec
                     accompagnement, dont espace temporaire d'accompagnement
                 </span>

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
@@ -21,7 +21,6 @@
             site.
         </span>
     </div>
-    {{ calculatedValue.value }}
     <DsfrRadioButtonSet
         v-model="closedWithSolutions"
         name="closed_with_solutions"

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
@@ -1,26 +1,29 @@
 <template>
     <div class="flex flex-col gap-2 -mb-2">
         <p class="font-bold -mb-0">{{ labels.closed_with_solutions }}</p>
-        <span v-if="peopleWithSolutions != null">
-            D'après les informations renseignées, environ
-            <DsfrBadge
-                small
-                :type="calculatedValue.color"
-                :label="`${peopleWithSolutions}%`"
-                noIcon
-            />
-            des habitants du site ont été orienté·es vers une solution longue
-            durée d’hébergement ou de logement adapté avec accompagnement, dont
-            espace temporaire d'accompagnement
-        </span>
+        <DsfrNotice
+            v-if="peopleWithSolutions != null"
+            :type="calculatedValue.color"
+        >
+            <template #default
+                ><span class="font-normal">
+                    D'après les informations renseignées, environ
+                    <span class="font-bold">{{ peopleWithSolutions }}%</span>
+                    des habitants du site ont été orienté·es vers une solution
+                    longue durée d’hébergement ou de logement adapté avec
+                    accompagnement, dont espace temporaire d'accompagnement
+                </span>
+            </template>
+        </DsfrNotice>
         <span class="mb-4"
             >Un site est considéré comme résorbé si une solution pérenne en
             logement ou hébergement est mise en place pour 66 % des habitants du
             site.
         </span>
     </div>
+    {{ calculatedValue.value }}
     <DsfrRadioButtonSet
-        v-model="calculatedValue.value"
+        v-model="closedWithSolutions"
         name="closed_with_solutions"
         id="closed_with_solutions"
         small
@@ -34,6 +37,7 @@
 
 <script setup>
 import { computed, toRefs } from "vue";
+import { useField } from "vee-validate";
 import labels from "../FormFermetureDeSite.labels";
 
 const props = defineProps({
@@ -44,16 +48,16 @@ const props = defineProps({
 });
 const { peopleWithSolutions } = toRefs(props);
 
+const { value: closedWithSolutions, setValue } = useField(
+    "closed_with_solutions"
+);
+
 const calculatedValue = computed(() => {
-    if (peopleWithSolutions.value === undefined) {
-        return { color: "default", value: false };
-    }
     if (peopleWithSolutions.value >= 66) {
-        return { color: "success", value: true };
+        setValue(true);
+        return { color: "info", value: true };
     }
-    if (peopleWithSolutions.value >= 33) {
-        return { color: "warning", value: false };
-    }
-    return { color: "error", value: false };
+    setValue(false);
+    return { color: "alert", value: false };
 });
 </script>

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
@@ -51,8 +51,12 @@ const { value: closedWithSolutions, setValue } = useField(
     "closed_with_solutions"
 );
 
+if (peopleWithSolutions.value === null) {
+    setValue(false);
+}
+
 const calculatedValue = computed(() => {
-    if (peopleWithSolutions.value >= 66) {
+    if (peopleWithSolutions.value >= 66 && peopleWithSolutions.value <= 100) {
         setValue(true);
         return { color: "info", value: true };
     }

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
@@ -1,35 +1,39 @@
 <template>
-    <CheckableGroup
-        id="closed_with_solutions"
-        :label="labels.closed_with_solutions"
-        :info="info"
-        validationName="Est-ce que ce site a été résorbé définitivement ?"
-    >
+    <div class="flex flex-col gap-2 -mb-2">
+        <p class="font-bold -mb-0">{{ labels.closed_with_solutions }}</p>
+        <span v-if="peopleWithSolutions != null">
+            D'après les informations renseignées, environ
+            <DsfrBadge
+                small
+                :type="calculatedValue.color"
+                :label="`${peopleWithSolutions}%`"
+                noIcon
+            />
+            des habitants du site ont été orienté·es vers une solution longue
+            durée d’hébergement ou de logement adapté avec accompagnement, dont
+            espace temporaire d'accompagnement
+        </span>
         <span class="mb-4"
             >Un site est considéré comme résorbé si une solution pérenne en
             logement ou hébergement est mise en place pour 66 % des habitants du
             site.
         </span>
-
-        <Radio
-            :value="true"
-            label="Oui"
-            variant="card"
-            class="mr-1"
-            name="closed_with_solutions"
-        />
-        <Radio
-            :value="false"
-            label="Non"
-            variant="card"
-            name="closed_with_solutions"
-        />
-    </CheckableGroup>
+    </div>
+    <DsfrRadioButtonSet
+        v-model="calculatedValue.value"
+        name="closed_with_solutions"
+        id="closed_with_solutions"
+        small
+        class="!-mb-6"
+        :options="[
+            { label: 'Oui', value: true },
+            { label: 'Non', value: false },
+        ]"
+    />
 </template>
 
 <script setup>
-import { computed, defineProps, toRefs } from "vue";
-import { CheckableGroup, Radio } from "@resorptionbidonvilles/ui";
+import { computed, toRefs } from "vue";
 import labels from "../FormFermetureDeSite.labels";
 
 const props = defineProps({
@@ -40,19 +44,16 @@ const props = defineProps({
 });
 const { peopleWithSolutions } = toRefs(props);
 
-const info = computed(() => {
-    if (
-        peopleWithSolutions.value === undefined ||
-        peopleWithSolutions.value === null
-    ) {
-        return "";
+const calculatedValue = computed(() => {
+    if (peopleWithSolutions.value === undefined) {
+        return { color: "default", value: false };
     }
-
-    return `D'après les informations renseignées, environ 
-        ${peopleWithSolutions.value} %
-        des habitants du site ont été
-        orientées vers une solution longue durée d’hébergement ou de
-        logement adapté avec accompagnement,
-        dont espace temporaire d'accompagnement`;
+    if (peopleWithSolutions.value >= 66) {
+        return { color: "success", value: true };
+    }
+    if (peopleWithSolutions.value >= 33) {
+        return { color: "warning", value: false };
+    }
+    return { color: "error", value: false };
 });
 </script>

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosingContext.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosingContext.vue
@@ -1,13 +1,23 @@
 <template>
-    <TextArea
+    <DsfrInputGroup
+        v-model="closing_context"
+        isTextarea
         id="closing_context"
         name="closing_context"
+        labelVisible
         label="Préciser le contexte de la fermeture et les faits à signaler"
-        info="Exemples : incendie, violences, départ spontané des habitants..."
+        labelClass="font-bold"
+        hint="Exemples : incendie, violences, départ spontané des habitants..."
         :rows="5"
+        :errorMessage="errors.length > 0 ? errors[0] : ''"
     />
 </template>
 
 <script setup>
-import { TextArea } from "@resorptionbidonvilles/ui";
+import { useField } from "vee-validate";
+
+const { value: closing_context, errors } = useField(
+    "closing_context",
+    "required"
+);
 </script>

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosingContext.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosingContext.vue
@@ -4,13 +4,18 @@
         isTextarea
         id="closing_context"
         name="closing_context"
-        labelVisible
-        label="Préciser le contexte de la fermeture et les faits à signaler"
-        labelClass="font-bold"
-        hint="Exemples : incendie, violences, départ spontané des habitants..."
         :rows="5"
         :errorMessage="errors.length > 0 ? errors[0] : ''"
-    />
+    >
+        <template #before-input>
+            <p class="font-bold" :class="{ 'text-error': errors.length > 0 }">
+                Préciser le contexte de la fermeture et les faits à signaler
+            </p>
+            <span class="fr-hint-text">
+                Exemples : incendie, violences, départ spontané des habitants...
+            </span>
+        </template>
+    </DsfrInputGroup>
 </template>
 
 <script setup>
@@ -21,3 +26,8 @@ const { value: closing_context, errors } = useField(
     "required"
 );
 </script>
+<style scoped>
+.fr-label {
+    font-weight: 600 !important;
+}
+</style>

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputSolutions.vue
@@ -1,64 +1,98 @@
 <template>
-    <CheckableGroup id="solutions" :label="labels.solutions">
-        <div
-            v-for="item in configStore.config.closing_solutions"
-            :key="item.id"
-            class="flex flex-col flex-wrap w-full md:w-4/6"
-        >
-            <Checkbox
-                :value="item.id"
-                :label="item.label"
-                name="solutions"
-                variant="checkbox"
-                v-bind="$attrs"
-                v-model="values.solutions"
-            />
-
+    <DsfrCheckboxSet name="solutions" id="solutions" small>
+        <template #legend>
+            <span class="font-bold">{{ labels.solutions }}</span>
+        </template>
+        <template #default>
             <div
-                v-if="values.solutions.includes(item.id)"
-                class="my-3 bg-G200 p-3"
+                v-for="item in configStore.config.closing_solutions"
+                :key="item.id"
+                class="flex flex-col flex-wrap w-full md:w-4/6"
             >
-                <div class="flex items-center justify-between space-x-3">
-                    <span>Ménages</span>
-                    <TextInput
-                        :id="`solution_details.${item.id}.householdsAffected`"
-                        :name="`solution_details.${item.id}.householdsAffected`"
-                        v-bind="$attrs"
+                <DsfrCheckbox
+                    :value="item.id"
+                    :label="item.label"
+                    name="solutions"
+                    :id="`solution_${item.id}`"
+                    variant="checkbox"
+                    v-model="values.solutions"
+                    small
+                />
+                <div
+                    v-if="values.solutions.includes(item.id)"
+                    class="mb-3 bg-blue100 p-3 rounded-sm border-2 border-G200"
+                >
+                    <div class="flex items-center justify-between space-x-3">
+                        <span>Ménages</span>
+                        <DsfrInput
+                            :id="`solution_details.${item.id}.householdsAffected`"
+                            :name="`solution_details.${item.id}.householdsAffected`"
+                            v-model="
+                                values.solution_details[item.id]
+                                    .householdsAffected
+                            "
+                            withoutMargin
+                        />
+                        <span class="pl-4">Personnes</span>
+                        <DsfrInput
+                            :id="`solution_details.${item.id}.peopleAffected`"
+                            :name="`solution_details.${item.id}.peopleAffected`"
+                            v-model="
+                                values.solution_details[item.id].peopleAffected
+                            "
+                            :class="{ 'border-red500 bg-red200': error }"
+                            withoutMargin
+                        />
+                    </div>
+
+                    <p class="mt-2">Commentaire</p>
+                    <DsfrInput
+                        :id="`solution_details.${item.id}.message`"
+                        :name="`solution_details.${item.id}.message`"
+                        placeholder="Saisissez ici toute information complémentaire"
+                        v-model="values.solution_details[item.id].message"
                         withoutMargin
-                    />
-                    <span class="pl-4">Personnes</span>
-                    <TextInput
-                        :id="`solution_details.${item.id}.peopleAffected`"
-                        :name="`solution_details.${item.id}.peopleAffected`"
-                        :class="{ 'border-red500 bg-red200': error }"
-                        v-bind="$attrs"
-                        withoutMargin
+                        isTextarea
                     />
                 </div>
-
-                <p class="mt-2">Commentaire</p>
-                <TextInput
-                    :id="`solution_details.${item.id}.message`"
-                    :name="`solution_details.${item.id}.message`"
-                    placeholder="Saisissez ici toute information complémentaire"
-                    v-bind="$attrs"
-                    withoutMargin
-                />
             </div>
-        </div>
-    </CheckableGroup>
+        </template>
+    </DsfrCheckboxSet>
 </template>
 
 <script setup>
-import { defineEmits, watch } from "vue";
+import { watch } from "vue";
 import { useFormValues } from "vee-validate";
 import { useConfigStore } from "@/stores/config.store";
-import { CheckableGroup, Checkbox, TextInput } from "@resorptionbidonvilles/ui";
 import labels from "../FormFermetureDeSite.labels";
 
 const emit = defineEmits(["update:solutions"]);
 const configStore = useConfigStore();
 const values = useFormValues();
+
+// Proxy afin d'éviter l'erreur liée au chargement d'une valeur pas encore créée
+const ensureDetail = (id) => {
+    if (!values.value.solution_details[id]) {
+        values.value.solution_details[id] = {
+            householdsAffected: "",
+            peopleAffected: "",
+            message: "",
+        };
+    }
+};
+
+watch(
+    () => [...values.value.solutions],
+    (next, prev = []) => {
+        const added = next.filter((id) => !prev.includes(id));
+        const removed = prev.filter((id) => !next.includes(id));
+        added.forEach(ensureDetail);
+        removed.forEach((id) => {
+            delete values.value.solution_details[id];
+        });
+    },
+    { immediate: true }
+);
 
 watch(
     () => values.value.solution_details,

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputSolutions.vue
@@ -1,5 +1,10 @@
 <template>
-    <DsfrCheckboxSet name="solutions" id="solutions" small>
+    <DsfrCheckboxSet
+        name="solutions"
+        id="solutions"
+        :errorMessage="errors ? errors : ''"
+        small
+    >
         <template #legend>
             <span class="font-bold">{{ labels.solutions }}</span>
         </template>
@@ -20,7 +25,7 @@
                 />
                 <div
                     v-if="values.solutions.includes(item.id)"
-                    class="mb-3 bg-blue100 p-3 rounded-sm border-2 border-G200"
+                    class="ml-8 mb-3 bg-blue100 p-3 rounded-sm border-2 border-G200"
                 >
                     <div class="flex items-center justify-between space-x-3">
                         <span>Ménages</span>
@@ -61,10 +66,20 @@
 </template>
 
 <script setup>
-import { watch } from "vue";
+import { watch, toRefs } from "vue";
 import { useFormValues } from "vee-validate";
 import { useConfigStore } from "@/stores/config.store";
 import labels from "../FormFermetureDeSite.labels";
+
+const props = defineProps({
+    errors: {
+        type: Array,
+        required: false,
+        default: () => [],
+    },
+});
+
+const { errors } = toRefs(props);
 
 const emit = defineEmits(["update:solutions"]);
 const configStore = useConfigStore();

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputStatus.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputStatus.vue
@@ -1,18 +1,22 @@
 <template>
-    <CheckableGroup id="status" :label="labels.status">
-        <Radio
-            v-for="item in items"
-            :key="item.value"
-            :value="item.value"
-            :label="item.label"
-            name="status"
-            v-bind="$attrs"
-        />
-    </CheckableGroup>
+    <DsfrRadioButtonSet
+        v-model="status"
+        id="status"
+        name="status"
+        small
+        :options="items"
+        :errorMessage="errors.length > 0 ? errors[0] : ''"
+    >
+        <template #legend>
+            <p class="font-bold">{{ labels.status }}</p>
+        </template>
+    </DsfrRadioButtonSet>
 </template>
 
 <script setup>
-import { CheckableGroup, Radio } from "@resorptionbidonvilles/ui";
 import items from "@/utils/closing_reasons";
 import labels from "../FormFermetureDeSite.labels";
+import { useField } from "vee-validate";
+
+const { value: status, errors } = useField("status", "required");
 </script>

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputStatus.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputStatus.vue
@@ -8,7 +8,7 @@
         :errorMessage="errors.length > 0 ? errors[0] : ''"
     >
         <template #legend>
-            <p class="font-bold">{{ labels.status }}</p>
+            <p class="font-bold mb-4">{{ labels.status }}</p>
         </template>
     </DsfrRadioButtonSet>
 </template>

--- a/packages/frontend/webapp/src/helpers/dsfr.js
+++ b/packages/frontend/webapp/src/helpers/dsfr.js
@@ -4,11 +4,15 @@ import {
     DsfrBadge,
     DsfrButton,
     DsfrButtonGroup,
+    DsfrCallout,
     DsfrCard,
     DsfrCheckbox,
+    DsfrCheckboxSet,
     DsfrInput,
+    DsfrInputGroup,
     DsfrNotice,
     DsfrPagination,
+    DsfrRadioButtonSet,
     DsfrSearchBar,
     DsfrSegmented,
     DsfrSegmentedSet,
@@ -35,11 +39,15 @@ export function useDsfr(app) {
     app.component("DsfrBadge", DsfrBadge);
     app.component("DsfrButton", DsfrButton);
     app.component("DsfrButtonGroup", DsfrButtonGroup);
+    app.component("DsfrCallout", DsfrCallout);
     app.component("DsfrCard", DsfrCard);
     app.component("DsfrCheckbox", DsfrCheckbox);
+    app.component("DsfrCheckboxSet", DsfrCheckboxSet);
     app.component("DsfrInput", DsfrInput);
+    app.component("DsfrInputGroup", DsfrInputGroup);
     app.component("DsfrNotice", DsfrNotice);
     app.component("DsfrPagination", DsfrPagination);
+    app.component("DsfrRadioButtonSet", DsfrRadioButtonSet);
     app.component("DsfrSearchBar", DsfrSearchBar);
     app.component("DsfrSegmented", DsfrSegmented);
     app.component("DsfrSegmentedSet", DsfrSegmentedSet);

--- a/packages/frontend/webapp/src/views/FermetureDeSiteView.vue
+++ b/packages/frontend/webapp/src/views/FermetureDeSiteView.vue
@@ -11,12 +11,8 @@
             d'urgence.</template
         >
         <template v-slot:actions>
-            <Button
-                icon="rotate-right"
-                iconPosition="left"
-                type="button"
-                @click="load"
-                >Réessayer</Button
+            <DsfrButton icon="fr-icon-refresh-line" @click="load"
+                >Réessayer</DsfrButton
             >
             <ButtonContact />
         </template>
@@ -29,16 +25,10 @@
             }}<template v-if="town.name"> « {{ town.name }} »</template>
         </template>
         <template v-slot:buttons>
-            <Button
-                variant="primaryOutline"
-                type="button"
-                @click="back"
-                class="!border-2 !border-primary hover:!bg-primary"
-                >Annuler</Button
-            >
-            <Button @click="submit" :loading="form?.isSubmitting">{{
+            <DsfrButton secondary @click.prevent="back">Annuler</DsfrButton>
+            <DsfrButton @click="submit" :loading="form?.isSubmitting">{{
                 submitWording
-            }}</Button>
+            }}</DsfrButton>
         </template>
 
         <ContentWrapper size="intermediate">
@@ -53,7 +43,7 @@ import { useTownsStore } from "@/stores/towns.store.js";
 import { useUserStore } from "@/stores/user.store";
 import router, { setDocumentTitle } from "@/helpers/router";
 
-import { Button, ContentWrapper } from "@resorptionbidonvilles/ui";
+import { ContentWrapper } from "@resorptionbidonvilles/ui";
 import LayoutError from "@/components/LayoutError/LayoutError.vue";
 import LayoutLoading from "@/components/LayoutLoading/LayoutLoading.vue";
 import LayoutForm from "@/components/LayoutForm/LayoutForm.vue";


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/nfASWExI/2515-site-ux-ui-modification-de-la-popup-de-fermeture

## 🛠 Description de la PR
La PR apporte des modifications de design au formulaire de fermeture de site:
- Le taux d'habitant orientés vers des solutions longues durée est maintenant colorisé
- Il agit également sur la sélection du bouton radio Oui/Non lié
- Les champs, à l'exception du DatePicker, ont été migrés en DSFR
- L'affichage d'erreur sur les champs non-DSFR a été modifiée pour coller plus à l'affichage d'erreur des champs DSFR

## 📸 Captures d'écran


## 🚨 Notes pour la mise en production
_Liste des choses à faire pour le déploiement (changement de configuration, migrations à faire tourner, etc.), si possible avec les éléments les plus précis possibles (commande exacte à exécuter, etc.)._