### PR TITLE
#patch (2690) DSFRisation des boutons de changement d'année

### DIFF
--- a/packages/frontend/webapp/src/components/ActionFinances/ActionFinances.vue
+++ b/packages/frontend/webapp/src/components/ActionFinances/ActionFinances.vue
@@ -1,26 +1,25 @@
 <template>
     <div class="flex justify-between items-center">
-        <Button
-            icon="arrow-left"
-            iconPosition="left"
-            type="button"
-            variant="textPrimary"
+        <DsfrButton
+            icon="fr-icon-arrow-left-line"
+            tertiary
+            no-outline
             :disabled="focusedYear <= minYear"
             @click="previousYear"
-            >Année précédente</Button
-        >
+            label="Année précédente"
+        />
         <p class="text-lg text-primary font-bold text-center">
             Année {{ focusedYear }}
         </p>
-        <Button
-            icon="arrow-right"
-            iconPosition="right"
-            type="button"
-            variant="textPrimary"
+        <DsfrButton
+            icon="fr-icon-arrow-right-line"
+            icon-right
+            tertiary
+            no-outline
             :disabled="focusedYear >= maxYear"
             @click="nextYear"
-            >Année suivante</Button
-        >
+            label="Année suivante"
+        />
     </div>
 
     <Tableau :columns="COLUMNS_DEFINITION" :data="focusedYearData">
@@ -59,7 +58,7 @@ import { defineProps, toRefs, computed, ref } from "vue";
 import formatMoney from "@/utils/formatMoney";
 
 import Tableau from "@/components/Tableau/TableauRb.vue";
-import { Button, Link } from "@resorptionbidonvilles/ui";
+import { Link } from "@resorptionbidonvilles/ui";
 
 const props = defineProps({
     minYear: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/ikqsEIy1/2690-fiche-action-dsfriser-les-boutons-de-changement-dann%C3%A9e-de-financement

## 🛠 Description de la PR
Cette PR remplace les boutons de changement d'années de financement pour utiliser des boutons DSFR.

## 📸 Captures d'écran
<img width="2620" height="1126" alt="image" src="https://github.com/user-attachments/assets/c86a5429-b910-4ce7-b2fa-93f5624c4763" />

## 🚨 Notes pour la mise en production
RàS