### PR TITLE
#patch (2708) [Expé 44] régression sur la mise en surbrillance de la colonne de population une fois la résorption lancée

### DIFF
--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteHabitants/FicheSiteHabitantsTableau.vue
@@ -1,7 +1,9 @@
 <template>
     <table class="table-fixed text-center">
         <caption class="mb-4">
-            Récapitulatif des habitants et des habitats sur le site
+            <p class="font-bold">
+                Récapitulatif des habitants et des habitats sur le site
+            </p>
             <span class="sr-only">
                 Les caractéristiques des habitants et des habitats sont
                 présentées par ligne. Chaque colonne correspond à une date de
@@ -207,34 +209,6 @@ const sections = [
 ];
 const closestEntryDate = ref(null);
 
-watch(
-    () => town.value?.preparatoryPhasesTowardResorption,
-    (phases) => {
-        if (!phases?.length) {
-            return;
-        }
-
-        const officialOpeningDate = phases.find(
-            (phase) => phase.preparatoryPhaseId === "official_opening"
-        )?.completedAt;
-
-        if (officialOpeningDate) {
-            const entriesAfterOpening = town.value.changelog.filter(
-                (entry) =>
-                    new Date(entry.date * 1000).setHours(0, 0, 0, 0) >=
-                    new Date(officialOpeningDate * 1000).setHours(0, 0, 0, 0)
-            );
-
-            if (entriesAfterOpening.length > 0) {
-                closestEntryDate.value =
-                    entriesAfterOpening[entriesAfterOpening.length - 1].date *
-                    1000;
-            }
-        }
-    },
-    { immediate: true }
-);
-
 const populationHistory = computed(() => {
     let ref = {
         populationTotal: formatInt(town.value.populationTotal, "-"),
@@ -334,4 +308,34 @@ const populationHistory = computed(() => {
         }),
     ];
 });
+
+watch(
+    () => town.value?.preparatoryPhasesTowardResorption,
+    (phases) => {
+        const officialOpeningDate = phases?.find(
+            (phase) => phase.preparatoryPhaseId === "official_opening"
+        )?.completedAt;
+
+        if (!officialOpeningDate) {
+            return;
+        }
+
+        const openingMidnight = new Date(officialOpeningDate).setHours(
+            0,
+            0,
+            0,
+            0
+        );
+
+        const lastValidEntry = populationHistory.value.findLast(
+            (entry) =>
+                new Date(entry.fullDate).setHours(0, 0, 0, 0) >= openingMidnight
+        );
+
+        if (lastValidEntry) {
+            closestEntryDate.value = lastValidEntry.fullDate;
+        }
+    },
+    { immediate: true }
+);
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/rVZLpQRB/2708-exp%C3%A9-44-r%C3%A9gression-sur-la-mise-en-surbrillance-de-la-colonne-de-population-une-fois-la-r%C3%A9sorption-lanc%C3%A9e

## 🛠 Description de la PR
Cette PR corrige la détection de la première date de mise à jour des indicateurs de population d'un site une fois la résorption officielle lancée. La colonne devait apparaître avec un fond bleu clair mais, suite à une modification de l'enregistrement et du traitement de dates, le système n'a pas été mis à jour en conséquence.

## 📸 Captures d'écran
<img width="805" height="477" alt="image" src="https://github.com/user-attachments/assets/f186e7ab-df40-486d-bf8f-ae9b29bb6256" />
<img width="805" height="835" alt="image" src="https://github.com/user-attachments/assets/f6b99a12-cb4d-48d4-b7b6-ebf31c4465c0" />

## 🚨 Notes pour la mise en production
RàS