### PR TITLE
#minor (2686) Permettre d'indiquer que les données sont à jour pour plusieurs sites

### DIFF
--- a/packages/api/server/controllers/shantytown/_common/shantytown.id.validator.ts
+++ b/packages/api/server/controllers/shantytown/_common/shantytown.id.validator.ts
@@ -9,9 +9,7 @@ export default param('id')
 
         try {
             req.shantytown = await findOneShantytown(req.user, parseInt(value, 10));
-        } catch (error) {
-            // eslint-disable-next-line no-console
-            console.error(error);
+        } catch {
             throw new Error('Une erreur de lecture en base de données est survenue');
         }
 

--- a/packages/api/server/controllers/shantytown/forceUpdateWithoutChanges/shantytown.forceUpdateWithoutChanges.route.ts
+++ b/packages/api/server/controllers/shantytown/forceUpdateWithoutChanges/shantytown.forceUpdateWithoutChanges.route.ts
@@ -1,0 +1,10 @@
+import { type ApplicationWithCustomRoutes } from '#server/loaders/customRouteMethodsLoader';
+import validator from './shantytown.forceUpdateWithoutChanges.validator';
+import controller from './shantytown.forceUpdateWithoutChanges';
+
+export default function forceUpdate(app: ApplicationWithCustomRoutes): void {
+    app.customRoutes.patch('/towns/:id/forcedupdate', controller, validator, {
+        authenticate: true,
+        multipart: false,
+    });
+}

--- a/packages/api/server/controllers/shantytown/forceUpdateWithoutChanges/shantytown.forceUpdateWithoutChanges.ts
+++ b/packages/api/server/controllers/shantytown/forceUpdateWithoutChanges/shantytown.forceUpdateWithoutChanges.ts
@@ -1,0 +1,29 @@
+import shantytownService from '#server/services/shantytown';
+
+const ERROR_RESPONSES = {
+    not_found: { code: 404, message: 'Le site que vous essayez de mettre à jour n\'existe pas.' },
+    permission_denied: { code: 403, message: 'Vous n\'avez pas les permissions nécessaires pour mettre à jour ce site.' },
+    update_failed: { code: 500, message: 'La mise à jour de site n\'a pas pu être enregistrée.' },
+    fetch_failed: { code: 500, message: 'Votre mise à jour a bien été enregistrée mais une erreur s\'est produite. Veuillez rafraichir la page.' },
+    undefined: { code: 500, message: 'Une erreur inconnue est survenue.' },
+};
+
+export default async function forceUpdateWithoutChanges(req, res, next) {
+    let updatedTown = null;
+    try {
+        updatedTown = await shantytownService.forceUpdateWithoutChanges(
+            req.params.id,
+            req.user,
+        );
+    } catch (error) {
+        const { code, message } = ERROR_RESPONSES[error?.code] ?? ERROR_RESPONSES.undefined;
+        res.status(code).send({
+            user_message: message,
+        });
+        return next(error.nativeError ?? error);
+    }
+
+    return res.status(200).send(
+        updatedTown,
+    );
+}

--- a/packages/api/server/controllers/shantytown/forceUpdateWithoutChanges/shantytown.forceUpdateWithoutChanges.validator.ts
+++ b/packages/api/server/controllers/shantytown/forceUpdateWithoutChanges/shantytown.forceUpdateWithoutChanges.validator.ts
@@ -1,0 +1,4 @@
+import shantytownIdValidator from '#server/controllers/shantytown/_common/shantytown.id.validator';
+
+export default [
+    shantytownIdValidator];

--- a/packages/api/server/models/shantytownModel/_common/SQL.ts
+++ b/packages/api/server/models/shantytownModel/_common/SQL.ts
@@ -1,5 +1,6 @@
 import { ParcelOwners } from '#root/types/resources/ParcelOwner.d';
 import { ShantytownPreparatoryPhaseTowardResorption } from '#root/types/resources/ShantytownPreparatoryPhasesTowardResorption.d';
