### PR TITLE
#patch (2707) [Onglet sites, actions, entraide] L'item du menu n'est plus affiché comme actif quand on entre dans un sous-item

### DIFF
--- a/packages/frontend/webapp/src/stores/navigation.store.js
+++ b/packages/frontend/webapp/src/stores/navigation.store.js
@@ -172,10 +172,10 @@ export const useNavigationStore = defineStore("navigation", {
             }
 
             const items = [
-                { text: "Accueil", to: "/" },
+                { text: "Accueil", to: "/tableau-de-bord" },
                 { text: "Sites", to: "/liste-des-sites" },
                 { text: "Actions", to: "/liste-des-actions" },
-                { ...this.metricsItem, active: false },
+                { ...this.metricsItem },
                 { text: "Entraide", to: "/communaute" },
                 { text: "Carte", to: "/cartographie" },
                 { text: "Dernières activités", to: "/activites" },
@@ -200,7 +200,7 @@ export const useNavigationStore = defineStore("navigation", {
             }
 
             return itemsFilteredByPermission.map((item) => {
-                item.active =
+                item.ariaCurrent =
                     router.resolve(item.to).meta.navTab === currentNavTab;
                 return item;
             });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/uY51YlZa/2707-onglet-sites-actions-le-passage-%C3%A0-la-liste-retire-la-mise-en-valeur

## 🛠 Description de la PR
Cette PPR corrige l'affichage du trait bleu indiquant quel item du menu est actif lorsque l'on va sur une fiche site ou fiche action, ou bien quand on va dans la partie entraide/annuaire.

## 📸 Captures d'écran
<img width="1205" height="235" alt="image" src="https://github.com/user-attachments/assets/e9c20988-9793-432c-b5fc-01156f7aefcd" />

RàS