### PR TITLE
#patch (2697) [Liste des actions] Wording si aucune action trouvée

### DIFF
--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsStatistiques.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsStatistiques.vue
@@ -12,7 +12,7 @@
                     }}
                     <template v-if="actionsStore.filters.status === 'open'"
                         >en cours
-                        <div>
+                        <div v-if="actionsFinancedByDIHAL > 0">
                             <DsfrBadge
                                 :type="badgeDIHALVariant"
                                 :label="badgeDIHALLabel"
@@ -25,7 +25,7 @@
                             }}
                             actions sur {{ actionsFinancedByDIHAL }})
                         </div>
-                        <div>
+                        <div v-if="currentActionsCount > 0">
                             <DsfrBadge
                                 :type="badgeVariant"
                                 :label="badgeLabel"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/IG5rwlpO/2697-liste-des-actions-wording-si-aucune-action-trouv%C3%A9e

## 🛠 Description de la PR
Cette PR modifie la façon d'afficher les indicateurs de financements DIHAL et de mise à jour des indicateurs sur la liste des actions pour les cacher si le compteur n'est pas utile.

## 📸 Captures d'écran
<img width="402" height="370" alt="image" src="https://github.com/user-attachments/assets/2217b6ad-b40d-4d46-9b4e-ba30e186cb0c" />

## 🚨 Notes pour la mise en production
RàS