### PR TITLE
#patch (2657) Eviter de recharger le formulaire lors du clic sur une année

### DIFF
--- a/packages/frontend/webapp/src/components/InputActionFinances/InputActionFinances.vue
+++ b/packages/frontend/webapp/src/components/InputActionFinances/InputActionFinances.vue
@@ -77,6 +77,7 @@
             <template v-if="yearsWithData.length > 0">
                 Années avec financements renseignés :
                 <Link
+                    @click.stop.prevent
                     class="mr-1"
                     v-for="year in yearsWithData"
                     :key="year"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/rwZTIcBZ/2657

## 🛠 Description de la PR
Sur le formulaire de modification d'une action, la liste des années pour lesquels des financements existent est présentées de la façon suivante:
<img width="421" height="346" alt="{8EB2455D-9723-4CBA-A497-C94CE928F15C}" src="https://github.com/user-attachments/assets/5bba4697-b8bf-478a-9a66-bec447860772" />
Mais lors d'un clic sur une année, au lieu d'afficher les financements de l'année concernée, le formulaire d'édition de l'action est rechargé.

Pour éviter le bubbling de l'élément enfant vers les éléments parents, on utlise @click.stop.prevent qui appelle `event.stopPropagation()` ET empêche le comportement par défaut du navigateur grâce à `event.preventDefault()`.

## 🚨 Notes pour la mise en production
- Rien à signaler