### PR TITLE
#patch (2713) [EXPE44] Refonte du design des phases préparatoires de la résorption

### DIFF
--- a/packages/api/db/migrations/30000112-01-update-table-preparatory_phases_toward_resorption-date_label.js
+++ b/packages/api/db/migrations/30000112-01-update-table-preparatory_phases_toward_resorption-date_label.js
@@ -1,0 +1,46 @@
+const values = [
+    { uid: 'sociological_diagnosis', oldName: 'Réalisé le', newName: 'Réalisé' },
+    { uid: 'social_assessment', oldName: 'Réalisée le', newName: 'Réalisée' },
+    { uid: 'political_validation', oldName: 'Obtenue le', newName: 'Obtenue' },
+    { uid: 'contract_preparation', oldName: 'Finalisée le', newName: 'Finalisée' },
+    { uid: 'land_equipment_development', oldName: 'Terminé le', newName: 'Terminé' },
+    { uid: 'family_information', oldName: 'Réalisée le', newName: 'Réalisée' },
+    { uid: 'contractualization_of_families', oldName: 'Terminée le', newName: 'Terminée' },
+    { uid: 'official_opening', oldName: 'Le', newName: 'Le' },
+];
+
+async function updateDateLabel(queryInterface, Sequelize, uid, name, transaction) {
+    return queryInterface.bulkUpdate(
+        'preparatory_phases_toward_resorption',
+        { date_label: name },
+        { uid: { [Sequelize.Op.eq]: uid } },
+        { transaction },
+    );
+}
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            const promises = values.map(({ uid, newName }) => updateDateLabel(queryInterface, Sequelize, uid, newName, transaction));
+            await Promise.all(promises);
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+    async down(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            const promises = values.map(({ uid, oldName }) => updateDateLabel(queryInterface, Sequelize, uid, oldName, transaction));
+            await Promise.all(promises);
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+};