+import rawLocation from './rawLocation';
 
 export type ShantytownRow = {
     id: number,
@@ -278,15 +279,9 @@ export default {
         'updators_organizations.organization_id': 'updatedByOrganization',
         'updators_organizations.name': 'updatedByOrganizationName',
         'updators_organizations.abbreviation': 'updatedByOrganizationAbbreviation',
-        'cities.code': 'cityCode',
-        'cities.name': 'cityName',
-        'cities.fk_main': 'cityMain',
+        ...rawLocation.selection, // On intègre les selections de locations
         'cities.latitude': 'cityLatitude',
         'cities.longitude': 'cityLongitude',
-        'epci.code': 'epciCode',
-        'epci.name': 'epciName',
-        'departements.code': 'departementCode',
-        'departements.name': 'departementName',
         'departements.latitude': 'departementLatitude',
         'departements.longitude': 'departementLongitude',
         // Departement chieftown
@@ -294,8 +289,6 @@ export default {
         'departementChiefTown.name': 'departementChiefTownName',
         'departementChiefTown.latitude': 'departementChiefTownLatitude',
         'departementChiefTown.longitude': 'departementChiefTownLongitude',
-        'regions.code': 'regionCode',
-        'regions.name': 'regionName',
         'regions.latitude': 'regionLatitude',
         'regions.longitude': 'regionLongitude',
         'regionChiefTown.code': 'regionChiefTownCode',
@@ -338,11 +331,8 @@ export default {
     joins: [
         { table: 'field_types', on: 'shantytowns.fk_field_type = field_types.field_type_id' },
         { table: 'electricity_types', on: 'shantytowns.fk_electricity_type = electricity_types.electricity_type_id' },
-        { table: 'cities', on: 'shantytowns.fk_city = cities.code' },
-        { table: 'epci', on: 'cities.fk_epci = epci.code' },
-        { table: 'departements', on: 'cities.fk_departement = departements.code' },
+        ...rawLocation.joins, // On intègre les jointures de locations
         { table: 'cities AS departementChiefTown', on: 'departementChiefTown.code = departements.fk_city' },
-        { table: 'regions', on: 'departements.fk_region = regions.code' },
         { table: 'cities AS regionChiefTown', on: 'regionChiefTown.code = regions.fk_city' },
         { table: 'users AS creators', on: 'shantytowns.created_by = creators.user_id' },
         { table: 'organizations AS creators_organizations', on: 'creators.fk_organization = creators_organizations.organization_id' },

--- a/packages/api/server/models/shantytownModel/_common/getDiff.ts
+++ b/packages/api/server/models/shantytownModel/_common/getDiff.ts
@@ -379,9 +379,7 @@ export default function getDiff(oldVersion, newVersion): Diff[] {
                         }
                     });
                     return phasesMap;
-                } catch (error) {
-                    // eslint-disable-next-line no-console
-                    console.error('Erreur lors du traitement des phases de la résorption :', error);
+                } catch {
                     return {};
                 }
             },

--- a/packages/api/server/models/shantytownModel/_common/rawLocation.ts
+++ b/packages/api/server/models/shantytownModel/_common/rawLocation.ts
@@ -1,0 +1,19 @@
+export default {
+    selection: {
+        'cities.code': 'cityCode',
+        'cities.name': 'cityName',
+        'cities.fk_main': 'cityMain',
+        'epci.code': 'epciCode',
+        'epci.name': 'epciName',
+        'departements.code': 'departementCode',
+        'departements.name': 'departementName',
+        'regions.code': 'regionCode',
+        'regions.name': 'regionName',
+    },
+    joins: [
+        { table: 'cities', on: 'shantytowns.fk_city = cities.code' },
+        { table: 'epci', on: 'cities.fk_epci = epci.code' },
+        { table: 'departements', on: 'cities.fk_departement = departements.code' },
+        { table: 'regions', on: 'departements.fk_region = regions.code' },
+    ],
+};

--- a/packages/api/server/models/shantytownModel/findRaw.ts
+++ b/packages/api/server/models/shantytownModel/findRaw.ts
@@ -1,0 +1,70 @@
+import { sequelize } from '#db/sequelize';
+import { QueryTypes, Transaction } from 'sequelize';
+import rawLocation from './_common/rawLocation';
+
+export default async function findRaw(shantytownId: number, transaction: Transaction = undefined) {
+    const locationSelection = Object.entries(rawLocation.selection)
+        .map(([key, alias]) => `${key} AS "${alias}"`)
+        .join(', ');
+
+    const locationJoins = rawLocation.joins
+        .map(join => `LEFT JOIN ${join.table} ON ${join.on}`)
+        .join(' ');
+
+    const [town, locationRow]: any[] = await Promise.all([
+        // On récupère les données brutes du site
+        sequelize.query(
+            `SELECT shantytowns.*
+        FROM shantytowns
+        WHERE shantytowns.shantytown_id = :shantytownId`,
+            {
+                replacements: { shantytownId },
+                type: QueryTypes.SELECT,
+                transaction,
+            },
+        ),
+        // On récupère les données de localisation pour vérifier les permissions
+        sequelize.query(
+            `SELECT ${locationSelection}
+        FROM shantytowns
+        ${locationJoins}
+        WHERE shantytowns.shantytown_id = :shantytownId`,
+            {
+                replacements: { shantytownId },
+                type: QueryTypes.SELECT,
+                transaction,
+            },
+        ),
+    ]);
+
+    if (town.length !== 1) {
+        return null;
+    }
+
+    if (locationRow.length !== 1) {
+        return null;
+    }
+
+    // On construit l'objet de localisation nécessaire à la vérification des permissions
+    const location = {
+        city: {
+            code: locationRow[0].cityCode,
+            name: locationRow[0].cityName,
+            main: locationRow[0].cityMain,
+        },
+        epci: {
+            code: locationRow[0].epciCode,
+            name: locationRow[0].epciName,
+        },
+        departement: {
+            code: locationRow[0].departementCode,
+            name: locationRow[0].departementName,
+        },
+        region: {
+            code: locationRow[0].regionCode,
+            name: locationRow[0].regionName,
+        },
+    };
+
+    return { ...town[0], location };
+}

--- a/packages/api/server/models/shantytownModel/index.ts
+++ b/packages/api/server/models/shantytownModel/index.ts
@@ -3,6 +3,7 @@ import create from './create';
 import findAll from './findAll';
 import findNearby from './findNearby';
 import findOne from './findOne';
+import findRaw from './findRaw';
 import getClosureYearRange from './getClosureYearRange';
 import getHistory from './getHistory';
 import getHistoryAtGivenDate from './getHistoryAtGivenDate';
@@ -21,6 +22,7 @@ export default {
     findAll,
     findNearby,
     findOne,
+    findRaw,
     fixClosedStatus,
     getClosureYearRange,
     getHistory,

--- a/packages/api/server/services/shantytown/forceUpdateWithoutChanges.spec.ts
+++ b/packages/api/server/services/shantytown/forceUpdateWithoutChanges.spec.ts
@@ -1,0 +1,145 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiSubset from 'chai-subset';
+
+import { rewiremock } from '#test/rewiremock';
+import { serialized as fakeUser } from '#test/utils/user';
+import { updateInput as fakeTown } from '#test/utils/shantytown';
+import { AuthUser } from '#server/middlewares/authMiddleware';
+import ServiceError from '#server/errors/ServiceError';
+
+const { expect } = chai;
+chai.use(sinonChai);
+chai.use(chaiSubset);
+
+const sandbox = sinon.createSandbox();
+const stubs = {
+    sequelize: {
+        transaction: sinon.stub(),
+    },
+    shantytownModel: {
+        findRaw: sandbox.stub(),
+        update: sandbox.stub(),
+    },
+    can: sandbox.stub(),
+    do: sandbox.stub(),
+    on: sandbox.stub(),
+};
+
+rewiremock('#server/models/shantytownModel').with(stubs.shantytownModel);
+rewiremock('#server/utils/permission').with({ can: stubs.can });
+rewiremock('#db/sequelize').with({ sequelize: stubs.sequelize });
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import forceUpdateWithoutChanges from './forceUpdateWithoutChanges';
+rewiremock.disable();
+
+describe('services/shantytown', () => {
+    describe('forceUpdateWithoutChanges', () => {
+        let user: AuthUser;
+        let transaction;
+        const town = {
+            ...fakeTown(),
+            location: {
+                city: { code: '44162', name: 'Saint-Herblain', main: null },
+                epci: { code: '244400404', name: 'Nantes Métropole' },
+                departement: { code: '44', name: 'Loire-Atlantique' },
+                region: { code: '52', name: 'Pays de la Loire' },
+            },
+        };
+        beforeEach(() => {
+            transaction = {
+                commit: sinon.stub().resolves(),
+                rollback: sinon.stub().resolves(),
+            };
+            stubs.sequelize.transaction.reset();
+            stubs.sequelize.transaction.resolves(transaction);
+            stubs.can.returns({
+                do: stubs.do,
+            });
+            stubs.do.returns({
+                on: stubs.on,
+            });
+            user = fakeUser();
+            stubs.shantytownModel.findRaw.resolves(town);
+        });
+
+        afterEach(() => {
+            sandbox.reset();
+        });
+
+        it('renvoie un ServiceError si le site n\'existe pas', async () => {
+            stubs.shantytownModel.findRaw.resolves(null);
+
+            try {
+                await forceUpdateWithoutChanges(1, user);
+                throw new Error('Expected forceUpdateWithoutChanges to throw an error');
+            } catch (error) {
+                expect(error).to.be.instanceOf(ServiceError);
+                expect(error.code).to.equal('not_found');
+            }
+        });
+
+        it('renvoie un ServiceError si l\'utilisateur n\'a pas les permissions', async () => {
+            stubs.can.returns({
+                do: sinon.stub().returns({
+                    on: sinon.stub().returns(false),
+                }),
+            });
+
+            try {
+                await forceUpdateWithoutChanges(1, user);
+                throw new Error('Expected forceUpdateWithoutChanges to throw an error');
+            } catch (error) {
+                expect(error).to.be.instanceOf(ServiceError);
+                expect(error.code).to.equal('permission_denied');
+            }
+        });
+
+        it('renvoie un ServiceError si la mise à jour échoue', async () => {
+            stubs.can.returns({
+                do: sinon.stub().returns({
+                    on: sinon.stub().returns(true),
+                }),
+            });
+            stubs.shantytownModel.update.rejects(new Error('DB error'));
+
+            try {
+                await forceUpdateWithoutChanges(1, user);
+                throw new Error('Expected forceUpdateWithoutChanges to throw an error');
+            } catch (error) {
+                expect(error).to.be.instanceOf(ServiceError);
+                expect(error.code).to.equal('update_failed');
+                expect(error.nativeError).to.be.instanceOf(Error);
+                expect(error.nativeError.message).to.equal('DB error');
+            }
+        });
+
+        it('réussit la mise à jour sans modifications', async () => {
+            stubs.can.returns({
+                do: sinon.stub().returns({
+                    on: sinon.stub().returns(true),
+                }),
+            });
+            stubs.shantytownModel.update.resolves(true);
+
+            const result = await forceUpdateWithoutChanges(1, user);
+
+            expect(result).to.be.true;
+            expect(stubs.shantytownModel.findRaw).to.have.been.calledOnceWith(1, transaction);
+            expect(stubs.shantytownModel.update).to.have.been.calledOnce;
+            expect(stubs.shantytownModel.update.firstCall.args[0]).to.equal(user);
+            expect(stubs.shantytownModel.update.firstCall.args[1]).to.equal(1);
+            expect(stubs.shantytownModel.update.firstCall.args[3]).to.equal(transaction);
+            expect(stubs.shantytownModel.update.firstCall.args[2]).to.containSubset({
+                updated_without_any_change: true,
+            });
+            expect(stubs.shantytownModel.update.firstCall.args[2]).to.not.have.property('location');
+            expect(stubs.shantytownModel.update.firstCall.args[2].updated_at).to.be.instanceOf(Date);
+            expect(transaction.commit).to.have.been.calledOnce;
+            expect(transaction.rollback).not.to.have.been.called;
+        });
+    });
+});

--- a/packages/api/server/services/shantytown/forceUpdateWithoutChanges.spec.ts
+++ b/packages/api/server/services/shantytown/forceUpdateWithoutChanges.spec.ts
@@ -20,6 +20,7 @@ const stubs = {
     },
     shantytownModel: {
         findRaw: sandbox.stub(),
+        findOne: sandbox.stub(),
         update: sandbox.stub(),
     },
     can: sandbox.stub(),
@@ -123,11 +124,11 @@ describe('services/shantytown', () => {
                     on: sinon.stub().returns(true),
                 }),
             });
