### PR TITLE
#patch (2709) Afficher les informations sur l'orientation des ménages dans l'export des sites fermés

### DIFF
--- a/packages/api/server/models/shantytownModel/getHistoryAtGivenDate.ts
+++ b/packages/api/server/models/shantytownModel/getHistoryAtGivenDate.ts
@@ -1,6 +1,7 @@
 import { sequelize } from '#db/sequelize';
 import { QueryTypes } from 'sequelize';
 import shantytownActorModel from '#server/models/shantytownActorModel';
+import closingSolutionModel from '#server/models/closingSolutionModel';
 import geoUtils from '#server/utils/geo';
 import permissionUtils from '#server/utils/permission';
 import serializeShantytown from '#server/models/shantytownModel/_common/serializeShantytown';
@@ -491,17 +492,59 @@ function getShantytownHistoryArray(rows: ShantytownRow[]): ShantytownRow[] {
     return Object.values(acc);
 }
 
+async function loadClosingSolutionsIntoShantytowns(shantytownHistory: ShantytownRow[], user: AuthUser): Promise<Shantytown[]> {
+    const shantytownIds = shantytownHistory.map(town => String(town.id));
+    const closingSolutions = await closingSolutionModel.findByShantytown(shantytownIds);
+
+    const serializedTowns = shantytownHistory.map(town => serializeTownWithPhases(town, user));
+
+    closingSolutions.forEach((closingSolution) => {
+        const town = serializedTowns.find(t => t.id === closingSolution.shantytownId);
+        if (town) {
+            town.closingSolutions.push({
+                id: closingSolution.id,
+                peopleAffected: closingSolution.peopleAffected,
+                householdsAffected: closingSolution.householdsAffected,
+                message: closingSolution.message,
+            });
+        }
+    });
+
+    return serializedTowns;
+}
+
 async function serializeTowns(shantytownHistory: ShantytownRow[], filters: ShantytownFilters, options: ShantytownExportListOption[], user: AuthUser, exportDate: string): Promise<Shantytown[]> {
     let serializedTowns: Shantytown[];
-    if (filters.actors || options.includes('actors')) {
-        serializedTowns = await loadActorsIntoShantytowns(shantytownHistory, user, exportDate);
+    const needsActors = filters.actors || options.includes('actors');
+    const needsClosingSolutions = shantytownHistory.some(town => town.closedAt !== null);
 
-        // Filtrer sur les intervenants
-        if (filters.actors) {
-            serializedTowns = applyActorsFilters(serializedTowns, filters);
-        }
+    if (needsActors && needsClosingSolutions) {
+        serializedTowns = await loadActorsIntoShantytowns(shantytownHistory, user, exportDate);
+        const shantytownIds = shantytownHistory.map(town => String(town.id));
+        const closingSolutions = await closingSolutionModel.findByShantytown(shantytownIds);
+
+        closingSolutions.forEach((closingSolution) => {
+            const town = serializedTowns.find(t => t.id === closingSolution.shantytownId);
+            if (town) {
+                town.closingSolutions.push({
+                    id: closingSolution.id,
+                    peopleAffected: closingSolution.peopleAffected,
+                    householdsAffected: closingSolution.householdsAffected,
+                    message: closingSolution.message,
+                });
+            }
+        });
+    } else if (needsActors) {
+        serializedTowns = await loadActorsIntoShantytowns(shantytownHistory, user, exportDate);
+    } else if (needsClosingSolutions) {
+        serializedTowns = await loadClosingSolutionsIntoShantytowns(shantytownHistory, user);
     } else {
         serializedTowns = shantytownHistory.map(town => serializeTownWithPhases(town, user));
+    }
+
+    // Filtrer sur les intervenants
+    if (filters.actors) {
+        serializedTowns = applyActorsFilters(serializedTowns, filters);
     }
 
     return serializedTowns;

--- a/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
+++ b/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
@@ -1357,6 +1357,7 @@ export default (closingSolutions: ClosingSolution[]) => {
             },
             width: COLUMN_WIDTHS.SMALL,
             sum: true,
+            wrapText: true,
         };
     });
     return properties;


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/poV8iN0H/2709

## 🛠 Description de la PR
- Ajoute la récupération des closingSolutions dans `getHistoryAtGivenDate.ts`
- Active la mise à la ligne automatique (wrapText) pour les colonnes Message de la section "Orientation"
- Optimisation : récupération conditionnelle uniquement si sites fermés présents

## 📸 Captures d'écran
- sans objet

## 🚨 Notes pour la mise en production
- Rien à signaler