### PR TITLE
#patch: (2527) Correction de la sélection initiale de "closed_with_solutions"

### DIFF
--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/FormFermetureDeSite.vue
@@ -220,8 +220,6 @@ defineExpose({
         } catch (e) {
             error.value = e?.user_message || "Une erreur inconnue est survenue";
             if (e?.fields) {
-                console.log("Field errors: ", e.fields);
-
                 setErrors(e.fields);
             }
         }

--- a/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
+++ b/packages/frontend/webapp/src/components/FormFermetureDeSite/inputs/FormFermetureDeSiteInputClosedWithSolutions.vue
@@ -51,7 +51,10 @@ const { value: closedWithSolutions, setValue } = useField(
     "closed_with_solutions"
 );
 
-if (peopleWithSolutions.value === null) {
+if (
+    peopleWithSolutions.value === null &&
+    closedWithSolutions.value === undefined
+) {
     setValue(false);
 }
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/weHrtfHF/2527-bug-affichage-de-la-donn%C3%A9e-de-fermeture-oui-non-sur-le-formulaire-de-fermeture-de-site

## 🛠 Description de la PR
La PR corrige la sélection initiale du champ (radio) "Est-ce que ce site a été résorbé définitivement ?" Dorénavant, si le formulaire a déjà été renseigné et le site fermé, la sélection reflètera la donnée en base au lieu de sélectionner par défaut "Non".

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS