### PR TITLE
#patch (2682) [BUG] Correction du build API

### DIFF
--- a/packages/api/test/utils/shantytown.ts
+++ b/packages/api/test/utils/shantytown.ts
@@ -211,7 +211,7 @@ export function serialized(location: City = defaultLocation, override = {}): Sha
         city, epci, departement, region,
     } = location;
 
-    const shantytown: Shantytown = {
+    const shantytown: Shantytown & { hasInitialResorptionPhases?: boolean } = {
         type: 'shantytown',
         id: 1,
         updatedWithoutAnyChange: false,
@@ -402,7 +402,8 @@ export function serialized(location: City = defaultLocation, override = {}): Sha
         resorptionTarget: null,
         completionRate: 0.5,
         distance: null,
-        preparatoryPhasesTowardResorption: null,
+        preparatoryPhasesTowardResorption: [],
+        hasInitialResorptionPhases: false,
     };
 
     return {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/cKmWXQLe/2682-bug-correction-du-build-api

## 🛠 Description de la PR
Ce build corrige le typage de l'objet `Shantytown` utilisé pour les tests unitaires.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS