### PR TITLE
#patch (2672) Correction du doublon "Créer, mettre à jour les sites" pour les partenaires institutionnels

### DIFF
--- a/packages/api/server/permissions_description.ts
+++ b/packages/api/server/permissions_description.ts
@@ -59,7 +59,6 @@ const descriptions: RolePermissionDescriptions = {
         local_permissions: [
             [
                 { type: 'edit', label: 'Créer, mettre à jour les %sites%', comments: null },
-                { type: 'edit', label: 'Créer, mettre à jour les %sites%', comments: null },
                 {
                     type: 'deny', label: 'hors fermeture des sites', comments: null, option: 'close_shantytown',
                 },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/AaUc60ZT/2672-bug-cr%C3%A9er-mettre-%C3%A0-jour-les-sites-en-double-sur-la-fiche-des-utilisateurs-partenaire-institutionnel

## 🛠 Description de la PR
Cette PR corrige le doublon d'affichage du terme "Créer, mettre à jour les sites" pour les partenaires institutionnels.

## 📸 Captures d'écran
<img width="973" height="721" alt="image" src="https://github.com/user-attachments/assets/af0686ee-fe7c-4e82-bf0b-f88c29fe251a" />

## 🚨 Notes pour la mise en production
RàS