### PR TITLE
#patch (2691) éviter la perte de financements lors de la mise à jour d'une action sans permission

### DIFF
--- a/packages/api/server/models/actionModel/historize/historize.spec.ts
+++ b/packages/api/server/models/actionModel/historize/historize.spec.ts
@@ -1,0 +1,88 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import { rewiremock } from '#test/rewiremock';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+const sandbox = sinon.createSandbox();
+const stubs = {
+    historizeAction: sandbox.stub(),
+    historizeAddresses: sandbox.stub(),
+    historizeFinances: sandbox.stub(),
+    historizeManagers: sandbox.stub(),
+    historizeMetrics: sandbox.stub(),
+    historizeOperators: sandbox.stub(),
+    historizeShantytowns: sandbox.stub(),
+    historizeTopics: sandbox.stub(),
+};
+
+rewiremock('./historizeAction').with(stubs.historizeAction);
+rewiremock('./historizeAddresses').with(stubs.historizeAddresses);
+rewiremock('./historizeFinances').with(stubs.historizeFinances);
+rewiremock('./historizeManagers').with(stubs.historizeManagers);
+rewiremock('./historizeMetrics').with(stubs.historizeMetrics);
+rewiremock('./historizeOperators').with(stubs.historizeOperators);
+rewiremock('./historizeShantytowns').with(stubs.historizeShantytowns);
+rewiremock('./historizeTopics').with(stubs.historizeTopics);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import historize from './historize';
+rewiremock.disable();
+
+describe('models/actionModel/historize/historize()', () => {
+    const id = 7;
+    const hid = 42;
+    const transaction = {} as any;
+
+    beforeEach(() => {
+        stubs.historizeAction.resolves(hid);
+        stubs.historizeAddresses.resolves();
+        stubs.historizeFinances.resolves();
+        stubs.historizeManagers.resolves();
+        stubs.historizeMetrics.resolves();
+        stubs.historizeOperators.resolves();
+        stubs.historizeShantytowns.resolves();
+        stubs.historizeTopics.resolves();
+    });
+
+    afterEach(() => {
+        sandbox.reset();
+    });
+
+    describe('appels inconditionnels', () => {
+        it('appelle historizeAction avec id et transaction', async () => {
+            await historize(id, false, transaction);
+
+            expect(stubs.historizeAction).to.have.been.calledOnceWithExactly(id, transaction);
+        });
+
+        it('appelle historizeAddresses, historizeManagers, historizeMetrics, historizeOperators, historizeShantytowns et historizeTopics avec id, hid et transaction', async () => {
+            await historize(id, false, transaction);
+
+            expect(stubs.historizeAddresses).to.have.been.calledOnceWithExactly(id, hid, transaction);
+            expect(stubs.historizeManagers).to.have.been.calledOnceWithExactly(id, hid, transaction);
+            expect(stubs.historizeMetrics).to.have.been.calledOnceWithExactly(id, hid, transaction);
+            expect(stubs.historizeOperators).to.have.been.calledOnceWithExactly(id, hid, transaction);
+            expect(stubs.historizeShantytowns).to.have.been.calledOnceWithExactly(id, hid, transaction);
+            expect(stubs.historizeTopics).to.have.been.calledOnceWithExactly(id, hid, transaction);
+        });
+    });
+
+    describe('historisation conditionnelle des finances', () => {
+        it('appelle historizeFinances quand canWriteFinances est true', async () => {
+            await historize(id, true, transaction);
+
+            expect(stubs.historizeFinances).to.have.been.calledOnceWithExactly(id, hid, transaction);
+        });
+
+        it('n\'appelle pas historizeFinances quand canWriteFinances est false', async () => {
+            await historize(id, false, transaction);
+
+            expect(stubs.historizeFinances).not.to.have.been.called;
+        });
+    });
+});

--- a/packages/api/server/models/actionModel/historize/historize.ts
+++ b/packages/api/server/models/actionModel/historize/historize.ts
@@ -9,17 +9,22 @@ import historizeOperators from './historizeOperators';
 import historizeShantytowns from './historizeShantytowns';
 import historizeTopics from './historizeTopics';
 
