### PR TITLE
#patch: (2522) [API] Correction de la gestion CPU de PM2

### DIFF
--- a/packages/api/.env.sample
+++ b/packages/api/.env.sample
@@ -1,5 +1,6 @@
 NODE_ENV=development
 RB_API_PORT=8090
+RB_API_CPU_INSTANCES=1
 RB_API_BACK_URL=https://api.resorption-bidonvilles.localhost
 RB_API_FRONT_DOMAIN=resorption-bidonvilles.localhost
 RB_API_BLOG_URL=https://www.blog-resorption-bidonvilles.fr/

--- a/packages/api/pm2.config.js
+++ b/packages/api/pm2.config.js
@@ -3,8 +3,9 @@ module.exports = {
         {
             name: 'api',
             script: 'server/index.js',
-            instances: 1,
-            exec_mode: 'fork',
+            exec_mode: 'cluster',
+            instances: 'max',
+            log_date_format: 'YYYY-MM-DD HH:mm:ss.SSS Z',
             watch: false,
             env: {
                 NODE_ENV: 'production',

--- a/packages/api/pm2.config.js
+++ b/packages/api/pm2.config.js
@@ -4,7 +4,7 @@ module.exports = {
             name: 'api',
             script: 'server/index.js',
             exec_mode: 'cluster',
-            instances: 'max',
+            instances: process.env.RB_API_CPU_INSTANCES || 1,
             log_date_format: 'YYYY-MM-DD HH:mm:ss.SSS Z',
             watch: false,
             env: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/tLvenqhi/2522-bug-instabilit%C3%A9-de-la-plateforme

## 🛠 Description de la PR
Cette PR modifie la gestion du processus de l'API par PM2 en le passant en mode cluster. PM2 se base sur une variable d'environnement `RB_API_CPU_INSTANCES` pour savoir le nombre d'instances à démarrer.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
Initialiser la variable d'environnement `RB_API_CPU_INSTANCES` en fonction du nombre de CPU disponibles dans config/.env