-            stubs.shantytownModel.update.resolves(true);
+            stubs.shantytownModel.findOne.resolves(town);
 
             const result = await forceUpdateWithoutChanges(1, user);
 
-            expect(result).to.be.true;
+            expect(result).to.be.instanceOf(Object);
             expect(stubs.shantytownModel.findRaw).to.have.been.calledOnceWith(1, transaction);
             expect(stubs.shantytownModel.update).to.have.been.calledOnce;
             expect(stubs.shantytownModel.update.firstCall.args[0]).to.equal(user);

--- a/packages/api/server/services/shantytown/forceUpdateWithoutChanges.ts
+++ b/packages/api/server/services/shantytown/forceUpdateWithoutChanges.ts
@@ -5,9 +5,10 @@ import permissionUtils from '#server/utils/permission';
 
 import { AuthUser } from '#server/middlewares/authMiddleware';
 import { Location } from '#server/models/geoModel/Location.d';
+import { Shantytown } from '#root/types/resources/Shantytown.d';
 
 
-export default async function forceUpdateWithoutChanges(townId: number, user: AuthUser): Promise<boolean> {
+export default async function forceUpdateWithoutChanges(townId: number, user: AuthUser): Promise<Shantytown> {
     const transaction = await sequelize.transaction();
 
     try {
@@ -33,13 +34,15 @@ export default async function forceUpdateWithoutChanges(townId: number, user: Au
         }
 
         // On modifie la date de MAJ et le champ updated_without_any_change
-        townData.updated_at = new Date(Date.now());
+        townData.updated_at = new Date();
         townData.updated_without_any_change = true;
 
         await shantytownModel.update(user, townId, townData, transaction);
         await transaction.commit();
 
-        return true;
+        const updatedTown = await shantytownModel.findOne(user, townId);
+
+        return updatedTown;
     } catch (error) {
         await transaction.rollback();
 

--- a/packages/api/server/services/shantytown/forceUpdateWithoutChanges.ts
+++ b/packages/api/server/services/shantytown/forceUpdateWithoutChanges.ts
@@ -1,0 +1,52 @@
+import { sequelize } from '#db/sequelize';
+import shantytownModel from '#server/models/shantytownModel';
+import ServiceError from '#server/errors/ServiceError';
+import permissionUtils from '#server/utils/permission';
+
+import { AuthUser } from '#server/middlewares/authMiddleware';
+import { Location } from '#server/models/geoModel/Location.d';
+
+
+export default async function forceUpdateWithoutChanges(townId: number, user: AuthUser): Promise<boolean> {
+    const transaction = await sequelize.transaction();
+
+    try {
+        // On récupère le site tel qu'il est actuellement en DB pour historiser la demande de MAJ sans modif
+        const town = await shantytownModel.findRaw(townId, transaction);
+        if (!town) {
+            throw new ServiceError('not_found', new Error('Le site n\'existe pas'));
+        }
+
+        const { location: rawLocation, ...townData } = town;
+
+        const location: Location = {
+            type: 'city',
+            region: rawLocation?.region,
+            departement: rawLocation?.departement,
+            epci: rawLocation?.epci,
+            city: rawLocation?.city,
+        };
+
+        // On vérifie que l'utilisateur a les droits de modification sur le site
+        if (!user || !permissionUtils.can(user).do('update', 'shantytown').on(location)) {
+            throw new ServiceError('permission_denied', new Error('Vous n\'avez pas accès à ces données'));
+        }
+
+        // On modifie la date de MAJ et le champ updated_without_any_change
+        townData.updated_at = new Date(Date.now());
+        townData.updated_without_any_change = true;
+
+        await shantytownModel.update(user, townId, townData, transaction);
+        await transaction.commit();
+
+        return true;
+    } catch (error) {
+        await transaction.rollback();
+
+        if (error instanceof ServiceError) {
+            throw error;
+        }
+
+        throw new ServiceError('update_failed', error);
+    }
+}

--- a/packages/api/server/services/shantytown/index.ts
+++ b/packages/api/server/services/shantytown/index.ts
@@ -3,6 +3,7 @@ import create from './create';
 import list from './list';
 import find from './find';
 import findJusticeReaders from './findJusticeReaders';
+import forceUpdateWithoutChanges from './forceUpdateWithoutChanges';
 import getClosureYearRange from './getClosureYearRange';
 import close from './close';
 import deleteTown from './deleteTown';
@@ -28,6 +29,7 @@ export default {
     fixClosedStatus,
     setHeatwaveStatus,
     setResorptionTarget,
+    forceUpdateWithoutChanges,
     report,
     update,
 };

--- a/packages/frontend/webapp/src/api/towns.api.js
+++ b/packages/frontend/webapp/src/api/towns.api.js
@@ -49,7 +49,7 @@ export function destroy(townId) {
 export function edit(id, data) {
     const formData = new FormData();
     let attachmentsTable = [];
-    if (data.newAttachments?.length) {
+    if (data?.newAttachments?.length) {
         for (const newAttachment of data.newAttachments) {
             formData.append("attachments", newAttachment.file);
             attachmentsTable.push({
@@ -149,6 +149,10 @@ export function findRelations(townId, query) {
     return axios.get(
         `/towns/${encodeURI(townId)}/relations?q=${encodeURIComponent(query)}`
     );
+}
+
+export function forceUpdateWithoutAnyChanges(id) {
+    return axios.patch(`/towns/${encodeURI(id)}/forcedupdate`);
 }
 
 export function getJusticeReaders(townId) {

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -8,7 +8,7 @@
             label="Considérer à jour"
             icon="fr-icon-checkbox-line"
             secondary
-            :disabled="isAllowedToReUpdate"
+            :disabled="isRecentlyUpdated"
             @click.prevent.stop="handleNoChangeModalIfNeeded"
         />
         <DsfrButton
@@ -152,7 +152,7 @@ const navigateTo = (target) => {
     }
 };
 
-const isAllowedToReUpdate = computed(() => {
+const isRecentlyUpdated = computed(() => {
     // Revoie true ou false selon si le site a été mis à jour dans les dernières 24h
     return shantytown.value?.lastUpdatedAt >= Date.now() / 1000 - 24 * 60 * 60;
 });

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -8,6 +8,7 @@
             label="Considérer à jour"
             icon="fr-icon-checkbox-line"
             secondary
+            :disabled="isAllowedToReUpdate"
             @click.prevent.stop="handleNoChangeModalIfNeeded"
         />
         <DsfrButton
@@ -151,53 +152,52 @@ const navigateTo = (target) => {
     }
 };
 
+const isAllowedToReUpdate = computed(() => {
+    // Revoie true ou false selon si le site a été mis à jour dans les dernières 24h
+    return shantytown.value?.lastUpdatedAt >= Date.now() / 1000 - 24 * 60 * 60;
+});
+
 async function handleNoChangeModalIfNeeded() {
     if (shantytownId.value) {
         const modaleStore = useModaleStore();
-        shantytown.value.updatedWithoutAnyChange = true;
         const { default: ModaleMajSiteSansModification } = await import(
             "@/components/ModaleMajSiteSansModification/ModaleMajSiteSansModification.vue"
         );
 
-        const submitWithoutChanges = async () => {
-            const submit = async (id) => {
-                try {
-                    const townUpdateResult =
-                        await townsStore.forceUpdateWithoutChanges(id);
+        const submitWithoutChanges = async (id) => {
+            try {
+                const townUpdateResult =
+                    await townsStore.forceUpdateWithoutChanges(id);
 
-                    // Certains appels renvoient directement la donnée, d'autres un objet enveloppé
-                    const responseData =
-                        townUpdateResult?.data ?? townUpdateResult;
+                notificationStore.success(
+                    "Mise à jour sans modification",
+                    "Le site a été mis à jour sans modification"
+                );
+                trackEvent(
+                    "Site",
+                    "Mise à jour site sans modification",
+                    `S${id}`
+                );
+                return townUpdateResult;
+            } catch (error) {
+                const message =
+                    error?.response?.data?.user_message ||
+                    error?.user_message ||
+                    error?.message ||
+                    "Une erreur inconnue est survenue";
 
-                    if (responseData?.error) {
-                        throw new Error(responseData.error);
-                    }
-
-                    notificationStore.success(
-                        "Mise à jour sans modification",
-                        "Le site a été mis à jour sans modification"
-                    );
-                    trackEvent("Site", "Mise à jour site", `S${id}`);
-                    return responseData;
-                } catch (error) {
-                    const message =
-                        error?.response?.data?.user_message ||
-                        error?.user_message ||
-                        error?.message ||
-                        "Une erreur inconnue est survenue";
-
-                    notificationStore.error(
-                        "Mise à jour sans modification",
-                        message
-                    );
-                    throw error;
-                }
-            };
-            await submit(shantytown.value?.id);
+                notificationStore.error(
+                    "Mise à jour sans modification",
+                    message
+                );
+                throw error;
+            }
         };
 
         modaleStore.open(markRaw(ModaleMajSiteSansModification), {
-            onConfirm: submitWithoutChanges,
+            onConfirm: async () => {
+                await submitWithoutChanges(shantytown.value?.id);
+            },
         });
         return true;
     }

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -3,6 +3,14 @@
         class="flex flex-wrap justify-end md:h-10 items-end m-4 gap-3 print:hidden sm:flex-row"
     >
         <DsfrButton
+            v-if="isOpen && hasUpdateShantytownPermission"
+            size="sm"
+            label="Considérer à jour"
+            icon="fr-icon-checkbox-line"
+            secondary
+            @click.prevent.stop="handleNoChangeModalIfNeeded"
+        />
+        <DsfrButton
             v-if="isOpen"
             size="sm"
             :label="
@@ -41,13 +49,16 @@
             @click.prevent.stop="navigateTo(null)"
         />
     </div>
+    <ModaleMajSiteSansModification ref="modaleMajSiteSansModification" />
 </template>
 
 <script setup>
-import { defineProps, toRefs, computed } from "vue";
+import { computed, markRaw, toRefs } from "vue";
 import { useUserStore } from "@/stores/user.store";
 import { useNotificationStore } from "@/stores/notification.store";
 import { useTownsStore } from "@/stores/towns.store";
+import { useModaleStore } from "@/stores/modale.store";
+import { trackEvent } from "@/helpers/matomo";
 import { useResorptionTarget } from "@/utils/useResorptionTarget";
 
 import router from "@/helpers/router";
@@ -67,6 +78,7 @@ const { resorptionTargetIsLoading, markAsResorptionTarget } =
 const hasUpdateShantytownPermission = computed(() => {
     return userStore.hasUpdateShantytownPermission(shantytown.value);
 });
+
 const heatwaveStatus = computed(() => {
     return shantytown.value.heatwaveStatus;
 });
@@ -138,6 +150,59 @@ const navigateTo = (target) => {
         router.push(path);
     }
 };
+
+async function handleNoChangeModalIfNeeded() {
+    if (shantytownId.value) {
+        const modaleStore = useModaleStore();
+        shantytown.value.updatedWithoutAnyChange = true;
+        const { default: ModaleMajSiteSansModification } = await import(
+            "@/components/ModaleMajSiteSansModification/ModaleMajSiteSansModification.vue"
+        );
+
+        const submitWithoutChanges = async () => {
+            const submit = async (id) => {
+                try {
+                    const townUpdateResult =
+                        await townsStore.forceUpdateWithoutChanges(id);
+
+                    // Certains appels renvoient directement la donnée, d'autres un objet enveloppé
+                    const responseData =
+                        townUpdateResult?.data ?? townUpdateResult;
+
+                    if (responseData?.error) {
+                        throw new Error(responseData.error);
+                    }
+
+                    notificationStore.success(
+                        "Mise à jour sans modification",
+                        "Le site a été mis à jour sans modification"
+                    );
+                    trackEvent("Site", "Mise à jour site", `S${id}`);
+                    return responseData;
+                } catch (error) {
+                    const message =
+                        error?.response?.data?.user_message ||
+                        error?.user_message ||
+                        error?.message ||
+                        "Une erreur inconnue est survenue";
+
+                    notificationStore.error(
+                        "Mise à jour sans modification",
+                        message
+                    );
+                    throw error;
+                }
+            };
+            await submit(shantytown.value?.id);
+        };
+
+        modaleStore.open(markRaw(ModaleMajSiteSansModification), {
+            onConfirm: submitWithoutChanges,
+        });
+        return true;
+    }
+    return false;
+}
 </script>
 
 <style scoped>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeHeader.vue
@@ -38,7 +38,7 @@ import { defineProps, toRefs, computed } from "vue";
 import { useUserStore } from "@/stores/user.store";
 import useLastUpdated from "@/composables/useLastUpdated";
 import BadgeSiteOjectifResorption from "@/composables/BadgeSiteOjectifResorption.vue";
-import getStatusBadgeType from "@/utils/getStatusBadgeType";
+import useStatusBadge from "@/composables/useBadgeType";
 
 const props = defineProps({
     shantytown: {
@@ -55,6 +55,7 @@ const props = defineProps({
 });
 const { shantytown, currentTab } = toRefs(props);
 const { townStatus } = useLastUpdated(shantytown);
+const { badgeType } = useStatusBadge(shantytown);
 
 const userStore = useUserStore();
 
@@ -90,23 +91,5 @@ const attachmentsLabel = computed(() => {
         : totalAttachments === 0
         ? null
         : `${totalAttachments} Document partagé`;
-});
-
-const badgeType = computed(() => {
-    if (
-        shantytown.value.closedAt &&
-        shantytown.value.closedWithSolutions !== "yes"
-    ) {
-        return "error";
-    } else if (
-        shantytown.value.closedAt &&
-        shantytown.value.closedWithSolutions === "yes"
-    ) {
-        return "success";
-    }
-    return getStatusBadgeType(
-        shantytown.value.updatedAt,
-        shantytown.value.lastUpdatedAt
-    );
 });
 </script>

--- a/packages/frontend/webapp/src/components/ModaleMajSiteSansModification/ModaleMajSiteSansModification.vue
+++ b/packages/frontend/webapp/src/components/ModaleMajSiteSansModification/ModaleMajSiteSansModification.vue
@@ -1,5 +1,5 @@
 <template>
-    <Modal closeWhenClickOutside ref="modale">
+    <Modal :closeWhenClickOutside="!working" ref="modale">
         <template v-slot:title>Mise à jour sans modification</template>
         <template v-slot:body>
             <div class="fr-text">
@@ -19,11 +19,12 @@
         </template>
         <template v-slot:footer>
             <div class="flex justify-end gap-2">
-                <DsfrButton secondary @click="() => modale.close()"
+                <DsfrButton secondary :disabled="working" @click="closeModale"
                     >Annuler</DsfrButton
                 >
-                <DsfrButton @click="confirmUpdate"
-                    >Confirmer la mise à jour</DsfrButton
+                <DsfrButton :disabled="working" @click="confirmUpdate">
+                    <Spinner v-show="working" class="loader" />
+                    Confirmer la mise à jour</DsfrButton
                 >
             </div>
         </template>
@@ -31,7 +32,7 @@
 </template>
 <script setup>
 import { toRefs, ref } from "vue";
-import { Modal } from "@resorptionbidonvilles/ui";
+import { Modal, Spinner } from "@resorptionbidonvilles/ui";
 
 const props = defineProps({
     onConfirm: {
@@ -42,13 +43,24 @@ const props = defineProps({
 
 const { onConfirm } = toRefs(props);
 const modale = ref(null);
+const working = ref(false);
 
 const confirmUpdate = async () => {
     try {
+        working.value = true;
+
+        if (typeof onConfirm.value !== "function") {
+            throw new TypeError("Action de confirmation indisponible");
+        }
+
         await onConfirm.value();
-        modale.value.close();
-    } catch (error) {
-        console.error("Erreur lors de la mise à jour:", error);
+        modale.value?.close();
+    } finally {
+        working.value = false;
     }
+};
+
+const closeModale = () => {
+    modale.value?.close();
 };
 </script>

--- a/packages/frontend/webapp/src/composables/useBadgeType.js
+++ b/packages/frontend/webapp/src/composables/useBadgeType.js
@@ -1,21 +1,15 @@
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import getSince from "@/utils/getSince";
 
 /**
  * Composable pour gérer le type de badge de manière réactive
- * @param {Ref<string> | string} updatedAt
- * @param {Ref<string> | string} lastUpdatedAt
+ * @param {Ref<object> | object} town
  */
 export default function useStatusBadge(town) {
-    const townForLastUpdate = ref({
-        createdAt: town.value.createdAt,
-        updatedAt: town.value.lastUpdatedAt,
-        lastUpdatedAt: town.value.lastUpdatedAt,
-    });
     const badgeType = computed(() => {
-        const dateCreated = townForLastUpdate.value.createdAt;
-        const dateUpdate = townForLastUpdate.value.updatedAt;
-        const dateLastUpdate = townForLastUpdate.value.lastUpdatedAt;
+        const dateCreated = town.value.createdAt;
+        const dateUpdate = town.value.lastUpdatedAt;
+        const dateLastUpdate = town.value.lastUpdatedAt;
 
         let type = "success";
 
@@ -39,7 +33,5 @@ export default function useStatusBadge(town) {
         return type;
     });
 
-    return {
-        badgeType,
-    };
+    return { badgeType };
 }

--- a/packages/frontend/webapp/src/composables/useBadgeType.js
+++ b/packages/frontend/webapp/src/composables/useBadgeType.js
@@ -1,0 +1,45 @@
+import { computed, ref } from "vue";
+import getSince from "@/utils/getSince";
+
+/**
+ * Composable pour gérer le type de badge de manière réactive
+ * @param {Ref<string> | string} updatedAt
+ * @param {Ref<string> | string} lastUpdatedAt
+ */
+export default function useStatusBadge(town) {
+    const townForLastUpdate = ref({
+        createdAt: town.value.createdAt,
+        updatedAt: town.value.lastUpdatedAt,
+        lastUpdatedAt: town.value.lastUpdatedAt,
+    });
+    const badgeType = computed(() => {
+        const dateCreated = townForLastUpdate.value.createdAt;
+        const dateUpdate = townForLastUpdate.value.updatedAt;
+        const dateLastUpdate = townForLastUpdate.value.lastUpdatedAt;
+
+        let type = "success";
+
+        const { months: monthsSinceCreation } = getSince(dateCreated);
+        const { months } = getSince(dateLastUpdate);
+        const { months: monthsSinceLastUpdate } = getSince(dateUpdate);
+
+        if (monthsSinceLastUpdate >= 6) {
+            type = "error";
+        } else if (
+            monthsSinceCreation >= 3 &&
+            monthsSinceCreation < 6 &&
+            monthsSinceLastUpdate >= 3 &&
+            monthsSinceLastUpdate < 6 &&
+            months >= 3 &&
+            months < 6
+        ) {
+            type = "warning";
+        }
+
+        return type;
+    });
+
+    return {
+        badgeType,
+    };
+}

--- a/packages/frontend/webapp/src/stores/towns.store.js
+++ b/packages/frontend/webapp/src/stores/towns.store.js
@@ -18,6 +18,7 @@ import {
     fetch,
     fetchList,
     findNearby,
+    forceUpdateWithoutAnyChanges,
     inviteNewActor,
     removeActor,
     removeActorTheme,
@@ -234,6 +235,10 @@ export const useTownsStore = defineStore("towns", () => {
         setTowns(townId);
     }
 
+    const forceUpdateWithoutChanges = async (townId) => {
+        return await forceUpdateWithoutAnyChanges(townId);
+    };
+
     const { bus } = useEventBus();
     watch(() => bus.value.get("new-user"), reset);
     reset();
@@ -293,6 +298,7 @@ export const useTownsStore = defineStore("towns", () => {
             return town;
         },
         setTown,
+        forceUpdateWithoutChanges,
         async destroy(townId) {
             await destroy(townId);
 

--- a/packages/frontend/webapp/src/stores/towns.store.js
+++ b/packages/frontend/webapp/src/stores/towns.store.js
@@ -236,7 +236,12 @@ export const useTownsStore = defineStore("towns", () => {
     }
 
     const forceUpdateWithoutChanges = async (townId) => {
-        return await forceUpdateWithoutAnyChanges(townId);
+        const updatedTown = await forceUpdateWithoutAnyChanges(townId);
+        if (updatedTown) {
+            // On force la mise à jour dans le hash
+            updateLastUpdatedAt(townId, updatedTown.updatedAt);
+        }
+        return updatedTown;
     };
 
     const { bus } = useEventBus();


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/hzhuJdo5/2686-liste-des-sites-permettre-dindiquer-que-les-donn%C3%A9es-sont-%C3%A0-jour-pour-plusieurs-sites

## 🛠 Description de la PR
Cette PR permet de considérer un site comme étant à jour en procédant à une "mise à jour sans modification", directement depuis la liste des sites.

# Workflow
## Frontend
```
[ Bouton "Considérer à jour" ] -> [ Active la modale "Mise à jour sans modification" ] -> [ Bouton "Confirmer" ] -> [ TownStore ] -> [ Town API ] -> API -> Notification Succès/Erreur
```
## Backend
```
-> [ Route/Controller `shantytown.forceUpdateWithoutChanges` ] -> [ Service `forceUpdateWithoutChanges` ] -> [ Modèle `FindRaw` + `update` ] -> Renvoi la donnée au front
```
### Fonctionnement du service `forceUpdateWithoutChanges`
Le service créé va:
- Récupérer les données brutes du site en cherchant par son ID, tel qu'il apparaît en base, grâce à `findRaw`:
  - `findRaw` récupère le site
  - puis construit l'objet brut `rawLocation` utilisé pour la validation de droit utilisateur
- Si le site n'existe pas en DB, stoppe et renvoie une erreur `not_found`
- Utilise l'objet `rawLocation` renvoyé par `findRaw` pour construire vérifier si l'utilisateur a le droit d'effectuer la modification
- Si l'utilisateur n'a pas le droit, renvoie une erreur `permission_denied`
- Force la date de mise à jour (`updated_at`) et le statut `updated_without_any_change` à `true`
- Utilise le modèle existant `shantytown.update` pour mettre à jour le site et historiser la mise à jour

## 📸 Captures d'écran
<img width="1500" height="417" alt="image" src="https://github.com/user-attachments/assets/55156b7f-9125-4ad1-8c25-064b8246a21b" />

## 🚨 Notes pour la mise en production
RàS