### PR TITLE
#patch (2662) Ajouter les indicateurs de suivi de la màj du nombre d'habitants dans les emails récap hebdo

### DIFF
--- a/packages/api/server/mails/dist/activity_summary.html
+++ b/packages/api/server/mails/dist/activity_summary.html
@@ -269,33 +269,6 @@
                   
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
             <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">0%</span>
-            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
-            <span aria-label="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
-            <span aria-label="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #FFEB9C; color: #000000; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% else %}</mj-raw>
-            <span aria-label="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #b8fec9; color: #18753c; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% endif %}</mj-raw>
-             de sites (soit {{ summary.updated_shantytowns_6_months }} sur {{ summary.shantytowns_total }}, représentant
-                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
-                un taux moyen)
-                <mj-raw>{% else %}</mj-raw>
-                un très bon taux)
-                <mj-raw>{% endif %}</mj-raw>
-             ont été mis à jour au cours des 6 derniers mois</div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                  
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">0%</span>
             <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
             <span aria-label="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
             <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
@@ -303,7 +276,7 @@
             <mj-raw>{% else %}</mj-raw>
             <span aria-label="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #b8fec9; color: #18753c; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
             <mj-raw>{% endif %}</mj-raw>
-             de sites (soit {{ summary.updated_population_3_months }} sur {{ summary.shantytowns_total }}, représentant
+             de sites (soit
                 <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
                 un taux faible)
                 <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
@@ -314,6 +287,33 @@
                 un très bon taux)
                 <mj-raw>{% endif %}</mj-raw>
              ont fait l'objet d'une mise à jour du nombre d'habitants dans les 3 derniers mois</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">0%</span>
+            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
+            <span aria-label="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
+            <span aria-label="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #FFEB9C; color: #000000; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+            <mj-raw>{% else %}</mj-raw>
+            <span aria-label="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #b8fec9; color: #18753c; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+            <mj-raw>{% endif %}</mj-raw>
+             de sites (soit
+                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+                un taux faible)
+                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
+                un taux faible)
+                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
+                un taux moyen)
+                <mj-raw>{% else %}</mj-raw>
+                un très bon taux)
+                <mj-raw>{% endif %}</mj-raw>
+             ont été mis à jour au cours des 6 derniers mois</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/activity_summary.html
+++ b/packages/api/server/mails/dist/activity_summary.html
@@ -294,6 +294,33 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">0%</span>
+            <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
+            <span aria-label="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
+            <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
+            <span aria-label="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #FFEB9C; color: #000000; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
+            <mj-raw>{% else %}</mj-raw>
+            <span aria-label="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #b8fec9; color: #18753c; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
+            <mj-raw>{% endif %}</mj-raw>
+             de sites (soit {{ summary.updated_population_3_months }} sur {{ summary.shantytowns_total }}, représentant
+                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+                un taux faible)
+                <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
+                un taux faible)
+                <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
+                un taux moyen)
+                <mj-raw>{% else %}</mj-raw>
+                un très bon taux)
+                <mj-raw>{% endif %}</mj-raw>
+             ont fait l'objet d'une mise à jour du nombre d'habitants dans les 3 derniers mois</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                  
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><span aria-label="{{ summary.population_total }} habitants" class="rate-span rate-none" title="{{ summary.population_total }}" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #e8edff; color: #0063cb; font-weight: bold;">{{ summary.population_total }}</span> habitants en bidonvilles ou squats</div>
     
                 </td>

--- a/packages/api/server/mails/dist/activity_summary.text
+++ b/packages/api/server/mails/dist/activity_summary.text
@@ -26,29 +26,27 @@ attend dans l'espace d'entraide [{{var:webappUrl}}/communaute?{{var:utm}}] :
 {% endif %}{% for summary in var:summaries %}
 {{ summary.code }} – {{ summary.name }}
 {% if summary.shantytowns_total == 0 %} 0% {% elseif
+summary.updated_population_3_months_percentage < 80 %} {{
+summary.updated_population_3_months_percentage }}% {% elseif
+summary.updated_population_3_months_percentage < 95 %} {{
+summary.updated_population_3_months_percentage }}% {% else %} {{
+summary.updated_population_3_months_percentage }}% {% endif %} de sites (soit {%
+if summary.shantytowns_total == 0 %} un taux faible) {% elseif
+summary.updated_population_3_months_percentage < 80 %} un taux faible) {% elseif
+summary.updated_population_3_months_percentage < 95 %} un taux moyen) {% else %}
+un très bon taux) {% endif %} ont fait l'objet d'une mise à jour du nombre
+d'habitants dans les 3 derniers mois
+{% if summary.shantytowns_total == 0 %} 0% {% elseif
 summary.updated_shantytowns_6_months_percentage <= 30 %} {{
 summary.updated_shantytowns_6_months_percentage }}% {% elseif
 summary.updated_shantytowns_6_months_percentage <= 60 %} {{
 summary.updated_shantytowns_6_months_percentage }}% {% else %} {{
 summary.updated_shantytowns_6_months_percentage }}% {% endif %} de sites (soit
-{{ summary.updated_shantytowns_6_months }} sur {{ summary.shantytowns_total }},
-représentant {% if summary.shantytowns_total == 0 %} un taux faible) {% elseif
+{% if summary.shantytowns_total == 0 %} un taux faible) {% elseif
 summary.updated_shantytowns_6_months_percentage <= 30 %} un taux faible) {%
 elseif summary.updated_shantytowns_6_months_percentage <= 60 %} un taux moyen)
 {% else %} un très bon taux) {% endif %} ont été mis à jour au cours des 6
 derniers mois
-{% if summary.shantytowns_total == 0 %} 0% {% elseif
-summary.updated_population_3_months_percentage < 80 %} {{
-summary.updated_population_3_months_percentage }}% {% elseif
-summary.updated_population_3_months_percentage < 95 %} {{
-summary.updated_population_3_months_percentage }}% {% else %} {{
-summary.updated_population_3_months_percentage }}% {% endif %} de sites (soit {{
-summary.updated_population_3_months }} sur {{ summary.shantytowns_total }},
-représentant {% if summary.shantytowns_total == 0 %} un taux faible) {% elseif
-summary.updated_population_3_months_percentage < 80 %} un taux faible) {% elseif
-summary.updated_population_3_months_percentage < 95 %} un taux moyen) {% else %}
-un très bon taux) {% endif %} ont fait l'objet d'une mise à jour du nombre
-d'habitants dans les 3 derniers mois
 {{ summary.population_total }} habitants en bidonvilles ou squats
 {% if var:showDetails %}{% if summary.new_shantytowns_length > 1 %}
 {{ summary.new_shantytowns_length }} nouveaux sites

--- a/packages/api/server/mails/dist/activity_summary.text
+++ b/packages/api/server/mails/dist/activity_summary.text
@@ -37,6 +37,18 @@ summary.updated_shantytowns_6_months_percentage <= 30 %} un taux faible) {%
 elseif summary.updated_shantytowns_6_months_percentage <= 60 %} un taux moyen)
 {% else %} un très bon taux) {% endif %} ont été mis à jour au cours des 6
 derniers mois
+{% if summary.shantytowns_total == 0 %} 0% {% elseif
+summary.updated_population_3_months_percentage < 80 %} {{
+summary.updated_population_3_months_percentage }}% {% elseif
+summary.updated_population_3_months_percentage < 95 %} {{
+summary.updated_population_3_months_percentage }}% {% else %} {{
+summary.updated_population_3_months_percentage }}% {% endif %} de sites (soit {{
+summary.updated_population_3_months }} sur {{ summary.shantytowns_total }},
+représentant {% if summary.shantytowns_total == 0 %} un taux faible) {% elseif
+summary.updated_population_3_months_percentage < 80 %} un taux faible) {% elseif
+summary.updated_population_3_months_percentage < 95 %} un taux moyen) {% else %}
+un très bon taux) {% endif %} ont fait l'objet d'une mise à jour du nombre
+d'habitants dans les 3 derniers mois
 {{ summary.population_total }} habitants en bidonvilles ou squats
 {% if var:showDetails %}{% if summary.new_shantytowns_length > 1 %}
 {{ summary.new_shantytowns_length }} nouveaux sites

--- a/packages/api/server/mails/preview/activity_summary.variables.example.json
+++ b/packages/api/server/mails/preview/activity_summary.variables.example.json
@@ -29,7 +29,10 @@
             "new_users_length": 0,
             "shantytowns_total": 10,
             "population_total": 120,
