### PR TITLE
#patch (2703) Corriger le nombre de sites affiché sur la carte de France

### DIFF
--- a/packages/frontend/webapp/src/assets/main.css
+++ b/packages/frontend/webapp/src/assets/main.css
@@ -21,6 +21,7 @@ body {
 .leaflet-control-zoom a:hover {
     background-color: rgb(0 0 145) !important;
     color: white !important;
+    border-radius: 0 !important;
 }
 
 /* CSS spécifique pour écraser le DSFR */

--- a/packages/frontend/webapp/src/assets/main.css
+++ b/packages/frontend/webapp/src/assets/main.css
@@ -18,6 +18,11 @@ body {
     border-radius: 0 !important;
 }
 
+.leaflet-control-zoom a:hover {
+    background-color: rgb(0 0 145) !important;
+    color: white !important;
+}
+
 /* CSS spécifique pour écraser le DSFR */
 :root {
     --underline-img: none; 
@@ -49,7 +54,7 @@ p {
 }
 
 @media (hover:hover) {
-     a[href]:not(.fr-nav__link, .fr-btn):hover, button:not(:disabled):not(.fr-tag):hover:not(.fr-btn), input[type=button]:not(:disabled):hover, input[type=image]:not(:disabled):hover, input[type=reset]:not(:disabled):hover, input[type=submit]:not(:disabled):hover {
+     a[href]:not(.fr-nav__link, .fr-btn):not(.leaflet-control-zoom a):hover, button:not(:disabled):not(.fr-tag):hover:not(.fr-btn), input[type=button]:not(:disabled):hover, input[type=image]:not(:disabled):hover, input[type=reset]:not(:disabled):hover, input[type=submit]:not(:disabled):hover {
         background: none;
     }
 }

--- a/packages/frontend/webapp/src/components/Carto/Carto.vue
+++ b/packages/frontend/webapp/src/components/Carto/Carto.vue
@@ -395,6 +395,12 @@ function syncTownMarkers() {
         towns.value.map((town) => {
             Object.keys(territoryData).forEach((key) => {
                 const location = town[keyMap[key]];
+
+                // Vérifier que la location existe et a un code valide
+                if (!location || !location.code) {
+                    return;
+                }
+
                 if (!territoryData[key][location.code]) {
                     territoryData[key][location.code] = {
                         total: 0,

--- a/packages/frontend/webapp/src/components/CartoNationale/CartoNationale.vue
+++ b/packages/frontend/webapp/src/components/CartoNationale/CartoNationale.vue
@@ -253,10 +253,14 @@ const createAddressTogglerControl = () => {
 };
 
 const onZoomEnd = () => {
+    if (!carto.value?.map) {
+        return;
+    }
+
     const { map } = carto.value;
     const zoomLevel = map.getZoom();
 
-    if (!map || map._animatingZoom) {
+    if (map._animatingZoom) {
         return;
     }
 
@@ -277,6 +281,10 @@ const onZoomEnd = () => {
 };
 
 const onMove = () => {
+    if (!carto.value?.map) {
+        return;
+    }
+
     const { map } = carto.value;
     const { lat, lng } = map.getCenter();
     const currentZoom = map.getZoom();
@@ -288,6 +296,10 @@ const onMove = () => {
 };
 
 const updateAddress = () => {
+    if (!carto.value?.map) {
+        return;
+    }
+
     markersGroup.search.clearLayers();
 
     if (searchAddress.value?.data?.coordinates) {
@@ -305,15 +317,15 @@ const updateAddress = () => {
 };
 
 watch(
-    () => carto.value,
-    (newCarto) => {
-        if (newCarto) {
-            newCarto.map.options.zoomAnimation = false;
-            newCarto.map.options.markerZoomAnimation = false;
+    () => carto.value?.map,
+    (newMap) => {
+        if (newMap) {
+            newMap.options.zoomAnimation = false;
+            newMap.options.markerZoomAnimation = false;
 
-            newCarto.map.on("move", onMove);
-            newCarto.map.addLayer(markersGroup.search);
-            newCarto.addControl(
+            newMap.on("move", onMove);
+            newMap.addLayer(markersGroup.search);
+            carto.value.addControl(
                 "addressToggler",
                 createAddressTogglerControl()
             );
@@ -322,7 +334,7 @@ watch(
 );
 
 watch(pois, (newPois, oldPois) => {
-    if (!carto.value) {
+    if (!carto.value?.map) {
         return;
     }
 

--- a/packages/frontend/webapp/src/components/CartoNationale/CartoNationale.vue
+++ b/packages/frontend/webapp/src/components/CartoNationale/CartoNationale.vue
@@ -1,6 +1,7 @@
 <template>
     <Carto
         ref="carto"
+        :mapId="mapId"
         :layers="['Dessin', 'Satellite']"
         defaultLayer="Dessin"
         :townMarkerFn="marqueurSiteEau"
@@ -79,6 +80,11 @@ const searchAddress = computed({
 });
 
 const props = defineProps({
+    mapId: {
+        type: String,
+        required: false,
+        default: "map",
+    },
     pois: {
         type: Array,
         required: false,
@@ -102,7 +108,7 @@ const props = defineProps({
         },
     },
 });
-const { pois, showAddresses, defaultView } = toRefs(props);
+const { mapId, pois, showAddresses, defaultView } = toRefs(props);
 const emit = defineEmits([
     "poiclick",
     "viewchange",

--- a/packages/frontend/webapp/src/components/Cartographie/Cartographie.vue
+++ b/packages/frontend/webapp/src/components/Cartographie/Cartographie.vue
@@ -13,7 +13,7 @@
         </div>
         <div class="flex-1" style="height: 100vh">
             <CartoNationale
-                id="carte"
+                mapId="carte"
                 ref="carte"
                 :isLoading="!timedOut"
                 :defaultView="defaultView"

--- a/packages/frontend/webapp/src/utils/filterShantytownsForMap.js
+++ b/packages/frontend/webapp/src/utils/filterShantytownsForMap.js
@@ -4,10 +4,10 @@ const filterBy = {
 
         // Si les données n'existent pas, traiter comme 'unknown'
         if (!waterStatus) {
-            return checked.indexOf("unknown") !== -1;
+            return checked.includes("unknown");
         }
 
-        return checked.indexOf(waterStatus) !== -1;
+        return checked.includes(waterStatus);
     },
 
     fieldType(shantytown, checked) {
@@ -15,12 +15,12 @@ const filterBy = {
             return false;
         }
 
-        return checked.indexOf(shantytown.fieldType.id) !== -1;
+        return checked.includes(shantytown.fieldType.id);
     },
 
     population(shantytown, checked) {
         if (shantytown.populationTotal === null) {
-            return checked.indexOf(null) !== -1;
+            return checked.includes(null);
         }
 
         return checked.some((value) => {
@@ -60,11 +60,11 @@ const filterBy = {
 
         // Les sites "Existants" incluent les sites ouverts ET en cours de résorption
         if (isOpen || isInProgress) {
-            return checked.indexOf("open") !== -1;
+            return checked.includes("open");
         }
 
         // Les sites "Fermés" sont tous les autres
-        return checked.indexOf("closed") !== -1;
+        return checked.includes("closed");
     },
 
     ownerType(shantytown, checked) {

--- a/packages/frontend/webapp/src/utils/filterShantytownsForMap.js
+++ b/packages/frontend/webapp/src/utils/filterShantytownsForMap.js
@@ -1,16 +1,21 @@
 const filterBy = {
     waterAccessConditions(shantytown, checked) {
-        return (
-            checked.indexOf(shantytown.livingConditions.water.status.status) !==
-            -1
-        );
+        const waterStatus = shantytown.livingConditions?.water?.status?.status;
+
+        // Si les données n'existent pas, traiter comme 'unknown'
+        if (!waterStatus) {
+            return checked.indexOf("unknown") !== -1;
+        }
+
+        return checked.indexOf(waterStatus) !== -1;
     },
 
     fieldType(shantytown, checked) {
-        return (
-            shantytown.fieldType &&
-            checked.indexOf(shantytown.fieldType.id) !== -1
-        );
+        if (!shantytown.fieldType) {
+            return false;
+        }
+
+        return checked.indexOf(shantytown.fieldType.id) !== -1;
     },
 
     population(shantytown, checked) {
@@ -47,17 +52,30 @@ const filterBy = {
     },
 
     status(shantytown, checked) {
-        if (shantytown.status === "open") {
+        const isOpen = shantytown.status === "open";
+        const isInProgress = 
+            shantytown.preparatoryPhasesTowardResorption &&
+            shantytown.preparatoryPhasesTowardResorption.length > 0 &&
+            shantytown.status === "open";
+
+        // Les sites "Existants" incluent les sites ouverts ET en cours de résorption
+        if (isOpen || isInProgress) {
             return checked.indexOf("open") !== -1;
         }
 
+        // Les sites "Fermés" sont tous les autres
         return checked.indexOf("closed") !== -1;
     },
 
     ownerType(shantytown, checked) {
         const owners = shantytown.owners;
-        if (!Array.isArray(owners) || checked.length === 0) {
+        
+        if (checked.length === 0) {
             return false;
+        }
+
+        if (!Array.isArray(owners) || owners.length === 0) {
+            return checked.includes(null);
         }
 
         return owners.some((owner) => checked.includes(owner?.type ?? null));
@@ -70,9 +88,8 @@ export default function (shantytowns, filters) {
     );
 
     return shantytowns.filter((shantytown) => {
-        const toReturn = filterIds.every((filterId) => {
+        return filterIds.every((filterId) => {
             return filterBy[filterId](shantytown, filters[filterId]);
         });
-        return toReturn;
     });
 }

--- a/packages/frontend/webapp/src/utils/filterShantytownsForMap.js
+++ b/packages/frontend/webapp/src/utils/filterShantytownsForMap.js
@@ -53,7 +53,7 @@ const filterBy = {
 
     status(shantytown, checked) {
         const isOpen = shantytown.status === "open";
-        const isInProgress = 
+        const isInProgress =
             shantytown.preparatoryPhasesTowardResorption &&
             shantytown.preparatoryPhasesTowardResorption.length > 0 &&
             shantytown.status === "open";
@@ -69,7 +69,7 @@ const filterBy = {
 
     ownerType(shantytown, checked) {
         const owners = shantytown.owners;
-        
+
         if (checked.length === 0) {
             return false;
         }

--- a/packages/frontend/webapp/src/utils/map_filters.js
+++ b/packages/frontend/webapp/src/utils/map_filters.js
@@ -116,11 +116,18 @@ export default computed(() => {
         filters.definition.ownerType = {
             icon: "users",
             label: "Type de propriétaire",
-            options: (configStore.config?.owner_types || []).map((type) => ({
-                value: type.id,
-                label: type.label,
-                checked: true,
-            })),
+            options: [
+                ...(configStore.config?.owner_types || []).map((type) => ({
+                    value: type.id,
+                    label: type.label,
+                    checked: true,
+                })),
+                {
+                    value: null,
+                    label: "Inconnu",
+                    checked: true,
+                },
+            ],
         };
         filters.order.splice(-1, 0, "ownerType");
     }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/9JS8SJF6/2703

## 🛠 Description de la PR

### Problème à régler
- Les sites pour lesquels `owner IS NULL` étaient exclus du nombre de sites affichés sur les groupes de marqueurs de la carte de France, causant une différence entre le nombre de sites affichés sur la carte et la valeur affichée sur la liste des sites.

### Solution :

- Ajout d'une option "Inconnu" (value: `null`) dans le filtre "Type de propriétaire"
- Correction de la logique du filtre `ownerType` pour traiter les sites sans propriétaire comme ayant un type `null`

## 🚨 Notes pour la mise en production
- Rien à signaler