-export default async function historize(id: number, transaction: Transaction): Promise<void> {
+export default async function historize(id: number, canWriteFinances: boolean, transaction: Transaction): Promise<void> {
     // history
     const hid = await historizeAction(id, transaction);
 
-    await Promise.all([
+    const promises = [
         historizeAddresses(id, hid, transaction),
-        historizeFinances(id, hid, transaction),
         historizeManagers(id, hid, transaction),
         historizeMetrics(id, hid, transaction),
         historizeOperators(id, hid, transaction),
         historizeShantytowns(id, hid, transaction),
         historizeTopics(id, hid, transaction),
-    ]);
+    ];
+
+    if (canWriteFinances) {
+        promises.push(historizeFinances(id, hid, transaction));
+    }
+
+    await Promise.all(promises);
 }

--- a/packages/api/server/models/actionModel/update/resetAsideData.spec.ts
+++ b/packages/api/server/models/actionModel/update/resetAsideData.spec.ts
@@ -1,0 +1,78 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import { rewiremock } from '#test/rewiremock';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+const sandbox = sinon.createSandbox();
+const stubs = {
+    resetAddresses: sandbox.stub(),
+    resetFinances: sandbox.stub(),
+    resetManagers: sandbox.stub(),
+    resetMetrics: sandbox.stub(),
+    resetOperators: sandbox.stub(),
+    resetShantytowns: sandbox.stub(),
+    resetTopics: sandbox.stub(),
+};
+
+rewiremock('./resetAddresses').with(stubs.resetAddresses);
+rewiremock('./resetFinances').with(stubs.resetFinances);
+rewiremock('./resetManagers').with(stubs.resetManagers);
+rewiremock('./resetMetrics').with(stubs.resetMetrics);
+rewiremock('./resetOperators').with(stubs.resetOperators);
+rewiremock('./resetShantytowns').with(stubs.resetShantytowns);
+rewiremock('./resetTopics').with(stubs.resetTopics);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import resetAsideData from './resetAsideData';
+rewiremock.disable();
+
+describe('models/actionModel/update/resetAsideData()', () => {
+    const id = 7;
+    const transaction = {} as any;
+
+    beforeEach(() => {
+        stubs.resetAddresses.resolves();
+        stubs.resetFinances.resolves();
+        stubs.resetManagers.resolves();
+        stubs.resetMetrics.resolves();
+        stubs.resetOperators.resolves();
+        stubs.resetShantytowns.resolves();
+        stubs.resetTopics.resolves();
+    });
+
+    afterEach(() => {
+        sandbox.reset();
+    });
+
+    describe('appels inconditionnels', () => {
+        it('appelle resetAddresses, resetManagers, resetMetrics, resetOperators, resetShantytowns et resetTopics avec id et transaction', async () => {
+            await resetAsideData(id, false, transaction);
+
+            expect(stubs.resetAddresses).to.have.been.calledOnceWithExactly(id, transaction);
+            expect(stubs.resetManagers).to.have.been.calledOnceWithExactly(id, transaction);
+            expect(stubs.resetMetrics).to.have.been.calledOnceWithExactly(id, transaction);
+            expect(stubs.resetOperators).to.have.been.calledOnceWithExactly(id, transaction);
+            expect(stubs.resetShantytowns).to.have.been.calledOnceWithExactly(id, transaction);
+            expect(stubs.resetTopics).to.have.been.calledOnceWithExactly(id, transaction);
+        });
+    });
+
+    describe('reset conditionnel des finances', () => {
+        it('appelle resetFinances quand canWriteFinances est true', async () => {
+            await resetAsideData(id, true, transaction);
+
+            expect(stubs.resetFinances).to.have.been.calledOnceWithExactly(id, transaction);
+        });
+
+        it('n\'appelle pas resetFinances quand canWriteFinances est false', async () => {
+            await resetAsideData(id, false, transaction);
+
+            expect(stubs.resetFinances).not.to.have.been.called;
+        });
+    });
+});

--- a/packages/api/server/models/actionModel/update/resetAsideData.ts
+++ b/packages/api/server/models/actionModel/update/resetAsideData.ts
@@ -8,14 +8,19 @@ import resetOperators from './resetOperators';
 import resetShantytowns from './resetShantytowns';
 import resetTopics from './resetTopics';
 
-export default async function resetAsideData(id: number, transaction: Transaction): Promise<void> {
-    await Promise.all([
+export default async function resetAsideData(id: number, canWriteFinances: boolean, transaction: Transaction): Promise<void> {
+    const promises = [
         resetAddresses(id, transaction),
         resetManagers(id, transaction),
         resetMetrics(id, transaction),
         resetOperators(id, transaction),
         resetShantytowns(id, transaction),
         resetTopics(id, transaction),
-        resetFinances(id, transaction),
-    ]);
+    ];
+
+    if (canWriteFinances) {
+        promises.push(resetFinances(id, transaction));
+    }
+
+    await Promise.all(promises);
 }

--- a/packages/api/server/models/actionModel/update/update.ts
+++ b/packages/api/server/models/actionModel/update/update.ts
@@ -8,7 +8,7 @@ import updateAction from './updateAction';
 
 export default async function updateActionModel(id: number, data: ActionUpdateInput, canWriteFinances: boolean, transaction: Transaction): Promise<void> {
     // save current state into history tables
-    await historize(id, transaction);
+    await historize(id, canWriteFinances, transaction);
 
     // empty all "aside" tables
     await resetAsideData(id, canWriteFinances, transaction);

--- a/packages/api/server/models/actionModel/update/update.ts
+++ b/packages/api/server/models/actionModel/update/update.ts
@@ -6,12 +6,12 @@ import resetAsideData from './resetAsideData';
 import insertAsideData from '../create/insertAsideData';
 import updateAction from './updateAction';
 
-export default async function updateActionModel(id: number, data: ActionUpdateInput, transaction: Transaction): Promise<void> {
+export default async function updateActionModel(id: number, data: ActionUpdateInput, canWriteFinances: boolean, transaction: Transaction): Promise<void> {
     // save current state into history tables
     await historize(id, transaction);
 
     // empty all "aside" tables
-    await resetAsideData(id, transaction);
+    await resetAsideData(id, canWriteFinances, transaction);
 
     // update
     await updateAction(id, data, transaction);

--- a/packages/api/server/services/action/update.spec.ts
+++ b/packages/api/server/services/action/update.spec.ts
@@ -1,0 +1,256 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import { rewiremock } from '#test/rewiremock';
+import { serialized as fakeUser } from '#test/utils/user';
+import { serialized as fakeAction } from '#test/utils/action';
+import ServiceError from '#server/errors/ServiceError';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+const sandbox = sinon.createSandbox();
+const stubs = {
+    sequelize: {
+        transaction: sandbox.stub(),
+    },
+    transaction: {
+        commit: sandbox.stub(),
+        rollback: sandbox.stub(),
+    },
+    updateActionModel: sandbox.stub(),
+    fetchAction: sandbox.stub(),
+    can: sandbox.stub(),
+};
+
+class FakeUniqueConstraintError extends Error {
+    parent: { constraint: string };
+
+    constructor(constraint: string) {
+        super('Unique constraint error');
+        this.name = 'SequelizeUniqueConstraintError';
+        this.parent = { constraint };
+    }
+}
+
+rewiremock('#db/sequelize').with({ sequelize: stubs.sequelize });
+rewiremock('sequelize').with({ UniqueConstraintError: FakeUniqueConstraintError });
+rewiremock('#server/models/actionModel/update/update').with(stubs.updateActionModel);
+rewiremock('./write.fetchAction').with(stubs.fetchAction);
+rewiremock('#server/utils/permission/can').with(stubs.can);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import update from './update';
+rewiremock.disable();
+
+describe('services/action.update()', () => {
+    const action = fakeAction();
+    const user = fakeUser();
+    const actionData = {
+        name: 'Action mise à jour',
+        started_at: new Date(2023, 0, 1),
+        ended_at: null,
+        topics: ['health'],
+        goals: 'Objectifs mis à jour',
+        location: {
+            type: 'departement' as const,
+            region: { code: '11', name: 'Île-De-France' },
+            departement: { code: '78', name: 'Yvelines' },
+            epci: null,
+            city: null,
+        },
+        location_departement: '78',
+        location_type: 'logement' as const,
+        location_eti_addresses: null,
+        location_shantytowns: null,
+        location_autre: null,
+        managers: [{ id: 1, organization_id: 1 }],
+        operators: [{ id: 2, organization_id: 2 }],
+        indicateurs: {},
+    };
+
+    beforeEach(() => {
+        stubs.sequelize.transaction.resolves(stubs.transaction);
+        stubs.fetchAction.resolves(fakeAction());
+
+        // Configuration par défaut du stub can
+        const onStub = sandbox.stub().returns(true);
+        const doStub = sandbox.stub().returns({ on: onStub });
+        stubs.can.returns({ do: doStub });
+    });
+
+    afterEach(() => {
+        sandbox.reset();
+    });
+
+    describe('gestion des permissions finances', () => {
+        it('passe canWriteFinances=true au modèle si l\'utilisateur a la permission', async () => {
+            stubs.can.returns({
+                do: sandbox.stub().returns({
+                    on: sandbox.stub().returns(true),
+                }),
+            });
+
+            await update(action, user, actionData);
+
+            expect(stubs.updateActionModel).to.have.been.calledOnce;
+            const callArgs = stubs.updateActionModel.firstCall.args;
+            expect(callArgs[2]).to.equal(true);
+        });
+
+        it('passe canWriteFinances=false au modèle si l\'utilisateur n\'a pas la permission', async () => {
+            stubs.can.returns({
+                do: sandbox.stub().returns({
+                    on: sandbox.stub().returns(false),
+                }),
+            });
+
+            await update(action, user, actionData);
+
+            expect(stubs.updateActionModel).to.have.been.calledOnce;
+            const callArgs = stubs.updateActionModel.firstCall.args;
+            expect(callArgs[2]).to.equal(false);
+        });
+    });
+
+    describe('gestion de la transaction', () => {
+        it('démarre une transaction', async () => {
+            await update(action, user, actionData);
+
+            expect(stubs.sequelize.transaction).to.have.been.calledOnce;
+        });
+
+        it('commit la transaction en cas de succès', async () => {
+            await update(action, user, actionData);
+
+            expect(stubs.transaction.commit).to.have.been.calledOnce;
+            expect(stubs.transaction.rollback).not.to.have.been.called;
+        });
+
+        it('rollback la transaction en cas d\'erreur lors de l\'update', async () => {
+            stubs.updateActionModel.rejects(new Error('fake error'));
+
+            let caughtError: ServiceError | null = null;
+            try {
+                await update(action, user, actionData);
+            } catch (err) {
+                caughtError = err as ServiceError;
+            }
+
+            expect(stubs.transaction.rollback).to.have.been.calledOnce;
+            expect(stubs.transaction.commit).not.to.have.been.called;
+            expect(caughtError).to.be.instanceOf(ServiceError);
+        });
+
+        it('rollback la transaction en cas d\'erreur lors du fetch', async () => {
+            stubs.fetchAction.rejects(new Error('fake error'));
+
+            let caughtError: ServiceError | null = null;
+            try {
+                await update(action, user, actionData);
+            } catch (err) {
+                caughtError = err as ServiceError;
+            }
+
+            expect(stubs.transaction.rollback).to.have.been.calledOnce;
+            expect(stubs.transaction.commit).not.to.have.been.called;
+            expect(caughtError).to.be.instanceOf(ServiceError);
+        });
+    });
+
+    describe('mise à jour de l\'action', () => {
+        it('appelle le modèle avec les bonnes données', async () => {
+            await update(action, user, actionData);
+
+            expect(stubs.updateActionModel).to.have.been.calledOnce;
+            const callArgs = stubs.updateActionModel.firstCall.args;
+            expect(callArgs[0]).to.equal(action.id);
+            expect(callArgs[1]).to.deep.include({
+                ...actionData,
+                updated_by: user.id,
+            });
+        });
+
+        it('récupère l\'action mise à jour', async () => {
+            await update(action, user, actionData);
+
+            expect(stubs.fetchAction).to.have.been.calledOnce;
+            expect(stubs.fetchAction).to.have.been.calledWith(
+                user,
+                action.id,
+                true,
+                stubs.transaction,
+            );
+        });
+
+        it('retourne l\'action mise à jour', async () => {
+            const updatedAction = fakeAction({ name: 'Action mise à jour' });
+            stubs.fetchAction.resolves(updatedAction);
+
+            const result = await update(action, user, actionData);
+
+            expect(result).to.deep.equal(updatedAction);
+        });
+    });
+
+    describe('gestion des erreurs', () => {
+        it('traduit les erreurs de contrainte unique d\'adresse en ServiceError', async () => {
+            const uniqueError = new FakeUniqueConstraintError('uq__action_addresses__unique_address');
+            stubs.updateActionModel.rejects(uniqueError);
+
+            let caughtError: ServiceError | null = null;
+            try {
+                await update(action, user, actionData);
+            } catch (err) {
+                caughtError = err as ServiceError;
+            }
+
+            expect(caughtError).to.be.instanceOf(ServiceError);
+            expect(caughtError?.code).to.equal('duplicate_action_address');
+        });
+
+        it('traduit les autres erreurs d\'update en ServiceError action_insert_error', async () => {
+            stubs.updateActionModel.rejects(new Error('fake error'));
+
+            let caughtError: ServiceError | null = null;
+            try {
+                await update(action, user, actionData);
+            } catch (err) {
+                caughtError = err as ServiceError;
+            }
+
+            expect(caughtError).to.be.instanceOf(ServiceError);
+            expect(caughtError?.code).to.equal('action_insert_error');
+        });
+
+        it('propage les ServiceError lors du fetch', async () => {
+            const serviceError = new ServiceError('custom_error', new Error('test'));
+            stubs.fetchAction.rejects(serviceError);
+
+            let caughtError: ServiceError | null = null;
+            try {
+                await update(action, user, actionData);
+            } catch (err) {
+                caughtError = err as ServiceError;
+            }
+
+            expect(caughtError).to.equal(serviceError);
+        });
+
+        it('traduit les autres erreurs de fetch en ServiceError action_fetch_error', async () => {
+            stubs.fetchAction.rejects(new Error('fake error'));
+
+            let caughtError: ServiceError | null = null;
+            try {
+                await update(action, user, actionData);
+            } catch (err) {
+                caughtError = err as ServiceError;
+            }
+
+            expect(caughtError).to.be.instanceOf(ServiceError);
+            expect(caughtError?.code).to.equal('action_fetch_error');
+        });
+    });
+});

--- a/packages/api/server/services/action/update.ts
+++ b/packages/api/server/services/action/update.ts
@@ -17,7 +17,7 @@ export default async (action: Action, author: User, data: ActionInput): Promise<
         await update(action.id, {
             ...data,
             updated_by: author.id,
-        }, transaction);
+        }, canWriteFinances, transaction);
     } catch (error) {
         await transaction.rollback();
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/vOwc3ORw/2691

## 🛠 Description de la PR
### Résumé
- Corrige un bug critique de perte silencieuse de données : un utilisateur sans la permission `action_finances` qui éditait une action voyait tous ses financements supprimés en base, sans message d'erreur.
- Cause racine : le modèle `updateActionModel` supprimait inconditionnellement les financements via `resetAsideData`, alors que l'insertion suivante (`insertAsideData`) était conditionnée à la présence de `data.finances`.
- Solution : propager le flag `canWriteFinances` du service jusqu'au modèle, et conditionner `resetFinances` ainsi que `historizeFinances` à ce flag pour garantir une cohérence `reset/historize/insert` sur toute la cascade.

### Détails techniques
- `services/action/update.ts` calcule `canWriteFinances` via `can(author).do('access', 'action_finances').on(action)` et le propage au modèle.
- `models/actionModel/update/update.ts` transmet le flag à `historize()` et `resetAsideData()`.
- `models/actionModel/update/resetAsideData.ts` : `resetFinances` n'est plus appelé sans permission.
- `models/actionModel/historize/historize.ts` : `historizeFinances` n'est plus appelé sans permission (évite des éléments d'historique redondants dans `action_finances_history`).

### Tests ajoutés
- `services/action/update.spec.ts` : vérifie la propagation du flag du service vers le modèle.
- `models/actionModel/update/resetAsideData.spec.ts` : verrouille la condition sur `resetFinances`.
- `models/actionModel/historize/historize.spec.ts` : verrouille la condition sur `historizeFinances`.

### Tests à réaliser
- [ ] CI : tests unitaires verts sur les 3 fichiers `.spec.ts`
- [ ] Vérification manuelle : éditer une action en tant qu'opérateur (sans permission finances) → les financements existants doivent toujours être présents après l'update
- [ ] Vérification manuelle : éditer une action en tant qu'administrateur (avec permission) → les modifications de financements doivent être prises en compte normalement
- [ ] Vérification base : aucun snapshot redondant créé dans `action_finances_history` lors d'une édition par un opérateur

## 📸 Captures d'écran
Sans objet

## 🚨 Notes pour la mise en production
Rien à signaler