-            "updated_shantytowns_6_months": 9
+            "updated_shantytowns_6_months": 9,
+            "updated_shantytowns_6_months_percentage": 90,
+            "updated_population_3_months": 8,
+            "updated_population_3_months_percentage": 80
         }
     ]
 }

--- a/packages/api/server/mails/src/common/summary.mjml
+++ b/packages/api/server/mails/src/common/summary.mjml
@@ -6,28 +6,6 @@
         <mj-text mj-class='text-body'>
             <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
             <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent">0%</span>
-            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
-            <span aria-label="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
-            <span aria-label="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% else %}</mj-raw>
-            <span aria-label="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% endif %}</mj-raw>
-             de sites (soit {{ summary.updated_shantytowns_6_months }} sur {{ summary.shantytowns_total }}, représentant
-                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
-                un taux moyen)
-                <mj-raw>{% else %}</mj-raw>
-                un très bon taux)
-                <mj-raw>{% endif %}</mj-raw>
-             ont été mis à jour au cours des 6 derniers mois
-        </mj-text>
-        <mj-text mj-class='text-body'>
-            <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent">0%</span>
             <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
             <span aria-label="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent">{{ summary.updated_population_3_months_percentage }}%</span>
             <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
@@ -35,7 +13,7 @@
             <mj-raw>{% else %}</mj-raw>
             <span aria-label="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent">{{ summary.updated_population_3_months_percentage }}%</span>
             <mj-raw>{% endif %}</mj-raw>
-             de sites (soit {{ summary.updated_population_3_months }} sur {{ summary.shantytowns_total }}, représentant
+             de sites (soit
                 <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
                 un taux faible)
                 <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
@@ -46,6 +24,28 @@
                 un très bon taux)
                 <mj-raw>{% endif %}</mj-raw>
              ont fait l'objet d'une mise à jour du nombre d'habitants dans les 3 derniers mois
+        </mj-text>        
+        <mj-text mj-class='text-body'>
+            <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent">0%</span>
+            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
+            <span aria-label="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
+            <span aria-label="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+            <mj-raw>{% else %}</mj-raw>
+            <span aria-label="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+            <mj-raw>{% endif %}</mj-raw>
+             de sites (soit
+                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+                un taux faible)
+                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
+                un taux faible)
+                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
+                un taux moyen)
+                <mj-raw>{% else %}</mj-raw>
+                un très bon taux)
+                <mj-raw>{% endif %}</mj-raw>
+             ont été mis à jour au cours des 6 derniers mois
         </mj-text>
         <mj-text><span aria-label="{{ summary.population_total }} habitants" class="rate-span rate-none" title="{{ summary.population_total }}">{{ summary.population_total }}</span> habitants en bidonvilles ou squats</mj-text>
         <mj-raw>{% if var:showDetails %}</mj-raw>

--- a/packages/api/server/mails/src/common/summary.mjml
+++ b/packages/api/server/mails/src/common/summary.mjml
@@ -25,6 +25,28 @@
                 <mj-raw>{% endif %}</mj-raw>
              ont été mis à jour au cours des 6 derniers mois
         </mj-text>
+        <mj-text mj-class='text-body'>
+            <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent">0%</span>
+            <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
+            <span aria-label="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent">{{ summary.updated_population_3_months_percentage }}%</span>
+            <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
+            <span aria-label="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent">{{ summary.updated_population_3_months_percentage }}%</span>
+            <mj-raw>{% else %}</mj-raw>
+            <span aria-label="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent">{{ summary.updated_population_3_months_percentage }}%</span>
+            <mj-raw>{% endif %}</mj-raw>
+             de sites (soit {{ summary.updated_population_3_months }} sur {{ summary.shantytowns_total }}, représentant
+                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+                un taux faible)
+                <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
+                un taux faible)
+                <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
+                un taux moyen)
+                <mj-raw>{% else %}</mj-raw>
+                un très bon taux)
+                <mj-raw>{% endif %}</mj-raw>
+             ont fait l'objet d'une mise à jour du nombre d'habitants dans les 3 derniers mois
+        </mj-text>
         <mj-text><span aria-label="{{ summary.population_total }} habitants" class="rate-span rate-none" title="{{ summary.population_total }}">{{ summary.population_total }}</span> habitants en bidonvilles ou squats</mj-text>
         <mj-raw>{% if var:showDetails %}</mj-raw>
             <mj-include path="summary_full_activities.mjml" />

