### PR TITLE
#patch: (2517) Ouverture de la mise à jour des étapes de résorption "EXPE44"

### DIFF
--- a/packages/api/server/services/shantytown/update.ts
+++ b/packages/api/server/services/shantytown/update.ts
@@ -188,7 +188,7 @@ export default async (shantytown, user, decreeAttachments: DecreeAttachments): P
     // on tente d'enregistrer les phases transitoires vers la résorption
     if (shantytown.preparatory_phases_toward_resorption.length > 0) {
         try {
-            if (user.isAllowedTo('update', 'shantytown_resorption')) {
+            if (user.isAllowedTo('update', 'shantytown')) {
                 await shantytownResorptionService.update(
                     shantytown.id,
                     shantytown.preparatory_phases_toward_resorption,

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -106,6 +106,6 @@ const handleCheckboxChange = (checked) => {
 
 const canUpdate = computed(() => {
     const userStore = useUserStore();
-    return userStore.hasPermission("shantytown_resorption.update");
+    return userStore.hasPermission("shantytown.update");
 });
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/RwiBxOYv/2517-exp%C3%A944-permettre-la-maj-des-phases-pr%C3%A9paratoires-lors-de-la-maj-du-site

## 🛠 Description de la PR
Cette PR ouvre le droit à tous les utilisateurs du 44 ayant les droits de modification de site d'effectuer des mises à jour sur les étapes préparatoires à la résorption (EXPE44).

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS