### PR TITLE
#patch: (2511) Empêcher les changelogs de plus de 2 mois de générer des popup nouveauté

### DIFF
--- a/packages/api/server/models/changelogModel/getChangelogFor.ts
+++ b/packages/api/server/models/changelogModel/getChangelogFor.ts
@@ -37,6 +37,8 @@ export default async (user: User): Promise<Changelog[]> => {
             regexp_split_to_array(changelogs.app_version, '\\.')::int[] > regexp_split_to_array(:minVersion, '\\.')::int[]
             AND
             regexp_split_to_array(changelogs.app_version, '\\.')::int[] <= regexp_split_to_array(:maxVersion, '\\.')::int[]
+            AND
+            CURRENT_DATE <= (changelogs.date::date + INTERVAL '2 months')
         ORDER BY regexp_split_to_array(changelogs.app_version, '\\.')::int[] ASC, items.position ASC`,
         {
             type: QueryTypes.SELECT,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/pfmnlJAc/2511-popup-ajout-dune-date-de-fin

## 🛠 Description de la PR
La PR modifie la liste des changelogs remontés afin de ne pas y ajouter les changelogs datant de plus de 2 mois. Ainsi, la popup "nouveauté" n'affichera plus de nouveautés déjà devenue anciennes.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS