### PR TITLE
#minor (2683) [Barre de recherche] Permettre la recherche par le code postal

### DIFF
--- a/packages/frontend/ui/src/composables/useAutocomplete.js
+++ b/packages/frontend/ui/src/composables/useAutocomplete.js
@@ -35,7 +35,7 @@ const normalizePayload = (payload) => {
     }
 
     return String(payload ?? "");
-}
+};
 
 export default function useAutocomplete({
     fn,
@@ -90,6 +90,7 @@ export default function useAutocomplete({
     let lastEvent;
     let callId = 0;
     let timeout = null;
+    let isClearing = false;
 
     function setSelectedFromValue(newValue) {
         if (!newValue) {
@@ -107,7 +108,9 @@ export default function useAutocomplete({
     watch(
         modelValue,
         (newValue) => {
-            setInputValue(getInitialLabel(newValue));
+            if (!isClearing) {
+                setInputValue(getInitialLabel(newValue));
+            }
             setSelectedFromValue(newValue);
         },
         { immediate: true }
@@ -116,7 +119,8 @@ export default function useAutocomplete({
     if (value && value !== modelValue) {
         watch(value, (val) => {
             if (val === undefined) {
-                clear();
+                rawResults.value = [];
+                selectedItem.value = null;
                 return;
             }
 
@@ -251,17 +255,26 @@ export default function useAutocomplete({
     }
 
     function clear(options = {}) {
-        rawResults.value = [];
-        selectedItem.value = null;
-        abort();
+        isClearing = true;
+        clearTimeout(timeout);
+        timeout = null;
 
-        if (options.sendEvent !== false) {
-            handleChange?.(undefined);
-            sendEvent(undefined);
+        try {
+            setInputValue("");
+
+            rawResults.value = [];
+            selectedItem.value = null;
+            abort();
+
+            if (options.sendEvent !== false) {
+                sendEvent(undefined);
+                handleChange?.(undefined);
+            }
+
+            onClear();
+        } finally {
+            isClearing = false;
         }
-
-        setInputValue("");
-        onClear();
     }
 
     function sendEvent(data) {

--- a/packages/frontend/webapp/src/api/locations.api.js
+++ b/packages/frontend/webapp/src/api/locations.api.js
@@ -20,10 +20,13 @@ export async function autocomplete(search) {
                 },
             });
 
-            const features = Array.isArray(data?.features) ? data.features : [];
+            const features = Array.isArray(data?.features)
+                ? data.features.filter((f) => f?.properties?.citycode)
+                : [];
+
             return features.sort((a, b) => {
-                const cityA = a?.properties?.city?.toLowerCase() ?? "";
-                const cityB = b?.properties?.city?.toLowerCase() ?? "";
+                const cityA = a?.properties?.name?.toLowerCase() ?? "";
+                const cityB = b?.properties?.name?.toLowerCase() ?? "";
                 return cityA.localeCompare(cityB);
             });
         } catch {

--- a/packages/frontend/webapp/src/api/locations.api.js
+++ b/packages/frontend/webapp/src/api/locations.api.js
@@ -1,7 +1,39 @@
 import { axios } from "@/helpers/axios";
+import axiosExternal from "axios";
+import ENV from "@/helpers/env.js";
 
-export function autocomplete(search) {
-    return axios.get(`/locations/search?q=${encodeURIComponent(search)}`);
+const { ADRESSE_API_URL } = ENV;
+const POSTAL_CODE_PATTERN = /^\d{5}$/;
+
+export async function autocomplete(search) {
+    const normalizedSearch = (search ?? "").toString().trim();
+    if (normalizedSearch.length < 2) {
+        return [];
+    }
+
+    if (POSTAL_CODE_PATTERN.test(normalizedSearch)) {
+        try {
+            const { data } = await axiosExternal.get(ADRESSE_API_URL, {
+                params: {
+                    q: normalizedSearch,
+                    type: "municipality",
+                },
+            });
+
+            const features = Array.isArray(data?.features) ? data.features : [];
+            return features.sort((a, b) => {
+                const cityA = a?.properties?.city?.toLowerCase() ?? "";
+                const cityB = b?.properties?.city?.toLowerCase() ?? "";
+                return cityA.localeCompare(cityB);
+            });
+        } catch {
+            return [];
+        }
+    }
+
+    return axios.get(
+        `/locations/search?q=${encodeURIComponent(normalizedSearch)}`
+    );
 }
 
 export function get(type, code) {

--- a/packages/frontend/webapp/src/components/InputLocation/InputLocation.vue
+++ b/packages/frontend/webapp/src/components/InputLocation/InputLocation.vue
@@ -124,7 +124,7 @@ function toLocationItem(loc) {
             }),
             category: "Commune",
             data: {
-                code: loc.properties.postcode,
+                code: loc.properties.citycode,
                 departement: loc.properties.depcode,
                 typeName: "Commune",
                 typeUid: "city",

--- a/packages/frontend/webapp/src/components/InputLocation/InputLocation.vue
+++ b/packages/frontend/webapp/src/components/InputLocation/InputLocation.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-import { defineProps, toRefs, computed, defineEmits, ref } from "vue";
+import { toRefs, computed, ref } from "vue";
 import { Autocomplete } from "@resorptionbidonvilles/ui";
 import { autocomplete } from "@/api/locations.api.js";
 import { fetchOne } from "@/api/actions.api.js";
@@ -73,26 +73,9 @@ async function autocompleteFn(value) {
     }
 
     // 2. Recherche géographique
-    const locationPromise = autocomplete(value)
-        .then((items) =>
-            items.map((loc) => ({
-                id: loc.code,
-                label: formatLocationLabel(loc),
-                category: loc.label,
-                data: {
-                    code: loc.code,
-                    departement: loc.departement,
-                    typeName: loc.label,
-                    typeUid: loc.type,
-                    latitude: loc.latitude,
-                    longitude: loc.longitude,
-                },
-            }))
-        )
-        .catch((error) => {
-            console.error("Error fetching locations:", error);
-            return [];
-        });
+    const locationPromise = autocomplete(trimmedSearch)
+        .then((items) => items.map(toLocationItem))
+        .catch(() => []);
 
     // 3. Recherche de structures
     const organizationPromise = searchActionOperators(value)
@@ -129,4 +112,41 @@ defineExpose({
         input.value.focus();
     },
 });
+
+function toLocationItem(loc) {
+    // Résultat GeoJSON (recherche par code postal via API externe)
+    if (loc.type === "Feature") {
+        return {
+            id: loc.properties.id,
+            label: formatLocationLabel({
+                code: loc.properties.id,
+                name: loc.properties.name,
+            }),
+            category: "Commune",
+            data: {
+                code: loc.properties.postcode,
+                departement: loc.properties.depcode,
+                typeName: "Commune",
+                typeUid: "city",
+                latitude: loc.geometry?.coordinates?.[1],
+                longitude: loc.geometry?.coordinates?.[0],
+            },
+        };
+    }
+
+    // Résultat interne
+    return {
+        id: loc.code,
+        label: formatLocationLabel(loc),
+        category: loc.label,
+        data: {
+            code: loc.code,
+            departement: loc.departement,
+            typeName: loc.label,
+            typeUid: loc.type,
+            latitude: loc.latitude,
+            longitude: loc.longitude,
+        },
+    };
+}
 </script>

--- a/packages/frontend/webapp/src/views/ListeDesActionsView.vue
+++ b/packages/frontend/webapp/src/views/ListeDesActionsView.vue
@@ -1,8 +1,8 @@
 <template>
     <LayoutSearch
         allowFreeSearch
-        searchTitle="Rechercher une action, une commune, un département, une structure..."
-        searchPlaceholder="Identifiant d'une action, commune, département, structure"
+        searchTitle="Rechercher une action, un département, une structure..."
+        searchPlaceholder="Identifiant d'une action, département, structure"
         showNationalWording="Voir toutes les actions de France"
         v-model:location="location"
     >


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/fz9v8sAi/2683-barre-de-recherche-permettre-la-recherche-par-le-code-postal

## 🛠 Description de la PR
Cette PR ajoute la possibilité de rechercher les sites et actions par code postal en faisant appel à l'API `geopf`.

## 📸 Captures d'écran
<img width="663" height="149" alt="image" src="https://github.com/user-attachments/assets/4ae52bff-1cc4-4217-90aa-a2ca8372d6fa" />

## 🚨 Notes pour la mise en production
RàS