### PR TITLE
#patch (2713) Corriger les problèmes introduits/présents dans la refonte des phases préparatoires

### DIFF
--- a/packages/api/db/migrations/30000112-01-update-table-preparatory_phases_toward_resorption-date_label.js
+++ b/packages/api/db/migrations/30000112-01-update-table-preparatory_phases_toward_resorption-date_label.js
@@ -1,0 +1,46 @@
+const values = [
+    { uid: 'sociological_diagnosis', oldName: 'Réalisé le', newName: 'Réalisé' },
+    { uid: 'social_assessment', oldName: 'Réalisée le', newName: 'Réalisée' },
+    { uid: 'political_validation', oldName: 'Obtenue le', newName: 'Obtenue' },
+    { uid: 'contract_preparation', oldName: 'Finalisée le', newName: 'Finalisée' },
+    { uid: 'land_equipment_development', oldName: 'Terminé le', newName: 'Terminé' },
+    { uid: 'family_information', oldName: 'Réalisée le', newName: 'Réalisée' },
+    { uid: 'contractualization_of_families', oldName: 'Terminée le', newName: 'Terminée' },
+    { uid: 'official_opening', oldName: 'Le', newName: 'Le' },
+];
+
+async function updateDateLabel(queryInterface, Sequelize, uid, name, transaction) {
+    return queryInterface.bulkUpdate(
+        'preparatory_phases_toward_resorption',
+        { date_label: name },
+        { uid: { [Sequelize.Op.eq]: uid } },
+        { transaction },
+    );
+}
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            const promises = values.map(({ uid, newName }) => updateDateLabel(queryInterface, Sequelize, uid, newName, transaction));
+            await Promise.all(promises);
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+    async down(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            const promises = values.map(({ uid, oldName }) => updateDateLabel(queryInterface, Sequelize, uid, oldName, transaction));
+            await Promise.all(promises);
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+};

--- a/packages/api/db/migrations/30000112-01-update-table-preparatory_phases_toward_resorption-date_label.js
+++ b/packages/api/db/migrations/30000112-01-update-table-preparatory_phases_toward_resorption-date_label.js
@@ -3,10 +3,10 @@ const values = [
     { uid: 'social_assessment', oldName: 'Réalisée le', newName: 'Réalisée' },
     { uid: 'political_validation', oldName: 'Obtenue le', newName: 'Obtenue' },
     { uid: 'contract_preparation', oldName: 'Finalisée le', newName: 'Finalisée' },
-    { uid: 'land_equipment_development', oldName: 'Terminé le', newName: 'Terminé' },
+    { uid: 'land_equipment_development', oldName: 'Terminé le', newName: 'Finalisé' },
     { uid: 'family_information', oldName: 'Réalisée le', newName: 'Réalisée' },
-    { uid: 'contractualization_of_families', oldName: 'Terminée le', newName: 'Terminée' },
-    { uid: 'official_opening', oldName: 'Le', newName: 'Le' },
+    { uid: 'contractualization_of_families', oldName: 'Terminée le', newName: 'Finalisée' },
+    { uid: 'official_opening', oldName: 'Le', newName: 'Lancé' },
 ];
 
 async function updateDateLabel(queryInterface, Sequelize, uid, name, transaction) {

--- a/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
+++ b/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
@@ -11,7 +11,7 @@
         <div class="flex justify-start items-center text-sm">
             <div class="flex flex-row flex-wrap md:flex-auto gap-1">
                 <div class="flex flex-row shrink-0 gap-1">
-                    <DsfrBadge small :type="stautsType" :label="statusText" />
+                    <DsfrBadge small :type="statusType" :label="statusText" />
                 </div>
                 <div v-if="phase.completedAt" class="shrink-0">
                     {{ formattedDate }}
@@ -61,14 +61,7 @@ const formattedDate = computed(() => {
     });
 });
 