--- a/packages/api/server/models/activityModel/get.ts
+++ b/packages/api/server/models/activityModel/get.ts
@@ -17,6 +17,7 @@ type Row = {
     shantytownsTotal: number,
     populationTotal: number,
     updatedLessThan6MonthsTotal: number,
+    populationUpdatedLessThan3MonthsTotal: number,
     activityType: string,
     city: string,
     departement: string,
@@ -186,7 +187,10 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
                     COALESCE(SUM(s.population_total), 0) AS "populationTotal",
                     COUNT(*) FILTER (
                         WHERE s.updated_at >= (CURRENT_DATE - INTERVAL '6 months')
-                    ) AS "updatedLessThan6MonthsTotal"
+                    ) AS "updatedLessThan6MonthsTotal",
+                    COUNT(*) FILTER (
+                        WHERE s.population_updated_at >= (CURRENT_DATE - INTERVAL '3 months')
+                    ) AS "populationUpdatedLessThan3MonthsTotal"
                 FROM shantytowns s
                 LEFT JOIN cities c ON s.fk_city = c.code
                 WHERE closed_at IS NULL
@@ -199,6 +203,7 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
             COALESCE(totals."shantytownsTotal", 0) AS "shantytownsTotal",
             COALESCE(totals."populationTotal", 0)  AS "populationTotal",
             COALESCE(totals."updatedLessThan6MonthsTotal", 0)  AS "updatedLessThan6MonthsTotal",
+            COALESCE(totals."populationUpdatedLessThan3MonthsTotal", 0)  AS "populationUpdatedLessThan3MonthsTotal",
             activities.*
         FROM departements d
         LEFT JOIN totals ON totals.fk_departement = d.code
@@ -225,6 +230,9 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
             const updatedPercentage = row.shantytownsTotal > 0
                 ? Number.parseFloat(((row.updatedLessThan6MonthsTotal * 100) / row.shantytownsTotal).toFixed(2))
                 : 0;
+            const populationUpdatedPercentage = row.shantytownsTotal > 0
+                ? Number.parseFloat(((row.populationUpdatedLessThan3MonthsTotal * 100) / row.shantytownsTotal).toFixed(2))
+                : 0;
             acc[row.regionCode][row.departementCode] = {
                 has_activity: false,
                 code: row.departementCode,
@@ -244,6 +252,9 @@ export default async (argFrom: Date, argTo: Date): Promise<ActivityNationalSumma
                 updated_shantytowns_6_months:
                     row.updatedLessThan6MonthsTotal,
                 updated_shantytowns_6_months_percentage: updatedPercentage,
+                updated_population_3_months:
+                    row.populationUpdatedLessThan3MonthsTotal,
+                updated_population_3_months_percentage: populationUpdatedPercentage,
             };
         }
 

--- a/packages/api/server/models/activityModel/types/ActivityDepartementalSummary.ts
+++ b/packages/api/server/models/activityModel/types/ActivityDepartementalSummary.ts
@@ -33,5 +33,7 @@ export interface ActivityDepartementalSummary {
     shantytowns_total: number,
     population_total: number,
     updated_shantytowns_6_months: number,
-    updated_shantytowns_6_months_percentage: number
+    updated_shantytowns_6_months_percentage: number,
+    updated_population_3_months: number,
+    updated_population_3_months_percentage: number
 }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/RaJrq8bH/2662

## 🛠 Description de la PR
Ajout d'indicateurs de suivi de la mise à jour du nombre d'habitants dans les emails récapitulatifs d'activité départementale.
 
Cette modification permet de suivre le taux de sites dont le nombre d'habitants a été mis à jour au cours des 3 derniers mois, avec un affichage coloré selon les seuils de performance :
- < 80% : Taux faible (rouge)
- 80-95% : Taux moyen (orange)  
- ≥ 95% : Très bon taux (vert)

## 📸 Captures d'écran
<img width="872" height="718" alt="image" src="https://github.com/user-attachments/assets/bddfb3e7-47ee-47b9-bfdf-1b8453df2b5a" />

## 🚨 Notes pour la mise en production
- rien à signaler