### PR TITLE
#patch (2661) Ajouter l'adresse de messagerie du demandeur d'accès

### DIFF
--- a/packages/api/server/mails/dist/admin_new_request_notification.html
+++ b/packages/api/server/mails/dist/admin_new_request_notification.html
@@ -151,7 +151,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;padding-bottom:1rem;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Vous avez reçu une nouvelle demande d’accès à la plateforme <a href="{{var:webappUrl}}" class="link font-italic" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none; font-style: italic;">Résorption-bidonvilles</a>.</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;">Vous avez reçu une nouvelle demande d’accès à la plateforme <a href="{{var:webappUrl}}" class="link font-italic" target="_blank" rel="noopener noreferrer" style="color: #000091; text-decoration: none; font-style: italic;">Résorption-bidonvilles</a> de : {{var:userEmail}}.</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/admin_new_request_notification.text
+++ b/packages/api/server/mails/dist/admin_new_request_notification.text
@@ -2,7 +2,7 @@ Vous avez reçu une nouvelle demande d'accès à la plateforme
 Résorption-bidonvilles de {{var:userName}}, {{var:orgName}}
 Bonjour {{var:recipientName}},
 Vous avez reçu une nouvelle demande d’accès à la plateforme
-Résorption-bidonvilles [{{var:webappUrl}}].
+Résorption-bidonvilles [{{var:webappUrl}}] de : {{var:userEmail}}.
 Nous vous invitons à vous rendre sur l’onglet administration de la plateforme
 [{{var:adminUrl}}] pour ouvrir et paramétrer l’accès. Une réponse est souhaitée
 sous 7 jours.

--- a/packages/api/server/mails/mails.ts
+++ b/packages/api/server/mails/mails.ts
@@ -165,6 +165,7 @@ export default {
             variables: {
                 recipientName: formatName(recipient),
                 userName: variables.userName,
+                userEmail: variables.userEmail,
                 orgName: variables.orgName,
                 webappUrl: `${webappUrl}?${utm}`,
                 adminUrl: `${variables.adminUrl}?${utm}`,

--- a/packages/api/server/mails/src/admin_new_request_notification.mjml
+++ b/packages/api/server/mails/src/admin_new_request_notification.mjml
@@ -14,7 +14,7 @@
                 </mj-text>
                 <mj-include path='common/hello.mjml' />
                 <mj-text mj-class="pb-4">
-                    Vous avez reçu une nouvelle demande d’accès à la plateforme <a href="{{var:webappUrl}}" class="link font-italic" target="_blank" rel="noopener noreferrer">Résorption-bidonvilles</a>.
+                    Vous avez reçu une nouvelle demande d’accès à la plateforme <a href="{{var:webappUrl}}" class="link font-italic" target="_blank" rel="noopener noreferrer">Résorption-bidonvilles</a> de : {{var:userEmail}}.
                 </mj-text>
                 <mj-text>
                     Nous vous invitons à <a href="{{var:adminUrl}}" class="link font-bold" target="_blank" rel="noopener noreferrer">vous rendre sur l’onglet administration de la plateforme</a> pour ouvrir et paramétrer l’accès. Une réponse est souhaitée sous 7 jours.

--- a/packages/api/server/services/accessRequest/mailer.ts
+++ b/packages/api/server/services/accessRequest/mailer.ts
@@ -32,6 +32,7 @@ export default {
                     variables: {
                         adminUrl: `${webappUrl}/nouvel-utilisateur/${user.id}`,
                         userName: formatName(user),
+                        userEmail: user.email,
                         orgName: user.organization.abbreviation ?? user.organization.name,
                     },
                 })),


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/N20b9yhc/2661

## 🛠 Description de la PR
Ajouter l’adresse mel dans le mel à destination des administrateurs locaux et nationaux sur les demandes de création/modification de compte
Vous avez reçu une nouvelle demande d’accès à la plateforme Résorption en provenance de : xxx.yyy@zzz.vv


## 📸 Captures d'écran
<img width="637" height="365" alt="image" src="https://github.com/user-attachments/assets/d81c0278-1913-46fc-8f5a-99ae6f017cc5" />

## 🚨 Notes pour la mise en production
- Rien à signaler