-const stautsType = computed(() => {
-    switch (status.value) {
-        case "done":
-            return "success";
-        case "inprogress":
-            return "info";
-        default:
-            return "info";
-    }
+const statusType = computed(() => {
+    return status.value === "done" ? "success" : "info";
 });
 </script>

--- a/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
+++ b/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
@@ -14,7 +14,12 @@
                     <DsfrBadge small :type="statusType" :label="statusText" />
                 </div>
                 <div v-if="phase.completedAt" class="shrink-0">
-                    {{ formattedDate }}
+                    {{
+                        phase.preparatoryPhaseId === "official_opening"
+                            ? ""
+                            : "le "
+                    }}
+                    {{ formattedDate }} {{ phase.preparatoryPhaseUid }}
                 </div>
             </div>
         </div>

--- a/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
+++ b/packages/frontend/webapp/src/components/CartePhaseResorption/CartePhaseResorption.vue
@@ -14,12 +14,7 @@
                     <DsfrBadge small :type="statusType" :label="statusText" />
                 </div>
                 <div v-if="phase.completedAt" class="shrink-0">
-                    {{
-                        phase.preparatoryPhaseId === "official_opening"
-                            ? ""
-                            : "le "
-                    }}
-                    {{ formattedDate }} {{ phase.preparatoryPhaseUid }}
+                    le {{ formattedDate }} {{ phase.preparatoryPhaseUid }}
                 </div>
             </div>
         </div>

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -42,8 +42,8 @@
 </template>
 
 <script setup>
-import { computed, ref, toRefs, watch } from "vue";
-import { useFormValues } from "vee-validate";
+import { computed, ref, toRefs } from "vue";
+import { useField } from "vee-validate";
 import { DatepickerInput } from "@resorptionbidonvilles/ui";
 import { useUserStore } from "@/stores/user.store";
 
@@ -52,35 +52,50 @@ const props = defineProps({
         type: Object,
         required: true,
     },
-    activePhases: {
-        type: Array,
-        required: true,
-    },
-    index: {
-        type: Number,
-        required: true,
-    },
-    modelValue: {
-        type: [Array, String, Number, Boolean],
-        required: true,
-        default: undefined,
-    },
-    withBorder: {
-        type: Boolean,
-        default: true,
-    },
 });
 
-const { phase, activePhases } = toRefs(props);
+const { phase } = toRefs(props);
 
+// Mémorise la dernière date saisie pour la restaurer si l'utilisateur
+// repasse « Terminée » après être passé par « En cours » / « Non démarrée ».
 const initialDate = ref(null);
+
 const canUpdate = computed(() => {
     const userStore = useUserStore();
     return userStore.hasPermission("shantytown.update");
 });
 
+// Mécanisme repris de l'ancienne Checkbox : un useField en mode « checkbox »
+// partageant le name `preparatory_phases_toward_resorption` maintient le tableau
+// des UIDs cochés (source de vérité consommée par le backend). `handleChange(uid)`
+// toggle la présence de l'UID, `checked` reflète cette présence.
+const { checked, handleChange: togglePhaseUid } = useField(
+    "preparatory_phases_toward_resorption",
+    undefined,
+    {
+        type: "checkbox",
+        checkedValue: phase.value.uid,
+    }
+);
+
+// Garde le tableau d'UIDs et l'état coché alignés sur la cible voulue.
+const setChecked = (shouldBeChecked) => {
+    if (checked.value !== shouldBeChecked) {
+        togglePhaseUid(phase.value.uid);
+    }
+};
+
+// `active_preparatory_phases_toward_resorption` porte les dates de complétion.
+// On l'écrit via handleChange (et non en mutant `values`, exposé en lecture seule
+// par vee-validate) avec un tableau neuf à chaque fois pour préserver la réactivité.
+const { value: activePhases, handleChange: setActivePhases } = useField(
+    "active_preparatory_phases_toward_resorption"
+);
+
 const getAssociatedPhase = () =>
-    activePhases.value.find((p) => p.preparatoryPhaseId === phase.value.uid);
+    (activePhases.value || []).find(
+        (p) => p.preparatoryPhaseId === phase.value.uid
+    );
 
 const phaseStatus = computed({
     get() {
@@ -91,36 +106,35 @@ const phaseStatus = computed({
         return associatedPhase.completedAt ? "completed" : "started";
     },
     set(newStatus) {
-        const index = activePhases.value.findIndex(
-            (p) => p.preparatoryPhaseId === phase.value.uid
+        const others = (activePhases.value || []).filter(
+            (p) => p.preparatoryPhaseId !== phase.value.uid
         );
 
         if (newStatus === "not_started") {
             initialDate.value = completedDate.value;
-            if (index > -1) {
-                activePhases.value.splice(index, 1);
-            }
-        } else {
-            const resolvedDate =
-                newStatus === "completed"
-                    ? initialDate.value || completedDate.value || new Date()
-                    : null;
+            setActivePhases(others);
+            setChecked(false);
+            return;
+        }
 
-            const updatedPhase = {
+        const resolvedDate =
+            newStatus === "completed"
+                ? initialDate.value || completedDate.value || new Date()
+                : null;
+
+        setActivePhases([
+            ...others,
+            {
                 preparatoryPhaseId: phase.value.uid,
                 completedAt: resolvedDate ? resolvedDate.toISOString() : null,
-            };
+            },
+        ]);
 
-            if (index > -1) {
-                activePhases.value[index] = updatedPhase;
-            } else {
-                activePhases.value.push(updatedPhase);
-            }
-
-            if (newStatus === "completed") {
-                initialDate.value = null;
-            }
+        if (newStatus === "completed") {
+            initialDate.value = null;
         }
+
+        setChecked(true);
     },
 });
 
@@ -132,48 +146,18 @@ const completedDate = computed({
             : null;
     },
     set(newDate) {
-        const associatedPhase = getAssociatedPhase();
-        if (associatedPhase) {
-            associatedPhase.completedAt = newDate
-                ? newDate.toISOString()
-                : null;
-        }
+        const others = (activePhases.value || []).filter(
+            (p) => p.preparatoryPhaseId !== phase.value.uid
+        );
+        setActivePhases([
+            ...others,
+            {
+                preparatoryPhaseId: phase.value.uid,
+                completedAt: newDate ? newDate.toISOString() : null,
+            },
+        ]);
     },
 });
-
-const values = useFormValues();
-const fieldName = `phase_${props.phase.uid}_completed_at`;
-
-watch(
-    completedDate,
-    (newVal) => {
-        if (values.value && values.value[fieldName] !== newVal) {
-            values.value[fieldName] = newVal;
-        }
-    },
-    { immediate: true }
-);
-
-watch(
-    () => values.value?.[fieldName],
-    (newVal) => {
-        if (newVal === undefined) {
-            return;
-        }
-        const getTimestamp = (val) => {
-            if (val instanceof Date) {
-                return val.getTime();
-            }
-            if (val) {
-                return new Date(val).getTime();
-            }
-            return null;
-        };
-        if (getTimestamp(newVal) !== getTimestamp(completedDate.value)) {
-            completedDate.value = newVal ? new Date(newVal) : null;
-        }
-    }
-);
 </script>
 <style scoped>
 /* Rattrapage du mt-3 de la div enfant du DatePicker */

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -30,6 +30,7 @@
 
             <DatepickerInput
                 v-if="phaseStatus !== 'not_started'"
+                :key="`phase_${phase.uid}_${phaseStatus}`"
                 :name="`phase_${phase.uid}_completed_at`"
                 :id="`phase_${phase.uid}_completed_at`"
                 :maxDate="new Date()"
@@ -42,7 +43,7 @@
 </template>
 
 <script setup>
-import { computed, ref, toRefs } from "vue";
+import { computed, ref, toRefs, watch } from "vue";
 import { useField } from "vee-validate";
 import { DatepickerInput } from "@resorptionbidonvilles/ui";
 import { useUserStore } from "@/stores/user.store";
@@ -157,6 +158,23 @@ const completedDate = computed({
             },
         ]);
     },
+});
+
+// Le DatepickerInput possède son propre useField (name `phase_${uid}_completed_at`)
+// et n'émet rien vers le parent quand on efface la date via sa croix (@cleared).
+// On observe donc ce champ partagé pour propager l'effacement à la source de vérité
+// `active_preparatory_phases_toward_resorption` : la phase repasse « En cours »
+// (completedAt = null) et le DsfrSegmentedSet se repositionne sur « En cours ».
+const { value: pickerDate } = useField(`phase_${phase.value.uid}_completed_at`);
+
+watch(pickerDate, (newValue) => {
+    const isCleared =
+        newValue === null || newValue === undefined || newValue === "";
+    // On ne réagit qu'à l'effacement d'une phase actuellement « Terminée »,
+    // pour ne pas interférer avec la sélection normale d'une date.
+    if (isCleared && phaseStatus.value === "completed") {
+        completedDate.value = null;
+    }
 });
 </script>
 <style scoped>

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -4,7 +4,7 @@
             {{ phase.name }}
             <DsfrBadge
                 v-if="completedDate"
