### PR TITLE
#patch (2706) Propager le nom complet d'action (<structure> - <projet>) dans tous les modules de lecture

### DIFF
--- a/packages/api/server/models/actionActorModel/findAll.ts
+++ b/packages/api/server/models/actionActorModel/findAll.ts
@@ -1,5 +1,6 @@
 import { sequelize } from '#db/sequelize';
 import { QueryTypes } from 'sequelize';
+import { getActionFullNames } from '#server/utils/formatActionFullName';
 
 type ActionActorRow = {
     user_id: number,
@@ -58,6 +59,9 @@ export default async (year: number, activeOnly: boolean = false): Promise<Action
         },
     );
 
+    const actionIds = [...new Set(rows.map(row => row.action_id))];
+    const actionFullNames = await getActionFullNames(actionIds);
+
     const hash: { [key: number]: ActionActor } = {};
     rows.forEach((row) => {
         hash[row.user_id] ??= {
@@ -70,7 +74,7 @@ export default async (year: number, activeOnly: boolean = false): Promise<Action
 
         hash[row.user_id].actions.push({
             id: row.action_id,
-            name: row.action_name,
+            name: actionFullNames.get(row.action_id) ?? row.action_name,
         });
     });
 

--- a/packages/api/server/models/actionModel/getCommentHistory/getCommentHistory.ts
+++ b/packages/api/server/models/actionModel/getCommentHistory/getCommentHistory.ts
@@ -4,6 +4,7 @@ import { QueryTypes } from 'sequelize';
 import userModel from '#server/models/userModel';
 import permissionUtils from '#server/utils/permission';
 import outremer from '#server/utils/permission/outremer';
+import { getActionFullNames } from '#server/utils/formatActionFullName';
 
 import { Location } from '#server/models/geoModel/Location.d';
 import { ActionCommentActivity } from '#root/types/resources/Activity.d';
@@ -95,6 +96,9 @@ export default async (user: User, location: Location, numberOfActivities: number
 
     const actionComments = {};
 
+    const actionIds = [...new Set(activities.map((a: ActionCommentHistoryRow) => a.action_id))];
+    const actionFullNames = await getActionFullNames(actionIds);
+
     return activities
         .map((activity: ActionCommentHistoryRow) => {
             const o: ActionCommentActivity = {
@@ -103,7 +107,7 @@ export default async (user: User, location: Location, numberOfActivities: number
                 date: activity.date.getTime() / 1000,
                 actionEntity: {
                     id: activity.action_id,
-                    name: activity.action_name,
+                    name: actionFullNames.get(activity.action_id) ?? activity.action_name,
                 },
                 author: {
                     name: userModel.formatName({

--- a/packages/api/server/utils/formatActionFullName.spec.ts
+++ b/packages/api/server/utils/formatActionFullName.spec.ts
@@ -1,0 +1,136 @@
+import { expect } from 'chai';
+import { sequelize } from '#db/sequelize';
+import { QueryTypes } from 'sequelize';
+import { getActionFullNames, getActionFullName } from './formatActionFullName';
+
+describe('formatActionFullName', () => {
+    describe('getActionFullNames', () => {
+        it(' retourne une Map vide si aucun ID n\'est fourni', async () => {
+            const result = await getActionFullNames([]);
+            expect(result).to.be.instanceOf(Map);
+            expect(result.size).to.equal(0);
+        });
+
+        it(' retourne le nom complet au format "structure - projet" pour une action avec opérateur principal', async () => {
+            const rows = await sequelize.query(
+                `SELECT ao.fk_action as action_id
+                 FROM action_operators ao
+                 WHERE ao.is_principal = true
+                 LIMIT 1`,
+                { type: QueryTypes.SELECT },
+            );
+
+            if (rows.length > 0) {
+                const actionId = (rows[0] as { action_id: number }).action_id;
+                const result = await getActionFullNames([actionId]);
+
+                expect(result).to.be.instanceOf(Map);
+                expect(result.size).to.equal(1);
+
+                const fullName = result.get(actionId);
+                expect(fullName).to.exist;
+                expect(fullName).to.include(' - ');
+            }
+        });
+
+        it(' retourne uniquement le nom du projet si aucun opérateur principal n\'existe', async () => {
+            const rows = await sequelize.query(
+                `SELECT action_id FROM actions 
+                 WHERE action_id NOT IN (
+                     SELECT fk_action FROM action_operators WHERE is_principal = true
+                 ) LIMIT 1`,
+                { type: QueryTypes.SELECT },
+            );
+
+            if (rows.length > 0) {
+                const actionId = (rows[0] as { action_id: number }).action_id;
+                const result = await getActionFullNames([actionId]);
+                const fullName = result.get(actionId);
+
+                expect(fullName).to.exist;
+                expect(fullName).to.not.include(' - ');
+            }
+        });
+
+        it(' gère correctement plusieurs actions', async () => {
+            const rows = await sequelize.query(
+                'SELECT action_id FROM actions LIMIT 3',
+                { type: QueryTypes.SELECT },
+            );
+
+            if (rows.length > 0) {
+                const actionIds = rows.map(row => (row as { action_id: number }).action_id);
+                const result = await getActionFullNames(actionIds);
+
+                expect(result).to.be.instanceOf(Map);
+                expect(result.size).to.equal(actionIds.length);
+
+                actionIds.forEach((id) => {
+                    expect(result.has(id)).to.be.true;
+                    expect(result.get(id)).to.be.a('string');
+                });
+            }
+        });
+
+        it(' utilise l\'abréviation de l\'organisation si disponible', async () => {
+            const rows = await sequelize.query(
+                `SELECT ao.fk_action as action_id
+                 FROM action_operators ao
+                 INNER JOIN users u ON u.user_id = ao.fk_user
+                 INNER JOIN organizations org ON org.organization_id = u.fk_organization
+                 WHERE ao.is_principal = true 
+                 AND org.abbreviation IS NOT NULL 
+                 AND org.abbreviation != ''
+                 LIMIT 1`,
+                { type: QueryTypes.SELECT },
+            );
+
+            if (rows.length > 0) {
+                const actionId = (rows[0] as { action_id: number }).action_id;
+                const result = await getActionFullNames([actionId]);
+                const fullName = result.get(actionId);
+
+                expect(fullName).to.exist;
+                expect(fullName).to.include(' - ');
+            }
+        });
+    });
+
+    describe('getActionFullName', () => {
+        it(' retourne le nom complet pour une action existante', async () => {
+            const rows = await sequelize.query(
+                'SELECT action_id FROM actions LIMIT 1',
+                { type: QueryTypes.SELECT },
+            );
+
+            if (rows.length > 0) {
+                const actionId = (rows[0] as { action_id: number }).action_id;
+                const result = await getActionFullName(actionId);
+
+                expect(result).to.exist;
+                expect(result).to.be.a('string');
+                expect(result!.length).to.be.greaterThan(0);
+            }
+        });
+
+        it(' retourne null pour une action inexistante', async () => {
+            const result = await getActionFullName(999999);
+            expect(result).to.be.null;
+        });
+
+        it(' retourne le même résultat que getActionFullNames pour un seul ID', async () => {
+            const rows = await sequelize.query(
+                'SELECT action_id FROM actions LIMIT 1',
+                { type: QueryTypes.SELECT },
+            );
+
+            if (rows.length > 0) {
+                const actionId = (rows[0] as { action_id: number }).action_id;
+                const singleResult = await getActionFullName(actionId);
+                const multiResult = await getActionFullNames([actionId]);
+
+                expect(singleResult).to.equal(multiResult.get(actionId) ?? null);
+            }
+        });
+    });
+});

--- a/packages/api/server/utils/formatActionFullName.ts
+++ b/packages/api/server/utils/formatActionFullName.ts
@@ -1,0 +1,73 @@
+import { sequelize } from '#db/sequelize';
+import { QueryTypes } from 'sequelize';
+
+type ActionFullName = {
+    action_id: number;
+    full_name: string;
+};
+
+/**
+ * Récupère le nom complet des actions au format "structure - projet"
+ * en utilisant l'opérateur principal (is_principal = true)
+ *
+ * @param actionIds - Liste des IDs d'actions pour lesquelles récupérer le nom complet
+ * @returns Map avec action_id comme clé et nom complet comme valeur
+ */
+export const getActionFullNames = async (actionIds: number[]): Promise<Map<number, string>> => {
+    if (actionIds.length === 0) {
+        return new Map();
+    }
+
+    const rows: ActionFullName[] = await sequelize.query(
+        `
+        WITH principal_operator AS (
+            SELECT
+                ao.fk_action,
+                COALESCE(NULLIF(org.abbreviation, ''), org."name") AS operator_name
+            FROM
+                action_operators ao
+            INNER JOIN
+                users u ON u.user_id = ao.fk_user
+            INNER JOIN
+                organizations org ON org.organization_id = u.fk_organization
+            WHERE
+                ao.is_principal = true
+        )
+        SELECT
+            actions.action_id,
+            CASE
+                WHEN po.operator_name IS NOT NULL THEN 
+                    UPPER(SUBSTRING(po.operator_name, 1, 1)) || SUBSTRING(po.operator_name, 2) || ' - ' || actions.name
+                ELSE actions.name
+            END AS full_name
+        FROM
+            actions
+        LEFT JOIN
+            principal_operator po ON po.fk_action = actions.action_id
+        WHERE
+            actions.action_id IN (:actionIds)
+        `,
+        {
+            type: QueryTypes.SELECT,
+            replacements: { actionIds },
+        },
+    );
+
+    const result = new Map<number, string>();
+    rows.forEach((row) => {
+        result.set(row.action_id, row.full_name);
+    });
+
+    return result;
+};
+
+/**
+ * Récupère le nom complet d'une seule action au format "structure - projet"
+ *
+ * @param actionId - ID de l'action
+ * @returns Nom complet de l'action ou null si non trouvée
+ */
+export const getActionFullName = async (actionId: number): Promise<string | null> => {
+    const names = await getActionFullNames([actionId]);
+    return names.get(actionId) ?? null;
+};

--- a/packages/api/server/utils/mattermost.ts
+++ b/packages/api/server/utils/mattermost.ts
@@ -1,6 +1,7 @@
 import IncomingWebhook from 'node-mattermost';
 import config from '#server/config';
 import statusDetails from '#server/utils/statusDetails';
+import { getActionFullName } from '#server/utils/formatActionFullName';
 import Action from '#root/types/resources/Action.d';
 import { EnrichedAction } from '#root/types/resources/ActionEnriched.d';
 import { CommentAuthor } from '#root/types/resources/CommentAuthor.d';
@@ -262,7 +263,8 @@ async function triggerNewActionComment(comment: string, action: Action, author: 
     const newCommentAlert = new IncomingWebhook(mattermost);
 
     const username = formatUsername(author);
-    const actionLink = formatActionLink(action.id, action.name);
+    const actionFullName = await getActionFullName(action.id) ?? action.name;
+    const actionLink = formatActionLink(action.id, actionFullName);
 
     const mattermostMessage: MattermostMsg = buildMattermostMessage(
         '#notif-action-nouveau-commentaire',


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/17BTTncn/2706

## 🛠 Description de la PR

### Objectifs
Centraliser l'affichage du nom complet des actions au format "structure - projet" dans tous les modules consommateurs.

### Fichier créé: `formatActionFullName.ts`
- Service centralisé utilisant une CTE principal_operator (inspirée de fetchReport.ts)
- Jointure sur action_operators avec is_principal = true
- Deux fonctions exportées :
    - `getActionFullNames(actionIds[])` : retourne une `Map<number, string>`
    - `getActionFullName(actionId)` : retourne `string | null`
- Un fichier de test :
    - `formatActionFullName.spec.ts` 
        - Tests unitaires couvrant les cas principaux
        - Vérification du format "structure - projet"
        - Gestion des cas sans opérateur principal
        
### Fichiers modifiés
1. `getCommentHistory.ts`
    - Import du service centralisé
    - Enrichissement des actionEntity.name avec le nom complet

2. `findAll.ts`
    - `Import du service centralisé
    - `Enrichissement des actions[].name avec le nom complet

3. `mattermost.ts`
    - `Import du service centralisé
    - `Enrichissement du nom d'action dans triggerNewActionComment()

### Templates MJML
Les templates `action_alert_preshot.mjml`, `action_alert_postshot.mjml` et `user_new_action_comment.mjml` affichent déjà le bon format car :
    - Les alertes preshot/postshot utilisent `actionActorModel.findAll()` qui retourne maintenant le nom complet
    - Le template `user_new_action_comment` utilise `actionModel.fetch()` qui construit déjà le nom complet via `computeActionNames()`
    
### Impact
    -  Historique des commentaires : affiche "Structure - Projet"
    -  Export acteurs : affiche "Structure - Projet"
    -  Notifications Mattermost : affiche "Structure - Projet"
    -  Emails d'alerte : affiche "Structure - Projet"
    -  Centralisation : une seule source de vérité pour le formatage
    -  Cohérence : même logique que `fetchReport.ts`

## 📸 Captures d'écran
- Sans objet

## 🚨 Notes pour la mise en production
- Rien à signaler