--- a/packages/api/db/migrations/30000112-01-update-table-preparatory_phases_toward_resorption-date_label.js
+++ b/packages/api/db/migrations/30000112-01-update-table-preparatory_phases_toward_resorption-date_label.js
@@ -3,10 +3,10 @@ const values = [
     { uid: 'social_assessment', oldName: 'Réalisée le', newName: 'Réalisée' },
     { uid: 'political_validation', oldName: 'Obtenue le', newName: 'Obtenue' },
     { uid: 'contract_preparation', oldName: 'Finalisée le', newName: 'Finalisée' },
-    { uid: 'land_equipment_development', oldName: 'Terminé le', newName: 'Terminé' },
+    { uid: 'land_equipment_development', oldName: 'Terminé le', newName: 'Finalisé' },
     { uid: 'family_information', oldName: 'Réalisée le', newName: 'Réalisée' },
-    { uid: 'contractualization_of_families', oldName: 'Terminée le', newName: 'Terminée' },
-    { uid: 'official_opening', oldName: 'Le', newName: 'Le' },
+    { uid: 'contractualization_of_families', oldName: 'Terminée le', newName: 'Finalisée' },
+    { uid: 'official_opening', oldName: 'Le', newName: 'Lancé' },
 ];
 
 async function updateDateLabel(queryInterface, Sequelize, uid, name, transaction) {

--- a/packages/frontend/ui/src/components/Input/DatepickerInput.vue
+++ b/packages/frontend/ui/src/components/Input/DatepickerInput.vue
@@ -1,37 +1,39 @@
 <template>
-    <InputWrapper :hasErrors="!!errors.length" :withoutMargin="withoutMargin">
-        <InputLabel
-            :label="label"
-            :info="info"
-            :inlineInfo="inlineInfo"
-            :showMandatoryStar="showMandatoryStar"
-            :for="`dp-input-${id}`"
-            :error="!!errors.length"
-        />
+  <InputWrapper :hasErrors="!!errors.length" :withoutMargin="withoutMargin">
+    <InputLabel
+      :label="label"
+      :info="info"
+      :inlineInfo="inlineInfo"
+      :showMandatoryStar="showMandatoryStar"
+      :for="`dp-input-${id}`"
+      :error="!!errors.length"
+    />
 
-        <div :class="width" class="mt-3">
-            <DatePicker
-                v-model="date"
-                locale="fr"
-                :format-locale="fr"
-                :format="(monthPicker || section === 'evolution') ? 'LLLL yyyy' : 'dd LLLL yyyy'"
-                :disabled="isSubmitting || disabled"
-                autoApply
-                :enableTimePicker="false"
-                :input-class-name="focusClasses.ring"
-                :preventMinMaxNavigation="!!$attrs.maxDate || !!$attrs.minDate"
-                :monthPicker="monthPicker"
-                v-bind="$attrs"
-                :uid="id"
-                @cleared="handleChange(null)"
-            />
-        </div>
-        <InputError v-if="errors.length">{{ errors[0] }}</InputError>
-    </InputWrapper>
+    <div :class="width" class="mt-3">
+      <DatePicker
+        v-model="date"
+        locale="fr"
+        :format-locale="fr"
+        :format="
+          monthPicker || section === 'evolution' ? 'LLLL yyyy' : 'dd LLLL yyyy'
+        "
+        :disabled="isSubmitting || disabled"
+        autoApply
+        :enableTimePicker="false"
+        :input-class-name="focusClasses.ring"
+        :preventMinMaxNavigation="!!$attrs.maxDate || !!$attrs.minDate"
+        :monthPicker="monthPicker"
+        v-bind="$attrs"
+        :uid="id"
+        @cleared="handleChange(null)"
+      />
+    </div>
+    <InputError v-if="errors.length">{{ errors[0] }}</InputError>
+  </InputWrapper>
 </template>
 
 <script setup>
-import { computed, defineProps, toRefs, defineEmits } from "vue";
+import { computed, toRefs } from "vue";
 import { useField, useIsSubmitting } from "vee-validate";
 import { fr } from "date-fns/locale";
 import focusClasses from "../../../../common/utils/focus_classes";
@@ -41,94 +43,114 @@ import InputLabel from "./utils/InputLabel.vue";
 import InputError from "./utils/InputError.vue";
 
 const props = defineProps({
-    id: String,
-    name: String,
-    label: String,
-    info: String,
-    inlineInfo: {
-        type: Boolean,
-        required: false,
-        default: false,
-    },
-    showMandatoryStar: Boolean,
-    rules: {
-        type: Object,
-        required: false,
-    },
-    disabled: {
-        type: Boolean,
-        required: false,
-        default: false
-    },
-    modelValue: {
-        type: [Date, String],
-        required: false,
-        default: undefined
-    },
-    width: { // tailwind class (par exemple : w-32)
-        type: String,
-        required: false,
-        default: ""
-    },
-    withoutMargin: {
-        type: Boolean,
-        required: false,
-        default: false
-    },
-    section: {
-        required: false,
-        type: String
-    },
-    monthPicker: {
-        type: Boolean,
-        required: false,
-        default: false
-    }
+  id: String,
+  name: String,
+  label: String,
+  info: String,
+  inlineInfo: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  showMandatoryStar: Boolean,
+  rules: {
+    type: Object,
+    required: false,
+  },
+  disabled: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  modelValue: {
+    type: [Date, String],
+    required: false,
+    default: undefined,
+  },
+  width: {
+    // tailwind class (par exemple : w-32)
+    type: String,
+    required: false,
+    default: "",
+  },
+  withoutMargin: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  section: {
+    required: false,
+    type: String,
+  },
+  monthPicker: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 });
 
-const { id, name, label, info, inlineInfo, showMandatoryStar, rules, disabled, modelValue, width, withoutMargin, section, monthPicker } = toRefs(props);
+const {
+  id,
+  name,
+  label,
+  info,
+  inlineInfo,
+  showMandatoryStar,
+  rules,
+  disabled,
+  modelValue,
+  width,
+  withoutMargin,
+  section,
+  monthPicker,
+} = toRefs(props);
 const isSubmitting = useIsSubmitting();
 const { handleChange, errors, value } = useField(name.value, rules.value, {
-    initialValue: modelValue.value
+  initialValue: modelValue.value,
 });
 const emit = defineEmits(["update:modelValue"]);
 
 const date = computed({
-    get() {
-        if (monthPicker.value && value.value instanceof Date) {
-            const d = value.value;
-            if (!isValidDate(d)) return null;
-            return {
-                month: d.getMonth(),
-                year: d.getFullYear()
-            };
-        }
-        return value.value;
-    },
-    set(newValue) {
-        const out = processDateValue(newValue, monthPicker.value);
-        if (out !== null) {
-            handleChange(out);
-            emit("update:modelValue", out);
-        }
+  get() {
+    if (monthPicker.value && value.value instanceof Date) {
+      const d = value.value;
+      if (!isValidDate(d)) return null;
+      return {
+        month: d.getMonth(),
+        year: d.getFullYear(),
+      };
     }
+    return value.value;
+  },
+  set(newValue) {
+    const out = processDateValue(newValue, monthPicker.value);
+    if (out !== null) {
+      handleChange(out);
+      emit("update:modelValue", out);
+    }
+  },
 });
 
 function isValidDate(date) {
-    return date instanceof Date && !isNaN(date.getTime());
+  return date instanceof Date && !isNaN(date.getTime());
 }
 
 function processDateValue(newValue, isMonthPicker) {
-    if (isMonthPicker && newValue && typeof newValue === 'object' && 'month' in newValue) {
-        const date = new Date(newValue.year, newValue.month, 1);
-        return isValidDate(date) ? date : null;
-    }
-    
-    if (newValue != null && !(newValue instanceof Date)) {
-        const date = new Date(newValue);
-        return isValidDate(date) ? date : null;
-    }
-    
-    return newValue;
+  if (
+    isMonthPicker &&
+    newValue &&
+    typeof newValue === "object" &&
+    "month" in newValue
+  ) {
+    const date = new Date(newValue.year, newValue.month, 1);
+    return isValidDate(date) ? date : null;
+  }
+
+  if (newValue != null && !(newValue instanceof Date)) {
+    const date = new Date(newValue);
+    return isValidDate(date) ? date : null;
+  }
+
+  return newValue;
 }
 </script>

--- a/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
+++ b/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
@@ -11,7 +11,7 @@
         <div class="flex justify-start items-center text-sm">
             <div class="flex flex-row flex-wrap md:flex-auto gap-1">
                 <div class="flex flex-row shrink-0 gap-1">
-                    <DsfrBadge small :type="stautsType" :label="statusText" />
+                    <DsfrBadge small :type="statusType" :label="statusText" />
                 </div>
                 <div v-if="phase.completedAt" class="shrink-0">
                     {{ formattedDate }}
@@ -61,14 +61,7 @@ const formattedDate = computed(() => {
     });
 });
 
