### PR TITLE
#minor (2678) Ajouter une option "Toutes" au filtre "Financement DIHAL"

### DIFF
--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
@@ -60,9 +60,11 @@ const dihalYearOptions = computed(() => {
             }
         }
     }
-    return [...years]
+    const yearOptions = [...years]
         .sort((a, b) => b - a)
         .map((year) => ({ value: String(year), label: String(year) }));
+
+    return [{ value: "all", label: "Toutes" }, ...yearOptions];
 });
 
 const filters = computed(() =>

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
@@ -64,7 +64,10 @@ const dihalYearOptions = computed(() => {
         .sort((a, b) => b - a)
         .map((year) => ({ value: String(year), label: String(year) }));
 
-    return [{ value: "all", label: "Toutes" }, ...yearOptions];
+    return [
+        { value: "all", label: "Toutes les années", displayBottomBorder: true },
+        ...yearOptions,
+    ];
 });
 
 const filters = computed(() =>

--- a/packages/frontend/webapp/src/utils/filterActions.js
+++ b/packages/frontend/webapp/src/utils/filterActions.js
@@ -117,6 +117,12 @@ function checkOrganization(action, organizationId) {
 }
 
 function checkDihalFinancing(action, dihalFinancingFilters) {
+    if (dihalFinancingFilters.includes("all")) {
+        return Object.values(action.finances || {}).some((financeLines) =>
+            financeLines.some((line) => line.type?.uid === "dedie")
+        );
+    }
+
     return Object.entries(action.finances || {}).some(
         ([year, financeLines]) =>
             dihalFinancingFilters.includes(String(year)) &&


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/fzADdwBp/2678

## 🛠 Description de la PR


### Frontend
1. **`ListeDesActionsFiltres.vue`**
    - Ajout de l'option { value: "all", label: "Toutes" } en début de liste des options du filtre "Financement DIHAL"
    L'option apparaît avant toutes les années disponibles

2. **`filterActions.js`**
    - Modification de la fonction `checkDihalFinancing()` pour gérer l'option "all"
    - Si "Toutes" est sélectionné : affiche toutes les actions ayant au moins un financement de type "dedie", quelle que soit l'année
    - Sinon : conserve le comportement actuel (filtrage par année spécifique)

### Comportement
- Lorsque l'utilisateur sélectionne "Toutes" dans le filtre "Financement DIHAL" :
  Affiche toutes les actions ayant bénéficié d'un financement DIHAL (type "dedie")
  Peu importe l'année du financement (2020, 2023, 2025, etc.)
  Compatible avec la sélection multiple

### Fichiers modifiés
    - packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsFiltres.vue
    - packages/frontend/webapp/src/utils/filterActions.js

## 📸 Captures d'écran
<img width="767" height="222" alt="{7153F78C-C9AF-443B-9239-6DC2DFF15352}" src="https://github.com/user-attachments/assets/32e5c67b-1c1c-463e-963c-e41f462f7d1d" />

## 🚨 Notes pour la mise en production
- Rien à siganler