### PR TITLE
#patch (2995) [Barre de recherche] Proposer vider si on a conservé un filtre de recherche

### DIFF
--- a/packages/frontend/ui/src/composables/useAutocomplete.js
+++ b/packages/frontend/ui/src/composables/useAutocomplete.js
@@ -1,4 +1,4 @@
-import { ref, computed, onBeforeUnmount, watch } from "vue";
+import { ref, computed, onBeforeUnmount, onMounted, watch } from "vue";
 import debounce from "../utils/debounce";
 
 const defaultBuildResults = (rawResults) => {
@@ -112,6 +112,12 @@ export default function useAutocomplete({
         },
         { immediate: true }
     );
+
+    onMounted(() => {
+        if (modelValue.value) {
+            setInputValue(getInitialLabel(modelValue.value));
+        }
+    });
 
     if (value && value !== modelValue) {
         watch(value, (val) => {

--- a/packages/frontend/webapp/src/components/LayoutSearch/LayoutSearch.vue
+++ b/packages/frontend/webapp/src/components/LayoutSearch/LayoutSearch.vue
@@ -23,8 +23,8 @@
                             v-model="inputLocation"
                         />
                         <DsfrButton size="sm" class="-mt-1.5"
-                            >Rechercher</DsfrButton
-                        >
+                            >Rechercher
+                        </DsfrButton>
                     </div>
                     <div
                         class="flex flex-col xs:flex-row gap-1 xs:gap-2 mt-2 text-left text-sm"
@@ -60,7 +60,7 @@
 </template>
 
 <script setup>
-import { defineProps, toRefs, computed, defineEmits } from "vue";
+import { toRefs, computed } from "vue";
 import { useUserStore } from "@/stores/user.store";
 
 import Layout from "@/components/Layout/Layout.vue";


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Y6e4dM20/2695-barre-de-recherche-proposer-vider-si-on-a-conserv%C3%A9-un-filtre-de-recherche

## 🛠 Description de la PR
Lorsque l'on effectue une recherche de site ou d'action ou encore d'activités, que l'on change de page puis que l'on revient sur la recherche, la recherche elle-même est toujours active mais la barre de recherche est vide. Ainsi, le bouton "vider" n'apparaît pas.
Cette PR corrige ce mécanisme en réintégrant la recherche actuelle dans la barre.

## 📸 Captures d'écran
<img width="955" height="230" alt="image" src="https://github.com/user-attachments/assets/69b34148-8db6-46b1-852a-04042b88c8a1" />

## 🚨 Notes pour la mise en production
RàS