-const stautsType = computed(() => {
-    switch (status.value) {
-        case "done":
-            return "success";
-        case "inprogress":
-            return "info";
-        default:
-            return "info";
-    }
+const statusType = computed(() => {
+    return status.value === "done" ? "success" : "info";
 });
 </script>

--- a/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
+++ b/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
@@ -14,7 +14,12 @@
                     <DsfrBadge small :type="statusType" :label="statusText" />
                 </div>
                 <div v-if="phase.completedAt" class="shrink-0">
-                    {{ formattedDate }}
+                    {{
+                        phase.preparatoryPhaseId === "official_opening"
+                            ? ""
+                            : "le "
+                    }}
+                    {{ formattedDate }} {{ phase.preparatoryPhaseUid }}
                 </div>
             </div>
         </div>

--- a/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
+++ b/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
@@ -11,11 +11,7 @@
         <div class="flex justify-start items-center text-sm">
             <div class="flex flex-row flex-wrap md:flex-auto gap-1">
                 <div class="flex flex-row shrink-0 gap-1">
-                    <i
-                        class="w-4 h-4 rounded-full"
-                        :class="`bg-${iconColor}`"
-                    />
-                    {{ statusText }}
+                    <DsfrBadge small :type="stautsType" :label="statusText" />
                 </div>
                 <div v-if="phase.completedAt" class="shrink-0">
                     {{ formattedDate }}
@@ -65,13 +61,14 @@ const formattedDate = computed(() => {
     });
 });
 