-                label="Validée"
+                label="Réalisée"
                 type="success"
                 small
             />

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -93,18 +93,22 @@ const { value: activePhases, handleChange: setActivePhases } = useField(
     "active_preparatory_phases_toward_resorption"
 );
 
-const getAssociatedPhase = () =>
+// Phase active correspondant à cet item. Mémoïsée : les getters de `phaseStatus`
+// et `completedDate` la partagent, donc un seul `.find()` est effectué par
+// invalidation (au lieu d'un par computed), et uniquement quand `activePhases`
+// ou l'UID de la phase change réellement.
+const associatedPhase = computed(() =>
     (activePhases.value || []).find(
         (p) => p.preparatoryPhaseId === phase.value.uid
-    );
+    )
+);
 
 const phaseStatus = computed({
     get() {
-        const associatedPhase = getAssociatedPhase();
-        if (!associatedPhase) {
+        if (!associatedPhase.value) {
             return "not_started";
         }
-        return associatedPhase.completedAt ? "completed" : "started";
+        return associatedPhase.value.completedAt ? "completed" : "started";
     },
     set(newStatus) {
         const others = (activePhases.value || []).filter(
@@ -141,9 +145,8 @@ const phaseStatus = computed({
 
 const completedDate = computed({
     get() {
-        const associatedPhase = getAssociatedPhase();
-        return associatedPhase?.completedAt
-            ? new Date(associatedPhase.completedAt)
+        return associatedPhase.value?.completedAt
+            ? new Date(associatedPhase.value.completedAt)
             : null;
     },
     set(newDate) {

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhases.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhases.vue
@@ -12,13 +12,9 @@
                 class="!mb-2"
             >
                 <InputResorptionPhaseItem
-                    v-for="(item, index) in phasesStartingResorption"
-                    v-model="preparatory_phases_toward_resorption_value"
+                    v-for="item in phasesStartingResorption"
                     :phase="item"
-                    :activePhases="activeValues"
-                    :index="index"
                     :key="item.uid"
-                    :withBorder="false"
                 />
             </CheckableGroup>
         </div>
@@ -26,11 +22,8 @@
 
     <CheckableGroup id="preparatory_phases_toward_resorption">
         <InputResorptionPhaseItem
-            v-for="(item, index) in phasesNotStartingResorption"
-            v-model="preparatory_phases_toward_resorption_value"
+            v-for="item in phasesNotStartingResorption"
             :phase="item"
-            :activePhases="activeValues"
-            :index="index"
             :key="item.uid"
             class="my-2"
         />
@@ -39,7 +32,6 @@
 
 <script setup>
 import { computed } from "vue";
-import { useFieldValue } from "vee-validate";
 import { CheckableGroup } from "@resorptionbidonvilles/ui";
 import InputResorptionPhaseItem from "./FormDeclarationDeSiteInputResorptionPhaseItem.vue";
 import { useConfigStore } from "@/stores/config.store";
@@ -50,14 +42,6 @@ const preparatory_phases_toward_resorption =
     configStore.config?.preparatory_phases_toward_resorption.sort(
         (a, b) => a.position - b.position
     ) || [];
-
-const preparatory_phases_toward_resorption_value = useFieldValue(
-    "preparatory_phases_toward_resorption"
-);
-
-const activeValues = useFieldValue(
-    "active_preparatory_phases_toward_resorption"
-);
 
 const phasesStartingResorption = computed(() =>
     preparatory_phases_toward_resorption.filter(


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/oamV696F/2713

## 🛠 Description de la PR
PR corrective à fusionner dans `issue/2713`. Elle corrige deux problèmes introduits/présents dans la refonte des phases préparatoires.

## Problème principal : perte de données silencieuse en édition
- La refonte `Checkbox → DsfrSegmentedSet` avait supprimé le seul mécanisme qui alimentait  `preparatory_phases_toward_resorption` (le tableau d'UIDs qui est la **source de vérité consommée par le backend**).

Conséquence en **édition** :
- une phase passée à "En cours" / "Terminée" n'était jamais persistée ;
- une phase repassée à "Non démarrée" n'était jamais supprimée.

L'utilisateur voyait son changement à l'écran et sauvegardait sans erreur,
mais le rechargement révélait la perte.

## Correctif
- Réintroduction du mécanisme de l'ancienne `Checkbox` via un `useField` en mode `checkbox` partageant le name `preparatory_phases_toward_resorption`, désormais piloté par le changement de statut du `DsfrSegmentedSet`.
- Écriture de `active_preparatory_phases_toward_resorption` via `handleChange` (tableau immuable) au lieu de muter `values` (lecture seule vee-validate) ; supprime les warnings `target is readonly`.
- Suppression des `watch` de synchronisation fragiles et des props inutiles.
- Correction d'une coquille `stautsType → statusType` dans `CartePhaseResorption.vue`.

## Vérification
- Lint sans erreur sur les composants modifiés.
- Test bout-en-bout contre la base réelle : une phase démarrée en édition
  est désormais bien créée avec sa date (et l'état initial restauré après test).
- Warnings `target is readonly` éliminés.


## 📸 Captures d'écran
Sans objet

## 🚨 Notes pour la mise en production
- Rien à signaler