### PR TITLE
#minor (2659) Permettre de filtrer les actions financé par la DIHAL par année

### DIFF
--- a/packages/api/server/models/actionModel/fetch/fetch.ts
+++ b/packages/api/server/models/actionModel/fetch/fetch.ts
@@ -19,7 +19,7 @@ import mergeTopics from './mergeTopics';
 import Action from '#root/types/resources/Action.d';
 import { User } from '#root/types/resources/User.d';
 
-export default async (user: User, actionIds: number[] = null, transaction?: Transaction): Promise<Action[]> => {
+export default async function fetch(user: User, actionIds: number[] = null, transaction?: Transaction): Promise<Action[]> {
     const clauseGroup = where().can(user).do('read', 'action');
     if (clauseGroup === null) {
         return [];
@@ -34,7 +34,7 @@ export default async (user: User, actionIds: number[] = null, transaction?: Tran
         fetchShantytowns(actionIds, clauseGroup, transaction),
         fetchComments(actionIds, null, clauseGroup, transaction),
         fetchMetrics(actionIds, clauseGroup, transaction),
-        financeClauseGroup !== null ? fetchFinances(actionIds, clauseGroup, financeClauseGroup, transaction) : [],
+        financeClauseGroup === null ? [] : fetchFinances(actionIds, clauseGroup, financeClauseGroup, transaction),
     ]);
 
     const hash = hashActions(actions);
@@ -47,4 +47,4 @@ export default async (user: User, actionIds: number[] = null, transaction?: Tran
     mergeFinances(hash, finances);
 
     return Object.values(hash);
-};
+}

--- a/packages/api/server/models/actionModel/fetch/fetch.ts
+++ b/packages/api/server/models/actionModel/fetch/fetch.ts
@@ -19,7 +19,7 @@ import mergeTopics from './mergeTopics';
 import Action from '#root/types/resources/Action.d';
 import { User } from '#root/types/resources/User.d';
 
-export default async function fetch(user: User, actionIds: number[] = null, transaction?: Transaction): Promise<Action[]> {
+export default async function fetch(user: User, actionIds?: number[], transaction?: Transaction): Promise<Action[]> {
     const clauseGroup = where().can(user).do('read', 'action');
     if (clauseGroup === null) {
         return [];
@@ -32,7 +32,7 @@ export default async function fetch(user: User, actionIds: number[] = null, tran
         fetchManagers(actionIds, clauseGroup, transaction),
         fetchOperators(actionIds, clauseGroup, transaction),
         fetchShantytowns(actionIds, clauseGroup, transaction),
-        fetchComments(actionIds, null, clauseGroup, transaction),
+        fetchComments(actionIds, undefined, clauseGroup, transaction),
         fetchMetrics(actionIds, clauseGroup, transaction),
         financeClauseGroup === null ? [] : fetchFinances(actionIds, clauseGroup, financeClauseGroup, transaction),
     ]);

--- a/packages/api/server/models/actionModel/fetch/hashActions.ts
+++ b/packages/api/server/models/actionModel/fetch/hashActions.ts
@@ -44,6 +44,7 @@ export default function hashActions(actions: ActionSelectRow[]): ActionHash {
             operators: [],
             finances: {},
             hasDihalFinancing: false,
+            dihalFinancingYear: null,
             metrics: [],
             metrics_updated_at: null,
             comments: [],

--- a/packages/api/server/models/actionModel/fetch/mergeFinances.spec.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeFinances.spec.ts
@@ -1,0 +1,148 @@
+import { expect } from 'chai';
+import { ActionHash } from './hashActions';
+import mergeFinances from './mergeFinances';
+import ActionFinanceRow from './ActionFinanceRow.d';
+
+function makeAction(id: number): ActionHash[number] {
+    return {
+        type: 'action',
+        id,
+        displayId: `ID${String(id).padStart(4, '0')}`,
+        name: `Action ${id}`,
+        started_at: new Date('2024-01-01').getTime(),
+        ended_at: null,
+        goals: null,
+        topics: [],
+        location: {
+            type: 'departement',
+            city: null,
+            epci: null,
+            departement: { code: '75', name: 'Paris' },
+            region: { code: '11', name: 'Île-de-France' },
+        },
+        location_type: 'departement',
+        eti: null,
+        location_other: null,
+        location_shantytowns: [],
+        managers: [],
+        operators: [],
+        finances: {},
+        hasDihalFinancing: false,
+        dihalFinancingYear: null,
+        metrics: [],
+        metrics_updated_at: null,
+        comments: [],
+        created_at: new Date('2024-01-01').getTime(),
+        created_by: {
+            id: 1,
+            first_name: 'Jean',
+            last_name: 'Dupont',
+            organization: { id: 1, name: 'Org', abbreviation: null },
+        },
+        updated_at: null,
+        updated_by: null,
+    } as unknown as ActionHash[number];
+}
+
+function makeFinanceRow(overrides: Partial<ActionFinanceRow> = {}): ActionFinanceRow {
+    return {
+        action_id: 1,
+        year: 2024,
+        amount: 10000,
+        real_amount: null,
+        comments: '',
+        action_finance_type_uid: 'etatique',
+        action_finance_type_name: 'Financement étatique',
+        ...overrides,
+    };
+}
+
+describe('models/actionModel/fetch/mergeFinances()', () => {
+    describe('hasDihalFinancing', () => {
+        it('une action sans aucun financement conserve hasDihalFinancing à false', () => {
+            const hash: ActionHash = { 1: makeAction(1) };
+            mergeFinances(hash, []);
+            expect(hash[1].hasDihalFinancing).to.equal(false);
+        });
+
+        it('une action avec un financement de type dedie passe hasDihalFinancing à true', () => {
+            const hash: ActionHash = { 1: makeAction(1) };
+            const finances: ActionFinanceRow[] = [
+                makeFinanceRow({ action_id: 1, action_finance_type_uid: 'dedie', action_finance_type_name: 'Financement dédié DIHAL' }),
+            ];
+            mergeFinances(hash, finances);
+            expect(hash[1].hasDihalFinancing).to.equal(true);
+        });
+
+        it('une action avec uniquement un financement de type etatique conserve hasDihalFinancing à false', () => {
+            const hash: ActionHash = { 1: makeAction(1) };
+            const finances: ActionFinanceRow[] = [
+                makeFinanceRow({ action_id: 1, action_finance_type_uid: 'etatique', action_finance_type_name: 'Financement étatique' }),
+            ];
+            mergeFinances(hash, finances);
+            expect(hash[1].hasDihalFinancing).to.equal(false);
+        });
+    });
+
+    describe('dihalFinancingYear', () => {
+        it('une action sans financement dedie conserve dihalFinancingYear à null', () => {
+            const hash: ActionHash = { 1: makeAction(1) };
+            mergeFinances(hash, []);
+            expect(hash[1].dihalFinancingYear).to.equal(null);
+        });
+
+        it('une action avec un seul financement dedie en 2024 positionne dihalFinancingYear à 2024', () => {
+            const hash: ActionHash = { 1: makeAction(1) };
+            const finances: ActionFinanceRow[] = [
+                makeFinanceRow({
+                    action_id: 1, year: 2024, action_finance_type_uid: 'dedie', action_finance_type_name: 'Financement dédié DIHAL',
+                }),
+            ];
+            mergeFinances(hash, finances);
+            expect(hash[1].dihalFinancingYear).to.equal(2024);
+        });
+
+        it('une action avec des financements dedie en 2023 et 2025 positionne dihalFinancingYear à 2025 (max)', () => {
+            const hash: ActionHash = { 1: makeAction(1) };
+            const finances: ActionFinanceRow[] = [
+                makeFinanceRow({
+                    action_id: 1, year: 2023, action_finance_type_uid: 'dedie', action_finance_type_name: 'Financement dédié DIHAL',
+                }),
+                makeFinanceRow({
+                    action_id: 1, year: 2025, action_finance_type_uid: 'dedie', action_finance_type_name: 'Financement dédié DIHAL',
+                }),
+            ];
+            mergeFinances(hash, finances);
+            expect(hash[1].dihalFinancingYear).to.equal(2025);
+        });
+
+        it('une action avec uniquement un financement etatique conserve dihalFinancingYear à null', () => {
+            const hash: ActionHash = { 1: makeAction(1) };
+            const finances: ActionFinanceRow[] = [
+                makeFinanceRow({
+                    action_id: 1, year: 2024, action_finance_type_uid: 'etatique', action_finance_type_name: 'Financement étatique',
+                }),
+            ];
+            mergeFinances(hash, finances);
+            expect(hash[1].dihalFinancingYear).to.equal(null);
+        });
+
+        it('deux actions distinctes calculent chacune leur propre dihalFinancingYear indépendamment', () => {
+            const hash: ActionHash = {
+                1: makeAction(1),
+                2: makeAction(2),
+            };
+            const finances: ActionFinanceRow[] = [
+                makeFinanceRow({
+                    action_id: 1, year: 2024, action_finance_type_uid: 'dedie', action_finance_type_name: 'Financement dédié DIHAL',
+                }),
+                makeFinanceRow({
+                    action_id: 2, year: 2022, action_finance_type_uid: 'dedie', action_finance_type_name: 'Financement dédié DIHAL',
+                }),
+            ];
+            mergeFinances(hash, finances);
+            expect(hash[1].dihalFinancingYear).to.equal(2024);
+            expect(hash[2].dihalFinancingYear).to.equal(2022);
+        });
+    });
+});

--- a/packages/api/server/models/actionModel/fetch/mergeFinances.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeFinances.ts
@@ -1,24 +1,20 @@
 import { ActionHash } from './hashActions';
 import ActionFinanceRow from './ActionFinanceRow.d';
 
-export default function mergeManagers(hash: ActionHash, finances: ActionFinanceRow[]): void {
+export default function mergeFinances(hash: ActionHash, finances: ActionFinanceRow[]): void {
     finances.forEach((row) => {
         const action = hash[row.action_id];
         if (action === undefined) {
             return;
         }
 
-        if (action.finances === undefined) {
-            // eslint-disable-next-line no-param-reassign
-            action.finances = {};
-        }
+        // eslint-disable-next-line no-param-reassign
+        action.finances ??= {};
 
-        const finances = action.finances;
-        if (finances[row.year] === undefined) {
-            finances[row.year] = [];
-        }
+        const actionFinances = action.finances;
+        actionFinances[row.year] ??= [];
 
-        finances[row.year]!.push({
+        actionFinances[row.year].push({
             type: {
                 uid: row.action_finance_type_uid,
                 name: row.action_finance_type_name,

--- a/packages/api/server/models/actionModel/fetch/mergeFinances.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeFinances.ts
@@ -3,12 +3,22 @@ import ActionFinanceRow from './ActionFinanceRow.d';
 
 export default function mergeManagers(hash: ActionHash, finances: ActionFinanceRow[]): void {
     finances.forEach((row) => {
-        if (hash[row.action_id].finances[row.year] === undefined) {
-            // eslint-disable-next-line no-param-reassign
-            hash[row.action_id].finances[row.year] = [];
+        const action = hash[row.action_id];
+        if (action === undefined) {
+            return;
         }
 
-        hash[row.action_id].finances[row.year].push({
+        if (action.finances === undefined) {
+            // eslint-disable-next-line no-param-reassign
+            action.finances = {};
+        }
+
+        const finances = action.finances;
+        if (finances[row.year] === undefined) {
+            finances[row.year] = [];
+        }
+
+        finances[row.year]!.push({
             type: {
                 uid: row.action_finance_type_uid,
                 name: row.action_finance_type_name,
@@ -20,7 +30,12 @@ export default function mergeManagers(hash: ActionHash, finances: ActionFinanceR
 
         if (row.action_finance_type_uid === 'dedie') {
             // eslint-disable-next-line no-param-reassign
-            hash[row.action_id].hasDihalFinancing = true;
+            action.hasDihalFinancing = true;
+            const currentYear = action.dihalFinancingYear;
+            if (currentYear === null || row.year > currentYear) {
+                // eslint-disable-next-line no-param-reassign
+                action.dihalFinancingYear = row.year;
+            }
         }
     });
 }

--- a/packages/api/test/utils/action.ts
+++ b/packages/api/test/utils/action.ts
@@ -93,6 +93,7 @@ export function serialized(override = {}): Action {
             },
         ],
         hasDihalFinancing: false,
+        dihalFinancingYear: null,
         created_at: (new Date(2022, 0, 1)).getTime(),
         created_by: {
             id: 1,

--- a/packages/api/types/resources/Action.d.ts
+++ b/packages/api/types/resources/Action.d.ts
@@ -195,6 +195,7 @@ interface GenericAction extends IAction {
     metrics_updated_at: number | null,
     finances?: ActionFinances,
     hasDihalFinancing: boolean,
+    dihalFinancingYear: number | null,
     created_at: number,
     created_by: ActionUser,
     updated_at: number | null,

--- a/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
@@ -29,7 +29,11 @@
                     />
                     <DsfrBadge
                         v-if="action.hasDihalFinancing"
-                        :label="`FINANCEMENT DIHAL${action.dihalFinancingYear ? ' ' + action.dihalFinancingYear : ''}`"
+                        :label="`FINANCEMENT DIHAL${
+                            action.dihalFinancingYear
+                                ? ' ' + action.dihalFinancingYear
+                                : ''
+                        }`"
                         noIcon
                         type="info"
                         class="mt-1 lg:place-self-end text-xs py-2"

--- a/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteActionDetaillee/CarteActionDetaillee.vue
@@ -29,7 +29,7 @@
                     />
                     <DsfrBadge
                         v-if="action.hasDihalFinancing"
-                        label="FINANCEMENT DIHAL"
+                        :label="`FINANCEMENT DIHAL${action.dihalFinancingYear ? ' ' + action.dihalFinancingYear : ''}`"
                         noIcon
                         type="info"
                         class="mt-1 lg:place-self-end text-xs py-2"

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActions.filtres.js
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActions.filtres.js
@@ -27,8 +27,8 @@ export default [
         ],
     },
     {
-        label: "Financement",
+        label: "Financement DIHAL",
         id: "dihalFinancing",
-        options: [{ value: "dihal", label: "Financement DIHAL" }],
+        options: [],
     },
 ];

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
@@ -52,7 +52,9 @@ const sortOptions = [sorts.startedAt, sorts.updatedAt, sorts.lastMetricUpdate];
 const dihalYearOptions = computed(() => {
     const years = new Set();
     for (const action of actionsStore.actions) {
-        for (const [year, financeLines] of Object.entries(action.finances || {})) {
+        for (const [year, financeLines] of Object.entries(
+            action.finances || {}
+        )) {
             if (financeLines.some((line) => line.type?.uid === "dedie")) {
                 years.add(Number(year));
             }
@@ -66,7 +68,11 @@ const dihalYearOptions = computed(() => {
 const filters = computed(() =>
     staticFilters.map((filter) =>
         filter.id === "dihalFinancing"
-            ? { ...filter, label: "Financement DIHAL", options: dihalYearOptions.value }
+            ? {
+                  ...filter,
+                  label: "Financement DIHAL",
+                  options: dihalYearOptions.value,
+              }
             : filter
     )
 );

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
@@ -41,13 +41,36 @@
 <script setup>
 import { computed } from "vue";
 import { useActionsStore } from "@/stores/actions.store";
-import filters from "./ListeDesActions.filtres";
+import staticFilters from "./ListeDesActions.filtres";
 import sorts from "./ListeDesActions.tris";
 import { Filter, Sort } from "@resorptionbidonvilles/ui";
 
 const actionsStore = useActionsStore();
 
 const sortOptions = [sorts.startedAt, sorts.updatedAt, sorts.lastMetricUpdate];
+
+const dihalYearOptions = computed(() => {
+    const years = new Set();
+    for (const action of actionsStore.actions) {
+        for (const [year, financeLines] of Object.entries(action.finances || {})) {
+            if (financeLines.some((line) => line.type?.uid === "dedie")) {
+                years.add(Number(year));
+            }
+        }
+    }
+    return [...years]
+        .sort((a, b) => b - a)
+        .map((year) => ({ value: String(year), label: String(year) }));
+});
+
+const filters = computed(() =>
+    staticFilters.map((filter) =>
+        filter.id === "dihalFinancing"
+            ? { ...filter, label: "Financement DIHAL", options: dihalYearOptions.value }
+            : filter
+    )
+);
+
 const isFiltered = computed(() => {
     const filterValues = Object.values(actionsStore.filters.properties);
     const activeFiltersCount = filterValues.filter(

--- a/packages/frontend/webapp/src/utils/filterActions.js
+++ b/packages/frontend/webapp/src/utils/filterActions.js
@@ -117,8 +117,9 @@ function checkOrganization(action, organizationId) {
 }
 
 function checkDihalFinancing(action, dihalFinancingFilters) {
-    if (dihalFinancingFilters.includes("dihal")) {
-        return action.hasDihalFinancing === true;
-    }
-    return true;
+    return Object.entries(action.finances || {}).some(
+        ([year, financeLines]) =>
+            dihalFinancingFilters.includes(String(year)) &&
+            financeLines.some((line) => line.type?.uid === "dedie")
+    );
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/kJPQPNTI/2659

## 🛠 Description de la PR
Cette PR ajoute la possibilité de filtrer les actions par année de financement DIHAL et d'afficher l'année concernée dans les badges.

Changements principaux :

Backend : Ajout du champ dihalFinancingYear qui stocke l'année la plus récente de financement DIHAL pour chaque action
Frontend : Le filtre "Financement DIHAL" affiche maintenant les années disponibles dynamiquement et permet de filtrer par année spécifique
Affichage : Le badge "FINANCEMENT DIHAL" affiche maintenant l'année concernée (ex: "FINANCEMENT DIHAL 2024")
Fonctionnalités :

Le badge DIHAL affiche l'année la plus récente de financement dédié
Le filtre DIHAL génère automatiquement les années disponibles depuis les données
Possibilité de filtrer les actions par année de financement DIHAL spécifique

## 📸 Captures d'écran
<img width="651" height="290" alt="{00A89236-39C6-4680-807C-F482FA729A56}" src="https://github.com/user-attachments/assets/ce895f98-7016-4ec1-8a6a-ae22d33327e7" />

## 🚨 Notes pour la mise en production
- Cette modification est rétrocompatible : les actions existantes auront dihalFinancingYear à null par défaut
- Le filtre DIHAL fonctionnera uniquement pour les actions ayant des financements dédiés
- Aucune migration de base de données nécessaire