-const STATUS_COLORS = {
-    done: "green",
-    inprogress: "orange600",
-    default: "G500",
-};
-
-const iconColor = computed(() => {
-    return STATUS_COLORS[status.value] || STATUS_COLORS.default;
+const stautsType = computed(() => {
+    switch (status.value) {
+        case "done":
+            return "success";
+        case "inprogress":
+            return "info";
+        default:
+            return "info";
+    }
 });
 </script>

--- a/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
+++ b/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
@@ -14,12 +14,7 @@
                     <DsfrBadge small :type="statusType" :label="statusText" />
                 </div>
                 <div v-if="phase.completedAt" class="shrink-0">
-                    {{
-                        phase.preparatoryPhaseId === "official_opening"
-                            ? ""
-                            : "le "
-                    }}
-                    {{ formattedDate }} {{ phase.preparatoryPhaseUid }}
+                    le {{ formattedDate }} {{ phase.preparatoryPhaseUid }}
                 </div>
             </div>
         </div>

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/FormDeclarationDeSite.vue
@@ -53,8 +53,6 @@
 <script setup>
 import {
     computed,
-    defineExpose,
-    defineProps,
     markRaw,
     onBeforeUnmount,
     ref,
@@ -434,12 +432,21 @@ function buildTerminatedPreparatoryPhases(initOrEdit) {
         }
     } else if (initOrEdit === "edit") {
         for (const phase of values.preparatory_phases_toward_resorption) {
-            if (values[`phase_${phase}_completed_at`] !== null) {
+            if (
+                values[`phase_${phase}_completed_at`] !== undefined &&
+                values[`phase_${phase}_completed_at`] !== null
+            ) {
                 terminatedPreparatoryPhases[phase] =
                     values[`phase_${phase}_completed_at`];
-            } else if (phase.completedAt !== null) {
-                terminatedPreparatoryPhases[phase.preparatoryPhaseId] =
-                    phase.completedAt;
+            } else {
+                const originalPhase =
+                    values.active_preparatory_phases_toward_resorption?.find(
+                        (p) => p.preparatoryPhaseId === phase
+                    );
+                if (originalPhase?.completedAt != null) {
+                    terminatedPreparatoryPhases[phase] =
+                        originalPhase.completedAt;
+                }
             }
         }
     }

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -42,8 +42,8 @@
 </template>
 
 <script setup>
-import { computed, ref, toRefs, watch } from "vue";
-import { useFormValues } from "vee-validate";
+import { computed, ref, toRefs } from "vue";
+import { useField } from "vee-validate";
 import { DatepickerInput } from "@resorptionbidonvilles/ui";
 import { useUserStore } from "@/stores/user.store";
 
@@ -52,35 +52,50 @@ const props = defineProps({
         type: Object,
         required: true,
     },
-    activePhases: {
-        type: Array,
-        required: true,
-    },
-    index: {
-        type: Number,
-        required: true,
-    },
-    modelValue: {
-        type: [Array, String, Number, Boolean],
-        required: true,
-        default: undefined,
-    },
-    withBorder: {
-        type: Boolean,
-        default: true,
-    },
 });
 
-const { phase, activePhases } = toRefs(props);
+const { phase } = toRefs(props);
 
+// Mémorise la dernière date saisie pour la restaurer si l'utilisateur
+// repasse « Terminée » après être passé par « En cours » / « Non démarrée ».
 const initialDate = ref(null);
+
 const canUpdate = computed(() => {
     const userStore = useUserStore();
     return userStore.hasPermission("shantytown.update");
 });
 
+// Mécanisme repris de l'ancienne Checkbox : un useField en mode « checkbox »
+// partageant le name `preparatory_phases_toward_resorption` maintient le tableau
+// des UIDs cochés (source de vérité consommée par le backend). `handleChange(uid)`
+// toggle la présence de l'UID, `checked` reflète cette présence.
+const { checked, handleChange: togglePhaseUid } = useField(
+    "preparatory_phases_toward_resorption",
+    undefined,
+    {
+        type: "checkbox",
+        checkedValue: phase.value.uid,
+    }
+);
+
+// Garde le tableau d'UIDs et l'état coché alignés sur la cible voulue.
+const setChecked = (shouldBeChecked) => {
+    if (checked.value !== shouldBeChecked) {
+        togglePhaseUid(phase.value.uid);
+    }
+};
+
+// `active_preparatory_phases_toward_resorption` porte les dates de complétion.
+// On l'écrit via handleChange (et non en mutant `values`, exposé en lecture seule
+// par vee-validate) avec un tableau neuf à chaque fois pour préserver la réactivité.
+const { value: activePhases, handleChange: setActivePhases } = useField(
+    "active_preparatory_phases_toward_resorption"
+);
+
 const getAssociatedPhase = () =>
-    activePhases.value.find((p) => p.preparatoryPhaseId === phase.value.uid);
+    (activePhases.value || []).find(
+        (p) => p.preparatoryPhaseId === phase.value.uid
+    );
 
 const phaseStatus = computed({
     get() {
@@ -91,36 +106,35 @@ const phaseStatus = computed({
         return associatedPhase.completedAt ? "completed" : "started";
     },
     set(newStatus) {
-        const index = activePhases.value.findIndex(
-            (p) => p.preparatoryPhaseId === phase.value.uid
+        const others = (activePhases.value || []).filter(
+            (p) => p.preparatoryPhaseId !== phase.value.uid
         );
 
         if (newStatus === "not_started") {
             initialDate.value = completedDate.value;
-            if (index > -1) {
-                activePhases.value.splice(index, 1);
-            }
-        } else {
-            const resolvedDate =
-                newStatus === "completed"
-                    ? initialDate.value || completedDate.value || new Date()
-                    : null;
+            setActivePhases(others);
+            setChecked(false);
+            return;
+        }
 
-            const updatedPhase = {
+        const resolvedDate =
+            newStatus === "completed"
+                ? initialDate.value || completedDate.value || new Date()
+                : null;
+
+        setActivePhases([
+            ...others,
+            {
                 preparatoryPhaseId: phase.value.uid,
                 completedAt: resolvedDate ? resolvedDate.toISOString() : null,
-            };
+            },
+        ]);
 
-            if (index > -1) {
-                activePhases.value[index] = updatedPhase;
-            } else {
-                activePhases.value.push(updatedPhase);
-            }
-
-            if (newStatus === "completed") {
-                initialDate.value = null;
-            }
+        if (newStatus === "completed") {
+            initialDate.value = null;
         }
+
+        setChecked(true);
     },
 });
 
@@ -132,48 +146,18 @@ const completedDate = computed({
             : null;
     },
     set(newDate) {
-        const associatedPhase = getAssociatedPhase();
-        if (associatedPhase) {
-            associatedPhase.completedAt = newDate
-                ? newDate.toISOString()
-                : null;
-        }
+        const others = (activePhases.value || []).filter(
+            (p) => p.preparatoryPhaseId !== phase.value.uid
+        );
+        setActivePhases([
+            ...others,
+            {
+                preparatoryPhaseId: phase.value.uid,
+                completedAt: newDate ? newDate.toISOString() : null,
+            },
+        ]);
     },
 });
-
-const values = useFormValues();
-const fieldName = `phase_${props.phase.uid}_completed_at`;
-
-watch(
-    completedDate,
-    (newVal) => {
-        if (values.value && values.value[fieldName] !== newVal) {
-            values.value[fieldName] = newVal;
-        }
-    },
-    { immediate: true }
-);
-
-watch(
-    () => values.value?.[fieldName],
-    (newVal) => {
-        if (newVal === undefined) {
-            return;
-        }
-        const getTimestamp = (val) => {
-            if (val instanceof Date) {
-                return val.getTime();
-            }
-            if (val) {
-                return new Date(val).getTime();
-            }
-            return null;
-        };
-        if (getTimestamp(newVal) !== getTimestamp(completedDate.value)) {
-            completedDate.value = newVal ? new Date(newVal) : null;
-        }
-    }
-);
 </script>
 <style scoped>
 /* Rattrapage du mt-3 de la div enfant du DatePicker */

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -1,29 +1,40 @@
 <template>
-    <div
-        class="p-2 px-4 w-full"
-        :class="{ 'border-1 border-primary rounded ': withBorder }"
-    >
-        <div
-            class="grid grid-cols-2 gap-4 item-start"
-            :class="{ 'mt-2 mb-1': withBorder }"
-        >
-            <Checkbox
-                :value="phase.uid"
-                :checked="isChecked"
-                :key="phase.uid"
-                :label="phase.name"
-                name="preparatory_phases_toward_resorption"
-                :modelValue="modelValue"
-                :disabled="isDisabled"
-                @change="handleCheckboxChange"
+    <div class="fr-container fr-my-2v">
+        <h3 class="h3 font-bold flex flex-wrap gap-2 items-center">
+            {{ phase.name }}
+            <DsfrBadge
+                v-if="completedDate"
+                label="Validée"
+                type="success"
+                small
             />
+            <DsfrBadge
+                v-if="phaseStatus === 'started'"
+                label="En cours"
+                type="info"
+                small
+            />
+        </h3>
+        <div class="flex flex-col lg:flex-row gap-2 w-full">
+            <DsfrSegmentedSet
+                :options="[
+                    { label: 'Non démarrée', value: 'not_started' },
+                    { label: 'En cours', value: 'started' },
+                    { label: 'Terminée', value: 'completed' },
+                ]"
+                v-model="phaseStatus"
+                :disabled="
+                    !canUpdate || (phase.is_a_starting_phase && completedDate)
+                "
+            />
+
             <DatepickerInput
-                v-if="isChecked"
+                v-if="phaseStatus !== 'not_started'"
                 :name="`phase_${phase.uid}_completed_at`"
                 :id="`phase_${phase.uid}_completed_at`"
                 :maxDate="new Date()"
-                v-model="completed_date"
-                class="!mb-0"
+                v-model="completedDate"
+                class="!mb-0 mt-0 w-64"
                 :disabled="!canUpdate"
             />
         </div>
@@ -31,8 +42,9 @@
 </template>
 
 <script setup>
-import { computed, defineProps, ref } from "vue";
-import { Checkbox, DatepickerInput } from "@resorptionbidonvilles/ui";
+import { computed, ref, toRefs, watch } from "vue";
+import { useFormValues } from "vee-validate";
+import { DatepickerInput } from "@resorptionbidonvilles/ui";
 import { useUserStore } from "@/stores/user.store";
 
 const props = defineProps({
@@ -59,58 +71,113 @@ const props = defineProps({
     },
 });
 
-const { phase, activePhases, withBorder } = props;
+const { phase, activePhases } = toRefs(props);
 
-const isDisabled = computed(
-    () => phase.is_a_starting_phase || canUpdate.value === false
-);
-
-const isChecked = ref(false);
-
-// Utiliser un ref modifiable
-const completed_date = ref(null);
-
-// Initialiser la valeur en fonction des phases actives
-isChecked.value = activePhases.some(
-    (activePhase) => activePhase.preparatoryPhaseId === phase.uid
-);
-
-// Initialiser le ref avec la date si elle existe
-const activePhase = activePhases.find(
-    (activePhase) => activePhase.preparatoryPhaseId === phase.uid
-);
-
-if (activePhase && activePhase.completedAt) {
-    completed_date.value = new Date(activePhase.completedAt);
-}
-
-const handleCheckboxChange = (checked) => {
-    isChecked.value = checked;
-
-    // Mettre à jour activePhases pour la gestion des dates
-    if (checked) {
-        if (
-            !activePhases.some(
-                (activePhase) => activePhase.preparatoryPhaseId === phase.uid
-            )
-        ) {
-            activePhases.push({ preparatoryPhaseId: phase.uid });
-        }
-    } else {
-        const index = activePhases.findIndex(
-            (activePhase) => activePhase.preparatoryPhaseId === phase.uid
-        );
-        if (index > -1) {
-            activePhases.splice(index, 1);
-        }
-    }
-
-    // Le v-model gère déjà l'ajout/suppression dans preparatory_phases_toward_resorption
-    // Pas besoin de le faire manuellement
-};
-
+const initialDate = ref(null);
 const canUpdate = computed(() => {
     const userStore = useUserStore();
     return userStore.hasPermission("shantytown.update");
 });
+
+const getAssociatedPhase = () =>
+    activePhases.value.find((p) => p.preparatoryPhaseId === phase.value.uid);
+
+const phaseStatus = computed({
+    get() {
+        const associatedPhase = getAssociatedPhase();
+        if (!associatedPhase) {
+            return "not_started";
+        }
+        return associatedPhase.completedAt ? "completed" : "started";
+    },
+    set(newStatus) {
+        const index = activePhases.value.findIndex(
+            (p) => p.preparatoryPhaseId === phase.value.uid
+        );
+
+        if (newStatus === "not_started") {
+            initialDate.value = completedDate.value;
+            if (index > -1) {
+                activePhases.value.splice(index, 1);
+            }
+        } else {
+            const resolvedDate =
+                newStatus === "completed"
+                    ? initialDate.value || completedDate.value || new Date()
+                    : null;
+
+            const updatedPhase = {
+                preparatoryPhaseId: phase.value.uid,
+                completedAt: resolvedDate ? resolvedDate.toISOString() : null,
+            };
+
+            if (index > -1) {
+                activePhases.value[index] = updatedPhase;
+            } else {
+                activePhases.value.push(updatedPhase);
+            }
+
+            if (newStatus === "completed") {
+                initialDate.value = null;
+            }
+        }
+    },
+});
+
+const completedDate = computed({
+    get() {
+        const associatedPhase = getAssociatedPhase();
+        return associatedPhase?.completedAt
+            ? new Date(associatedPhase.completedAt)
+            : null;
+    },
+    set(newDate) {
+        const associatedPhase = getAssociatedPhase();
+        if (associatedPhase) {
+            associatedPhase.completedAt = newDate
+                ? newDate.toISOString()
+                : null;
+        }
+    },
+});
+
+const values = useFormValues();
+const fieldName = `phase_${props.phase.uid}_completed_at`;
+
+watch(
+    completedDate,
+    (newVal) => {
+        if (values.value && values.value[fieldName] !== newVal) {
+            values.value[fieldName] = newVal;
+        }
+    },
+    { immediate: true }
+);
+
+watch(
+    () => values.value?.[fieldName],
+    (newVal) => {
+        if (newVal === undefined) {
+            return;
+        }
+        const getTimestamp = (val) => {
+            if (val instanceof Date) {
+                return val.getTime();
+            }
+            if (val) {
+                return new Date(val).getTime();
+            }
+            return null;
+        };
+        if (getTimestamp(newVal) !== getTimestamp(completedDate.value)) {
+            completedDate.value = newVal ? new Date(newVal) : null;
+        }
+    }
+);
 </script>
+<style scoped>
+/* Rattrapage du mt-3 de la div enfant du DatePicker */
+.mt-0 {
+    margin-top: -0.75rem !important;
+}
+</style>

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -30,6 +30,7 @@
 
             <DatepickerInput
                 v-if="phaseStatus !== 'not_started'"
+                :key="`phase_${phase.uid}_${phaseStatus}`"
                 :name="`phase_${phase.uid}_completed_at`"
                 :id="`phase_${phase.uid}_completed_at`"
                 :maxDate="new Date()"
@@ -42,7 +43,7 @@
 </template>
 
 <script setup>
-import { computed, ref, toRefs } from "vue";
+import { computed, ref, toRefs, watch } from "vue";
 import { useField } from "vee-validate";
 import { DatepickerInput } from "@resorptionbidonvilles/ui";
 import { useUserStore } from "@/stores/user.store";
@@ -157,6 +158,23 @@ const completedDate = computed({
             },
         ]);
     },
+});
+
+// Le DatepickerInput possède son propre useField (name `phase_${uid}_completed_at`)
+// et n'émet rien vers le parent quand on efface la date via sa croix (@cleared).
+// On observe donc ce champ partagé pour propager l'effacement à la source de vérité
+// `active_preparatory_phases_toward_resorption` : la phase repasse « En cours »
+// (completedAt = null) et le DsfrSegmentedSet se repositionne sur « En cours ».
+const { value: pickerDate } = useField(`phase_${phase.value.uid}_completed_at`);
+
+watch(pickerDate, (newValue) => {
+    const isCleared =
+        newValue === null || newValue === undefined || newValue === "";
+    // On ne réagit qu'à l'effacement d'une phase actuellement « Terminée »,
+    // pour ne pas interférer avec la sélection normale d'une date.
+    if (isCleared && phaseStatus.value === "completed") {
+        completedDate.value = null;
+    }
 });
 </script>
 <style scoped>

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -4,7 +4,7 @@
             {{ phase.name }}
             <DsfrBadge
                 v-if="completedDate"
-                label="Validée"
+                label="Réalisée"
                 type="success"
                 small
             />

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -93,18 +93,22 @@ const { value: activePhases, handleChange: setActivePhases } = useField(
     "active_preparatory_phases_toward_resorption"
 );
 
-const getAssociatedPhase = () =>
+// Phase active correspondant à cet item. Mémoïsée : les getters de `phaseStatus`
+// et `completedDate` la partagent, donc un seul `.find()` est effectué par
+// invalidation (au lieu d'un par computed), et uniquement quand `activePhases`
+// ou l'UID de la phase change réellement.
+const associatedPhase = computed(() =>
     (activePhases.value || []).find(
         (p) => p.preparatoryPhaseId === phase.value.uid
-    );
+    )
+);
 
 const phaseStatus = computed({
     get() {
-        const associatedPhase = getAssociatedPhase();
-        if (!associatedPhase) {
+        if (!associatedPhase.value) {
             return "not_started";
         }
-        return associatedPhase.completedAt ? "completed" : "started";
+        return associatedPhase.value.completedAt ? "completed" : "started";
     },
     set(newStatus) {
         const others = (activePhases.value || []).filter(
@@ -141,9 +145,8 @@ const phaseStatus = computed({
 
 const completedDate = computed({
     get() {
-        const associatedPhase = getAssociatedPhase();
-        return associatedPhase?.completedAt
-            ? new Date(associatedPhase.completedAt)
+        return associatedPhase.value?.completedAt
+            ? new Date(associatedPhase.value.completedAt)
             : null;
     },
     set(newDate) {

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhases.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhases.vue
@@ -8,7 +8,7 @@
                 Phase initiale
             </div>
             <CheckableGroup
-                id="preparatory_phases_toward_resorption"
+                id="initial_preparatory_phases_toward_resorption"
                 class="!mb-2"
             >
                 <InputResorptionPhaseItem

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhases.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhases.vue
@@ -12,13 +12,9 @@
                 class="!mb-2"
             >
                 <InputResorptionPhaseItem
-                    v-for="(item, index) in phasesStartingResorption"
-                    v-model="preparatory_phases_toward_resorption_value"
+                    v-for="item in phasesStartingResorption"
                     :phase="item"
-                    :activePhases="activeValues"
-                    :index="index"
                     :key="item.uid"
-                    :withBorder="false"
                 />
             </CheckableGroup>
         </div>
@@ -26,11 +22,8 @@
 
     <CheckableGroup id="preparatory_phases_toward_resorption">
         <InputResorptionPhaseItem
-            v-for="(item, index) in phasesNotStartingResorption"
-            v-model="preparatory_phases_toward_resorption_value"
+            v-for="item in phasesNotStartingResorption"
             :phase="item"
-            :activePhases="activeValues"
-            :index="index"
             :key="item.uid"
             class="my-2"
         />
@@ -39,7 +32,6 @@
 
 <script setup>
 import { computed } from "vue";
-import { useFieldValue } from "vee-validate";
 import { CheckableGroup } from "@resorptionbidonvilles/ui";
 import InputResorptionPhaseItem from "./FormDeclarationDeSiteInputResorptionPhaseItem.vue";
 import { useConfigStore } from "@/stores/config.store";
@@ -50,14 +42,6 @@ const preparatory_phases_toward_resorption =
     configStore.config?.preparatory_phases_toward_resorption.sort(
         (a, b) => a.position - b.position
     ) || [];
-
-const preparatory_phases_toward_resorption_value = useFieldValue(
-    "preparatory_phases_toward_resorption"
-);
-
-const activeValues = useFieldValue(
-    "active_preparatory_phases_toward_resorption"
-);
 
 const phasesStartingResorption = computed(() =>
     preparatory_phases_toward_resorption.filter(


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/oamV696F/2713-site-proprification-du-formulaire-expe44

## 🛠 Description de la PR
Cette PR apporte des modifications visuelles à l'affichage ainsi qu'au formulaire des phases préparatoires à la résorption (liées pour l'instant à l'EXPE44) en incluant des éléments DSFR, améliorant l'accessibilité générale.

## 📸 Captures d'écran
### Visualisation
<img width="1100" height="310" alt="image" src="https://github.com/user-attachments/assets/a603f6f5-2957-4fbd-8043-63b5f43da1fe" />

### Modification
<img width="850" height="702" alt="image" src="https://github.com/user-attachments/assets/7deb3eaf-928f-48db-a3cd-77a7071ba488" />

## 🚨 Notes pour la mise en production
RàS