### PR TITLE
#minor (2724) Masquer les numéros de téléphone aux utilisateurs non-administrateurs

### DIFF
--- a/packages/api/server/controllers/action/create/action.create.ts
+++ b/packages/api/server/controllers/action/create/action.create.ts
@@ -1,7 +1,8 @@
 import actionService from '#server/services/action/actionService';
 import userService from '#server/services/user/index';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     insert_action_error: { code: 500, message: 'Une erreur est survenue lors de l\'écriture en base de données' },
     action_fetch_error: { code: 500, message: 'Une erreur est survenue lors de la vérification d\'écriture en base de données' },

--- a/packages/api/server/controllers/action/createComment/action.createComment.ts
+++ b/packages/api/server/controllers/action/createComment/action.createComment.ts
@@ -1,7 +1,8 @@
 import actionService from '#server/services/action/actionService';
 import can from '#server/utils/permission/can';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     write_fail: { code: 500, message: 'Une erreur est survenue lors de l\'écriture en base de données' },
     upload_failed: { code: 500, message: 'L\'enregistrement des pièces jointes a échoué.' },
     commit_failed: { code: 500, message: 'L\'enregistrement du commentaire et/ou des pièces jointes a échoué.' },

--- a/packages/api/server/controllers/action/get/action.get.ts
+++ b/packages/api/server/controllers/action/get/action.get.ts
@@ -1,6 +1,7 @@
 import actionService from '#server/services/action/actionService';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
 

--- a/packages/api/server/controllers/action/getHistory/action.getHistory.ts
+++ b/packages/api/server/controllers/action/getHistory/action.getHistory.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from 'express';
 import actionService from '#server/services/action/actionService';
 import { User } from '#root/types/resources/User.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     fetch_failed: { code: 500, message: 'Une erreur est survenue lors de la récupération de l\'historique' },
 };

--- a/packages/api/server/controllers/action/getHistory/action.getHistory.ts
+++ b/packages/api/server/controllers/action/getHistory/action.getHistory.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import actionService from '#server/services/action/actionService';
-import { User } from '#root/types/resources/User.d';
 import { ControllerErrors } from '#server/errors/ControllerErrors';
+import { User } from '#root/types/resources/User.d';
 
 const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },

--- a/packages/api/server/controllers/action/list/action.list.ts
+++ b/packages/api/server/controllers/action/list/action.list.ts
@@ -1,6 +1,7 @@
 import actionService from '#server/services/action/actionService';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     fetch_failed: { code: 500, message: 'Impossible de récupérer les actions' },
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };

--- a/packages/api/server/controllers/action/requestPilot/action.requestPilot.ts
+++ b/packages/api/server/controllers/action/requestPilot/action.requestPilot.ts
@@ -1,6 +1,7 @@
 import actionService from '#server/services/action/actionService';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
 

--- a/packages/api/server/controllers/action/update/action.update.ts
+++ b/packages/api/server/controllers/action/update/action.update.ts
@@ -1,8 +1,9 @@
 import actionService from '#server/services/action/actionService';
 import userService from '#server/services/user/index';
 import can from '#server/utils/permission/can';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     action_insert_error: { code: 500, message: 'Une erreur est survenue lors de l\'écriture en base de données' },
     action_fetch_error: { code: 500, message: 'Une erreur est survenue lors de la vérifiation d\'écriture en base de données' },

--- a/packages/api/server/controllers/config/get/config.get.ts
+++ b/packages/api/server/controllers/config/get/config.get.ts
@@ -1,12 +1,13 @@
 import configService from '#server/services/config/index';
 import { NextFunction, Request, Response } from 'express';
 import { User } from '#root/types/resources/User.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
 interface ConfigListRequest extends Request {
     user: User
 }
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     fetch_failed: { code: 500, message: 'Une erreur est survenue lors de la lecture en base de données' },
 };

--- a/packages/api/server/controllers/config/get/config.get.ts
+++ b/packages/api/server/controllers/config/get/config.get.ts
@@ -1,7 +1,7 @@
 import configService from '#server/services/config/index';
 import { NextFunction, Request, Response } from 'express';
-import { User } from '#root/types/resources/User.d';
 import { ControllerErrors } from '#server/errors/ControllerErrors';
+import { User } from '#root/types/resources/User.d';
 
 interface ConfigListRequest extends Request {
     user: User

--- a/packages/api/server/controllers/contact/create/contact.create.ts
+++ b/packages/api/server/controllers/contact/create/contact.create.ts
@@ -2,9 +2,9 @@ import { Request, Response } from 'express';
 
 import userService from '#server/services/user/index';
 import contactService from '#server/services/contact/index';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 import { User } from '#root/types/resources/User.d';
 import { ContactBody } from '#root/types/inputs/ContactBody.d';
-import { ControllerErrors } from '#server/errors/ControllerErrors';
 
 interface ContactRequest extends Request {
     body: ContactBody,

--- a/packages/api/server/controllers/contact/create/contact.create.ts
+++ b/packages/api/server/controllers/contact/create/contact.create.ts
@@ -4,12 +4,13 @@ import userService from '#server/services/user/index';
 import contactService from '#server/services/contact/index';
 import { User } from '#root/types/resources/User.d';
 import { ContactBody } from '#root/types/inputs/ContactBody.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
 interface ContactRequest extends Request {
     body: ContactBody,
 }
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     insert_failed: { code: 500, message: 'Une erreur est survenue lors de l\'enregistrement de votre demande en base de données' },
 };

--- a/packages/api/server/controllers/directoryView/create/directoryView.create.ts
+++ b/packages/api/server/controllers/directoryView/create/directoryView.create.ts
@@ -1,35 +1,26 @@
-import organizationModel from '#server/models/organizationModel/index';
-import statsDirectoryViewsModel from '#server/models/statsDirectoryViewsModel';
+import directoryViewService from '#server/services/directoryView/directoryViewService';
 
-export default async (req, res, next) => {
-    const organizationId = parseInt(req.body.organization, 10);
-
-    try {
-        const organization = await organizationModel.findOneById(organizationId);
-
-        if (organization === null) {
-            return res.status(400).send({
-                user_message: 'La structure consultée n\'a pas été trouvéee en base de données',
-            });
-        }
-    } catch (error) {
-        res.status(500).send({
-            user_message: 'Une erreur est survenue lors de la lecture en base de données',
-        });
-        return next(error);
-    }
-
-    try {
-        await statsDirectoryViewsModel.create(
-            organizationId,
-            req.user.id,
-        );
-    } catch (error) {
-        res.status(500).send({
-            user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
-        });
-        return next(error);
-    }
-
-    return res.status(201).send({});
+const ERRORS = {
+    organization_not_found: { code: 400, message: 'La structure consultée n\'a pas été trouvée en base de données' },
+    fetch_failed: { code: 500, message: 'Une erreur est survenue lors de la lecture en base de données' },
+    write_failed: { code: 500, message: 'Une erreur est survenue lors de l\'écriture en base de données' },
+    undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
+
+const create = async (req, res, next) => {
+    const organizationId = Number.parseInt(req.body.organization, 10);
+
+    try {
+        await directoryViewService.create(organizationId, req.user);
+        return res.status(201).send({});
+    } catch (error) {
+        const { code, message } = ERRORS[error?.code] ?? ERRORS.undefined;
+        res.status(code).send({
+            user_message: message,
+        });
+
+        return next(error?.nativeError ?? error);
+    }
+};
+
+export default create;

--- a/packages/api/server/controllers/directoryView/create/directoryView.create.ts
+++ b/packages/api/server/controllers/directoryView/create/directoryView.create.ts
@@ -1,6 +1,7 @@
 import directoryViewService from '#server/services/directoryView/directoryViewService';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     organization_not_found: { code: 400, message: 'La structure consultée n\'a pas été trouvée en base de données' },
     fetch_failed: { code: 500, message: 'Une erreur est survenue lors de la lecture en base de données' },
     write_failed: { code: 500, message: 'Une erreur est survenue lors de l\'écriture en base de données' },

--- a/packages/api/server/controllers/organization/get/organization.get.validator.ts
+++ b/packages/api/server/controllers/organization/get/organization.get.validator.ts
@@ -1,9 +1,11 @@
 /* eslint-disable newline-per-chained-call */
-import { param } from 'express-validator';
+import { param, query } from 'express-validator';
 import findOneById from '#server/models/organizationModel/findOneById';
 import { Organization } from '#root/types/resources/Organization.d';
 
 export default [
+    query('activeOnly').optional().toBoolean(),
+
     param('id')
         .if(value => value !== 'search' && value !== 'search-action-operators')
         .toInt()
@@ -11,10 +13,8 @@ export default [
         .custom(async (value, { req }) => {
             let organization: Organization;
             try {
-                organization = await findOneById(value, req.query.activeOnly === 'true', req.user);
-            } catch (error) {
-                // eslint-disable-next-line no-console
-                console.error('Une erreur est survenue lors de la lecture en base de données:', error);
+                organization = await findOneById(value, req.query.activeOnly ?? false, req.user);
+            } catch {
                 throw new Error('Une erreur est survenue lors de la lecture en base de données');
             }
 

--- a/packages/api/server/controllers/organization/get/organization.get.validator.ts
+++ b/packages/api/server/controllers/organization/get/organization.get.validator.ts
@@ -11,7 +11,7 @@ export default [
         .custom(async (value, { req }) => {
             let organization: Organization;
             try {
-                organization = await findOneById(value, req.query.activeOnly === 'true');
+                organization = await findOneById(value, req.query.activeOnly === 'true', req.user);
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error('Une erreur est survenue lors de la lecture en base de données:', error);

--- a/packages/api/server/controllers/organization/list/organization.list.ts
+++ b/packages/api/server/controllers/organization/list/organization.list.ts
@@ -1,17 +1,24 @@
-import getDirectory from '#server/models/organizationModel/getDirectory';
+import organizationService from '#server/services/organization/organizationService';
 
-export default async (req, res, next) => {
-    let organizations;
-    try {
-        organizations = await getDirectory();
-    } catch (error) {
-        res.status(500).send({
-            user_message: 'Une erreur est survenue lors de la lecture en base de données',
-        });
-        return next(error);
-    }
-
-    return res.status(200).send({
-        organizations,
-    });
+const ERRORS = {
+    fetch_failed: { code: 500, message: 'Une erreur est survenue lors de la lecture en base de données' },
+    undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
+
+const list = async (req, res, next) => {
+    try {
+        const organizations = await organizationService.getDirectory(req.user);
+        return res.status(200).send({
+            organizations,
+        });
+    } catch (error) {
+        const { code, message } = ERRORS[error?.code] ?? ERRORS.undefined;
+        res.status(code).send({
+            user_message: message,
+        });
+
+        return next(error?.nativeError ?? error);
+    }
+};
+
+export default list;

--- a/packages/api/server/controllers/organization/list/organization.list.ts
+++ b/packages/api/server/controllers/organization/list/organization.list.ts
@@ -1,6 +1,7 @@
 import organizationService from '#server/services/organization/organizationService';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     fetch_failed: { code: 500, message: 'Une erreur est survenue lors de la lecture en base de données' },
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };

--- a/packages/api/server/controllers/question/create/question.create.ts
+++ b/packages/api/server/controllers/question/create/question.create.ts
@@ -1,7 +1,8 @@
 import questionService from '#server/services/question';
 import { EnrichedQuestion } from '#root/types/resources/QuestionEnriched.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     insert_failed: { code: 500, message: 'Votre question n\'a pas pu être enregistrée.' },
     upload_failed: { code: 500, message: 'L\'enregistrement des pièces jointes a échoué.' },
     fetch_failed: { code: 500, message: 'Votre question a bien été enregistrée mais la liste des questions n\'a pas pu être actualisée.' },

--- a/packages/api/server/controllers/question/create/question.create.ts
+++ b/packages/api/server/controllers/question/create/question.create.ts
@@ -1,6 +1,6 @@
 import questionService from '#server/services/question';
-import { EnrichedQuestion } from '#root/types/resources/QuestionEnriched.d';
 import { ControllerErrors } from '#server/errors/ControllerErrors';
+import { EnrichedQuestion } from '#root/types/resources/QuestionEnriched.d';
 
 const ERRORS: ControllerErrors = {
     insert_failed: { code: 500, message: 'Votre question n\'a pas pu être enregistrée.' },

--- a/packages/api/server/controllers/question/createAnswer/question.createAnswer.ts
+++ b/packages/api/server/controllers/question/createAnswer/question.createAnswer.ts
@@ -1,7 +1,8 @@
 import answerService from '#server/services/answer';
 import { CreateAnswerServiceResponse } from '#server/services/answer/createAnswer';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     insert_failed: { code: 500, message: 'Votre réponse n\'a pas pu être enregistrée.' },
     upload_failed: { code: 500, message: 'L\'enregistrement des pièces jointes a échoué.' },
     fetch_failed: { code: 500, message: 'Votre réponse a bien été enregistrée mais la liste des réponse n\'a pas pu être actualisée.' },

--- a/packages/api/server/controllers/question/moderateAnswer/question.moderateAnswer.ts
+++ b/packages/api/server/controllers/question/moderateAnswer/question.moderateAnswer.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Request, Response } from 'express';
 import deleteAnswer from '#server/services/answer/deleteAnswer';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 import { RawAnswer } from '#root/types/resources/AnswerRaw.d';
 import { EnrichedQuestion } from '#root/types/resources/QuestionEnriched.d';
-import { ControllerErrors } from '#server/errors/ControllerErrors';
 
 interface DeleteAnswerRequest extends Request {
     answer: RawAnswer,

--- a/packages/api/server/controllers/question/moderateAnswer/question.moderateAnswer.ts
+++ b/packages/api/server/controllers/question/moderateAnswer/question.moderateAnswer.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express';
 import deleteAnswer from '#server/services/answer/deleteAnswer';
 import { RawAnswer } from '#root/types/resources/AnswerRaw.d';
 import { EnrichedQuestion } from '#root/types/resources/QuestionEnriched.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
 interface DeleteAnswerRequest extends Request {
     answer: RawAnswer,
@@ -11,7 +12,7 @@ interface DeleteAnswerRequest extends Request {
     },
 }
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     delete_failed: { code: 500, message: 'Une erreur est survenue lors de la suppression de la réponse' },
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };

--- a/packages/api/server/controllers/question/update/question.update.ts
+++ b/packages/api/server/controllers/question/update/question.update.ts
@@ -1,9 +1,9 @@
 import questionService from '#server/services/question';
 import { Request } from 'express';
 import enrichQuestion from '#server/services/question/common/enrichQuestion';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 import { User } from '#root/types/resources/User.d';
 import { EnrichedQuestion } from '#root/types/resources/QuestionEnriched.d';
-import { ControllerErrors } from '#server/errors/ControllerErrors';
 
 interface QuestionUpdateRequest extends Request {
     user: User;

--- a/packages/api/server/controllers/question/update/question.update.ts
+++ b/packages/api/server/controllers/question/update/question.update.ts
@@ -3,13 +3,14 @@ import { Request } from 'express';
 import enrichQuestion from '#server/services/question/common/enrichQuestion';
 import { User } from '#root/types/resources/User.d';
 import { EnrichedQuestion } from '#root/types/resources/QuestionEnriched.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
 interface QuestionUpdateRequest extends Request {
     user: User;
     question: EnrichedQuestion;
 }
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
 

--- a/packages/api/server/controllers/shantytown/createComment/shantytown.createComment.validator.ts
+++ b/packages/api/server/controllers/shantytown/createComment/shantytown.createComment.validator.ts
@@ -11,9 +11,7 @@ export default [
             let shantytown;
             try {
                 shantytown = await shantytownModel.findOne(req.user, value);
-            } catch (error) {
-                // eslint-disable-next-line no-console
-                console.error(error);
+            } catch {
                 throw new Error('Impossible de retrouver le site concerné en base de données');
             }
 
@@ -127,9 +125,7 @@ export default [
                     fullTags = await commentTagModel.find({
                         ids: value,
                     });
-                } catch (error) {
-                    // eslint-disable-next-line no-console
-                    console.error(error);
+                } catch {
                     throw new Error('Une erreur de lecture en base de données est survenue lors de la validation du champ "Tags"');
                 }
 

--- a/packages/api/server/controllers/shantytown/createComment/shantytown.createComment.validator.ts
+++ b/packages/api/server/controllers/shantytown/createComment/shantytown.createComment.validator.ts
@@ -60,11 +60,11 @@ export default [
         .if((value, { req }) => req.body.targets?.mode && req.body.targets.mode !== 'public')
         .isArray().bail().withMessage('Le format des structures ciblées n\'est pas valide')
         .if(value => value.length > 0)
-        .custom(async (value) => {
+        .custom(async (value, { req }) => {
             // on vérifie, à minima, que les structures existent
             // il faudrait également vérifier que les structures en question ont l'accès en lecture
             // au site concerné par le commentaire (@todo)
-            const organizations = await organizationModel.findByIds(value.map(({ id }) => id));
+            const organizations = await organizationModel.findByIds(value.map(({ id }) => id), false, req.user);
             if (organizations.length !== value.length) {
                 throw new Error('Une ou plusieurs structures ciblées n\'existent pas');
             }
@@ -74,7 +74,7 @@ export default [
 
     body('targets.users')
         .customSanitizer((value, { req }) => {
-            if (!req.body.targets || req.body.targets.mode !== 'custom') {
+            if (req.body.targets?.mode !== 'custom') {
                 return [];
             }
 

--- a/packages/api/server/controllers/territory/get/territory.get.ts
+++ b/packages/api/server/controllers/territory/get/territory.get.ts
@@ -1,7 +1,8 @@
 import { NextFunction, Request, Response } from 'express';
 import territoryService from '#server/services/territory/index';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     fetch_failed: { code: 500, message: 'Une erreur est survenue lors de la récupération des départements' },
 };

--- a/packages/api/server/controllers/user/_common/user.write.validator.ts
+++ b/packages/api/server/controllers/user/_common/user.write.validator.ts
@@ -10,7 +10,7 @@ import { Organization } from '#root/types/resources/Organization.d';
 
 const { body } = expressValidator;
 
-export default (
+const createUserWriteValidator = (
     additionalValidators: ValidationChain[] = [],
     isAUserCreationCallback: CustomValidator = (() => true),
 ) => ([
@@ -151,7 +151,7 @@ export default (
 
             let organization: Organization;
             try {
-                organization = await organizationModel.findOneById(value);
+                organization = await organizationModel.findOneById(value, false, req.user);
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error(error);
@@ -175,7 +175,7 @@ export default (
         .custom(async (value, { req }) => {
             let organization: Organization;
             try {
-                organization = await organizationModel.findOneById(value);
+                organization = await organizationModel.findOneById(value, false, req.user);
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error(error);
@@ -203,7 +203,7 @@ export default (
 
             let organization: Organization;
             try {
-                organization = await organizationModel.findOneById(value?.data?.id);
+                organization = await organizationModel.findOneById(value?.data?.id, false, req.user);
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error(error);
@@ -227,7 +227,7 @@ export default (
         .custom(async (value, { req }) => {
             let organization: Organization;
             try {
-                organization = await organizationModel.findOneById(value);
+                organization = await organizationModel.findOneById(value, false, req.user);
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error(error);
@@ -251,7 +251,7 @@ export default (
         .custom(async (value, { req }) => {
             let organization: Organization;
             try {
-                organization = await organizationModel.findOneById(value);
+                organization = await organizationModel.findOneById(value, false, req.user);
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error(error);
@@ -284,3 +284,5 @@ export default (
             return true;
         }),
 ]);
+
+export default createUserWriteValidator;

--- a/packages/api/server/controllers/user/anonimyze/user.anonymize.ts
+++ b/packages/api/server/controllers/user/anonimyze/user.anonymize.ts
@@ -1,7 +1,7 @@
 import userService from '#server/services/user/index';
 import { Request, NextFunction, Response } from 'express';
-import { User } from '#root/types/resources/User.d';
 import { ControllerErrors } from '#server/errors/ControllerErrors';
+import { User } from '#root/types/resources/User.d';
 
 const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },

--- a/packages/api/server/controllers/user/anonimyze/user.anonymize.ts
+++ b/packages/api/server/controllers/user/anonimyze/user.anonymize.ts
@@ -1,8 +1,9 @@
 import userService from '#server/services/user/index';
 import { Request, NextFunction, Response } from 'express';
 import { User } from '#root/types/resources/User.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     anonymization_failure: { code: 500, message: 'Une erreur est survenue lors de l\'anonymisation de l\'utilisateur.' },
     refresh_failure: { code: 500, message: 'Une erreur est survenue lors de la lecture des données en base' },

--- a/packages/api/server/controllers/user/deactivate/user.deactivate.ts
+++ b/packages/api/server/controllers/user/deactivate/user.deactivate.ts
@@ -1,7 +1,7 @@
 import userService from '#server/services/user/index';
 import { Request, NextFunction, Response } from 'express';
-import { User } from '#root/types/resources/User.d';
 import { ControllerErrors } from '#server/errors/ControllerErrors';
+import { User } from '#root/types/resources/User.d';
 
 const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },

--- a/packages/api/server/controllers/user/deactivate/user.deactivate.ts
+++ b/packages/api/server/controllers/user/deactivate/user.deactivate.ts
@@ -1,8 +1,9 @@
 import userService from '#server/services/user/index';
 import { Request, NextFunction, Response } from 'express';
 import { User } from '#root/types/resources/User.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     deactivation_permission_failure: { code: 500, message: 'Vous n\'avez pas la permission de désactiver ce compte' },
     deactivation_failure: { code: 500, message: 'Une erreur est survenue lors de la désactivation du compte' },

--- a/packages/api/server/controllers/user/reactivate/user.reactivate.ts
+++ b/packages/api/server/controllers/user/reactivate/user.reactivate.ts
@@ -1,7 +1,7 @@
 import userService from '#server/services/user/index';
 import { Request, NextFunction, Response } from 'express';
-import { User } from '#root/types/resources/User.d';
 import { ControllerErrors } from '#server/errors/ControllerErrors';
+import { User } from '#root/types/resources/User.d';
 
 const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },

--- a/packages/api/server/controllers/user/reactivate/user.reactivate.ts
+++ b/packages/api/server/controllers/user/reactivate/user.reactivate.ts
@@ -1,8 +1,9 @@
 import userService from '#server/services/user/index';
 import { Request, NextFunction, Response } from 'express';
 import { User } from '#root/types/resources/User.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
 

--- a/packages/api/server/controllers/user/refuseAccess/user.refuseAccess.ts
+++ b/packages/api/server/controllers/user/refuseAccess/user.refuseAccess.ts
@@ -1,6 +1,7 @@
 import userService from '#server/services/user/index';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
 

--- a/packages/api/server/controllers/user/sendActivationLink/user.sendActivationLink.ts
+++ b/packages/api/server/controllers/user/sendActivationLink/user.sendActivationLink.ts
@@ -1,7 +1,7 @@
 import sendActivationLink from '#server/services/user/sendActivationLink';
 import { NextFunction, Request, Response } from 'express';
-import { User } from '#root/types/resources/User.d';
 import { ControllerErrors } from '#server/errors/ControllerErrors';
+import { User } from '#root/types/resources/User.d';
 
 interface UserSendActivationLinkRequest extends Request {
     user: User,

--- a/packages/api/server/controllers/user/sendActivationLink/user.sendActivationLink.ts
+++ b/packages/api/server/controllers/user/sendActivationLink/user.sendActivationLink.ts
@@ -1,6 +1,7 @@
 import sendActivationLink from '#server/services/user/sendActivationLink';
 import { NextFunction, Request, Response } from 'express';
 import { User } from '#root/types/resources/User.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
 interface UserSendActivationLinkRequest extends Request {
     user: User,
@@ -10,7 +11,7 @@ interface UserSendActivationLinkRequest extends Request {
     },
 }
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
 };
 

--- a/packages/api/server/controllers/user/setExpertiseTopics/user.setExpertiseTopics.ts
+++ b/packages/api/server/controllers/user/setExpertiseTopics/user.setExpertiseTopics.ts
@@ -1,8 +1,9 @@
 import userService from '#server/services/user/index';
 import { Request, NextFunction, Response } from 'express';
 import { User } from '#root/types/resources/User.d';
+import { ControllerErrors } from '#server/errors/ControllerErrors';
 
-const ERRORS = {
+const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },
     user_update_failure: { code: 500, message: 'Une erreur est survenue lors de la mise à jour du compte' },
     topics_save_failure: { code: 500, message: 'Une erreur est survenue lors de l\'enregistrement des sujets en base de données' },

--- a/packages/api/server/controllers/user/setExpertiseTopics/user.setExpertiseTopics.ts
+++ b/packages/api/server/controllers/user/setExpertiseTopics/user.setExpertiseTopics.ts
@@ -1,7 +1,7 @@
 import userService from '#server/services/user/index';
 import { Request, NextFunction, Response } from 'express';
-import { User } from '#root/types/resources/User.d';
 import { ControllerErrors } from '#server/errors/ControllerErrors';
+import { User } from '#root/types/resources/User.d';
 
 const ERRORS: ControllerErrors = {
     undefined: { code: 500, message: 'Une erreur inconnue est survenue' },

--- a/packages/api/server/errors/ControllerErrors.ts
+++ b/packages/api/server/errors/ControllerErrors.ts
@@ -1,0 +1,10 @@
+export type ControllerErrors = {
+    [key: string]: {
+        code: number;
+        message: string;
+    };
+    undefined: {
+        code: number;
+        message: string;
+    };
+};

--- a/packages/api/server/models/actionModel/fetch/fetch.ts
+++ b/packages/api/server/models/actionModel/fetch/fetch.ts
@@ -44,8 +44,8 @@ export default async function fetch(user: User, actionIds?: number[], transactio
     const hash = hashActions(actions);
     mergeAddresses(hash, addresses);
     mergeTopics(hash, topics);
-    mergeManagers(hash, managers);
-    mergeOperators(hash, operators);
+    mergeManagers(hash, managers, user);
+    mergeOperators(hash, operators, user);
     computeActionNames(hash);
     mergeShantytowns(hash, shantytowns);
     mergeComments(hash, comments);

--- a/packages/api/server/models/actionModel/fetch/mergeManagers.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeManagers.ts
@@ -6,7 +6,7 @@ import { User } from '#root/types/resources/User.d';
 export default function mergeManagers(hash: ActionHash, managers: ActionUserRow[], requestingUser?: User): void {
     managers.forEach((row) => {
         const index = hash[row.action_id].managers.findIndex(({ id }) => id === row.organization_id);
-        const canViewPhone = requestingUser?.is_superuser === true || requestingUser?.is_admin === true;
+        const canViewPhone = requestingUser?.is_admin === true;
         const user: ActionOrganizationMember = {
             id: row.id,
             email: row.email,

--- a/packages/api/server/models/actionModel/fetch/mergeManagers.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeManagers.ts
@@ -1,17 +1,19 @@
 import { ActionHash } from './hashActions';
 import ActionUserRow from './ActionUserRow.d';
 import { ActionOrganizationMember } from '#root/types/resources/Action.d';
+import { User } from '#root/types/resources/User.d';
 
-export default function mergeManagers(hash: ActionHash, managers: ActionUserRow[]): void {
+export default function mergeManagers(hash: ActionHash, managers: ActionUserRow[], requestingUser?: User): void {
     managers.forEach((row) => {
         const index = hash[row.action_id].managers.findIndex(({ id }) => id === row.organization_id);
+        const canViewPhone = requestingUser?.is_superuser === true || requestingUser?.is_admin === true;
         const user: ActionOrganizationMember = {
             id: row.id,
             email: row.email,
             first_name: row.first_name,
             last_name: row.last_name,
             position: row.position,
-            phone: row.phone,
+            phone: canViewPhone ? row.phone : null,
             role: row.admin_role_name || row.regular_role_name,
             is_admin: row.admin_role_name !== null,
             organization: {

--- a/packages/api/server/models/actionModel/fetch/mergeOperators.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeOperators.ts
@@ -1,19 +1,22 @@
 import ActionUserRow from './ActionUserRow.d';
 import { ActionOrganizationMember, ActionOrganization } from '#root/types/resources/Action.d';
+import { User } from '#root/types/resources/User.d';
 
 export default function mergeOperators<T extends { operators: ActionOrganization[] }>(
     hash: { [key: number]: T },
     operators: ActionUserRow[],
+    requestingUser?: User,
 ): void {
     operators.forEach((row) => {
         const index = hash[row.action_id].operators.findIndex(({ id }) => id === row.organization_id);
+        const canViewPhone = requestingUser?.is_superuser === true || requestingUser?.is_admin === true;
         const user: ActionOrganizationMember = {
             id: row.id,
             email: row.email,
             first_name: row.first_name,
             last_name: row.last_name,
             position: row.position,
-            phone: row.phone,
+            phone: canViewPhone ? row.phone : null,
             role: row.admin_role_name || row.regular_role_name,
             is_admin: row.admin_role_name !== null,
             is_principal: row.is_principal,

--- a/packages/api/server/models/actionModel/fetch/mergeOperators.ts
+++ b/packages/api/server/models/actionModel/fetch/mergeOperators.ts
@@ -9,7 +9,7 @@ export default function mergeOperators<T extends { operators: ActionOrganization
 ): void {
     operators.forEach((row) => {
         const index = hash[row.action_id].operators.findIndex(({ id }) => id === row.organization_id);
-        const canViewPhone = requestingUser?.is_superuser === true || requestingUser?.is_admin === true;
+        const canViewPhone = requestingUser?.is_admin === true;
         const user: ActionOrganizationMember = {
             id: row.id,
             email: row.email,

--- a/packages/api/server/models/actionModel/fetchByShantytown/fetch.ts
+++ b/packages/api/server/models/actionModel/fetchByShantytown/fetch.ts
@@ -20,7 +20,7 @@ export default async function fetchByShantytown(user: User, shantytownIds: numbe
 
     const hash = hashActions(actions);
     mergeTopics(hash, topics);
-    mergeOperators(hash, operators);
+    mergeOperators(hash, operators, user);
     computeActionNames(hash);
 
     return Object.values(hash);

--- a/packages/api/server/models/organizationModel/_common/find.ts
+++ b/packages/api/server/models/organizationModel/_common/find.ts
@@ -3,7 +3,7 @@ import { sequelize } from '#db/sequelize';
 import hashAreas from '#server/models/interventionAreaModel/hash';
 import listInterventionAreas from '#server/models/interventionAreaModel/list';
 
-import { UserExpertiseTopic, UserExpertiseTopicType } from '#root/types/resources/User.d';
+import { User, UserExpertiseTopic, UserExpertiseTopicType } from '#root/types/resources/User.d';
 import { Organization } from '#root/types/resources/Organization.d';
 
 type OrganizationRow = {
@@ -35,7 +35,7 @@ type OrganizationFindOptions = {
     nonEmpty?: boolean,
 };
 
-export default async (options: OrganizationFindOptions = {}, transaction?: Transaction): Promise<Organization[]> => {
+export default async (options: OrganizationFindOptions = {}, requestingUser?: User, transaction?: Transaction): Promise<Organization[]> => {
     const where = [];
     const replacements: any = {};
     if (options.ids !== undefined && options.ids?.length > 0) {
@@ -130,6 +130,7 @@ export default async (options: OrganizationFindOptions = {}, transaction?: Trans
         }
 
         if (user.user_id !== null && (options.activeOnly ? user.user_status === 'active' && user.user_to_be_tracked : true)) {
+            const canViewPhone = requestingUser?.is_superuser === true || requestingUser?.is_admin === true;
             hash[user.organization_id].users.push({
                 id: user.user_id,
                 is_admin: user.user_role_admin !== null,
@@ -137,7 +138,7 @@ export default async (options: OrganizationFindOptions = {}, transaction?: Trans
                 first_name: user.user_firstName,
                 last_name: user.user_lastName,
                 email: user.user_email,
-                phone: user.user_phone,
+                phone: canViewPhone ? user.user_phone : null,
                 position: user.user_position,
                 expertise_topics: user.user_topics.map((topic): UserExpertiseTopic => {
                     const [uid, type, label] = topic.split(';') as [string, UserExpertiseTopicType, string];

--- a/packages/api/server/models/organizationModel/_common/find.ts
+++ b/packages/api/server/models/organizationModel/_common/find.ts
@@ -130,7 +130,7 @@ export default async (options: OrganizationFindOptions = {}, requestingUser?: Us
         }
 
         if (user.user_id !== null && (options.activeOnly ? user.user_status === 'active' && user.user_to_be_tracked : true)) {
-            const canViewPhone = requestingUser?.is_superuser === true || requestingUser?.is_admin === true;
+            const canViewPhone = requestingUser?.is_admin === true;
             hash[user.organization_id].users.push({
                 id: user.user_id,
                 is_admin: user.user_role_admin !== null,

--- a/packages/api/server/models/organizationModel/findByIds.ts
+++ b/packages/api/server/models/organizationModel/findByIds.ts
@@ -3,4 +3,6 @@ import find from './_common/find';
 import { Organization } from '#root/types/resources/Organization.d';
 import { User } from '#root/types/resources/User.d';
 
-export default (ids: number[], activeOnly: boolean = false, requestingUser?: User, transaction?: Transaction): Promise<Organization[]> => find({ ids, activeOnly }, requestingUser, transaction);
+const findByIds = (ids: number[], activeOnly: boolean = false, requestingUser?: User, transaction?: Transaction): Promise<Organization[]> => find({ ids, activeOnly }, requestingUser, transaction);
+
+export default findByIds;

--- a/packages/api/server/models/organizationModel/findByIds.ts
+++ b/packages/api/server/models/organizationModel/findByIds.ts
@@ -1,5 +1,6 @@
 import { type Transaction } from 'sequelize';
 import find from './_common/find';
 import { Organization } from '#root/types/resources/Organization.d';
+import { User } from '#root/types/resources/User.d';
 
-export default (ids: number[], activeOnly: boolean = false, transaction?: Transaction): Promise<Organization[]> => find({ ids, activeOnly }, transaction);
+export default (ids: number[], activeOnly: boolean = false, requestingUser?: User, transaction?: Transaction): Promise<Organization[]> => find({ ids, activeOnly }, requestingUser, transaction);

--- a/packages/api/server/models/organizationModel/findOneById.ts
+++ b/packages/api/server/models/organizationModel/findOneById.ts
@@ -1,8 +1,9 @@
 import { Transaction } from 'sequelize';
 import findByIds from './findByIds';
 import { Organization } from '#root/types/resources/Organization.d';
+import { User } from '#root/types/resources/User.d';
 
-export default async (id: number, activeOnly: boolean = false, transaction?: Transaction): Promise<Organization | null> => {
-    const result = await findByIds([id], activeOnly, transaction);
+export default async (id: number, activeOnly: boolean = false, requestingUser?: User, transaction?: Transaction): Promise<Organization | null> => {
+    const result = await findByIds([id], activeOnly, requestingUser, transaction);
     return result.length === 1 ? result[0] : null;
 };

--- a/packages/api/server/models/organizationModel/findOneById.ts
+++ b/packages/api/server/models/organizationModel/findOneById.ts
@@ -3,7 +3,9 @@ import findByIds from './findByIds';
 import { Organization } from '#root/types/resources/Organization.d';
 import { User } from '#root/types/resources/User.d';
 
-export default async (id: number, activeOnly: boolean = false, requestingUser?: User, transaction?: Transaction): Promise<Organization | null> => {
+const findOneById = async (id: number, activeOnly: boolean = false, requestingUser?: User, transaction?: Transaction): Promise<Organization | null> => {
     const result = await findByIds([id], activeOnly, requestingUser, transaction);
     return result.length === 1 ? result[0] : null;
 };
+
+export default findOneById;

--- a/packages/api/server/models/organizationModel/getDirectory.ts
+++ b/packages/api/server/models/organizationModel/getDirectory.ts
@@ -1,5 +1,6 @@
 import { type Transaction } from 'sequelize';
 import find from './_common/find';
 import { Organization } from '#root/types/resources/Organization.d';
+import { User } from '#root/types/resources/User.d';
 
-export default (transaction?: Transaction): Promise<Organization[]> => find({ activeOnly: true, nonEmpty: true }, transaction);
+export default (requestingUser?: User, transaction?: Transaction): Promise<Organization[]> => find({ activeOnly: true, nonEmpty: true }, requestingUser, transaction);

--- a/packages/api/server/models/organizationModel/getDirectory.ts
+++ b/packages/api/server/models/organizationModel/getDirectory.ts
@@ -3,4 +3,6 @@ import find from './_common/find';
 import { Organization } from '#root/types/resources/Organization.d';
 import { User } from '#root/types/resources/User.d';
 
-export default (requestingUser?: User, transaction?: Transaction): Promise<Organization[]> => find({ activeOnly: true, nonEmpty: true }, requestingUser, transaction);
+const getDirectory = (requestingUser?: User, transaction?: Transaction): Promise<Organization[]> => find({ activeOnly: true, nonEmpty: true }, requestingUser, transaction);
+
+export default getDirectory;

--- a/packages/api/server/models/organizationModel/index.ts
+++ b/packages/api/server/models/organizationModel/index.ts
@@ -10,6 +10,7 @@ import findJusticeReadersByShantytown from './findJusticeReadersByShantytown';
 import findJusticeReadersByUserId from './findJusticeReadersByUserId';
 import findOneById from './findOneById';
 import findPrefAndDdets from './findPrefAndDdets';
+import getDirectory from './getDirectory';
 import searchActionOperators from './searchActionOperators';
 
 export default {
@@ -25,5 +26,6 @@ export default {
     findJusticeReadersByUserId,
     findOneById,
     findPrefAndDdets,
+    getDirectory,
     searchActionOperators,
 };

--- a/packages/api/server/models/userModel/getAdminsFor.ts
+++ b/packages/api/server/models/userModel/getAdminsFor.ts
@@ -6,10 +6,10 @@ import getNationalAdmins from './_common/getNationalAdmins';
 const getAdminsFor = async (user: User): Promise<User[]> => {
     const admins: User[] = [];
     const mainAreas = user.intervention_areas.areas.filter(area => area.is_main_area);
-    const types: LocationType[] = mainAreas.map(area => area.type);
+    const types: Set<LocationType> = new Set(mainAreas.map(area => area.type));
 
     // si l'utilisateur est lié à au moins un département, on prévient les administrateurs de ce/ces départements
-    if (types.includes('city') || types.includes('departement') || types.includes('epci')) {
+    if (types.has('city') || types.has('departement') || types.has('epci')) {
         admins.push(
             ...await getLocalAdminsForDepartement(
                 mainAreas.filter(area => area.departement !== null).map(area => area.departement.code),
@@ -18,7 +18,7 @@ const getAdminsFor = async (user: User): Promise<User[]> => {
     }
 
     // si l'utilisateur est lié à une région, au national, ou qu'aucun admin local n'a été trouvé, on prévient les admins nationaux
-    if (types.includes('nation') || types.includes('region') || admins.length === 0) {
+    if (types.has('nation') || types.has('region') || admins.length === 0) {
         admins.push(
             ...await getNationalAdmins(),
         );

--- a/packages/api/server/models/userModel/getAdminsFor.ts
+++ b/packages/api/server/models/userModel/getAdminsFor.ts
@@ -3,7 +3,7 @@ import { LocationType } from '../geoModel/LocationType';
 import getLocalAdminsForDepartement from './_common/getLocalAdminsForDepartement';
 import getNationalAdmins from './_common/getNationalAdmins';
 
-export default async (user: User): Promise<User[]> => {
+const getAdminsFor = async (user: User): Promise<User[]> => {
     const admins: User[] = [];
     const mainAreas = user.intervention_areas.areas.filter(area => area.is_main_area);
     const types: LocationType[] = mainAreas.map(area => area.type);
@@ -26,3 +26,5 @@ export default async (user: User): Promise<User[]> => {
 
     return admins;
 };
+
+export default getAdminsFor;

--- a/packages/api/server/services/directoryView/create/create.ts
+++ b/packages/api/server/services/directoryView/create/create.ts
@@ -1,0 +1,25 @@
+import ServiceError from '#server/errors/ServiceError';
+import organizationModel from '#server/models/organizationModel/index';
+import statsDirectoryViewsModel from '#server/models/statsDirectoryViewsModel';
+import { User } from '#root/types/resources/User.d';
+
+const create = async (organizationId: number, requestingUser: User): Promise<void> => {
+    let organization;
+    try {
+        organization = await organizationModel.findOneById(organizationId, false, requestingUser);
+    } catch (error) {
+        throw new ServiceError('fetch_failed', error);
+    }
+
+    if (organization === null) {
+        throw new ServiceError('organization_not_found', new Error(`L'organisation ${organizationId} n'existe pas`));
+    }
+
+    try {
+        await statsDirectoryViewsModel.create(organizationId, requestingUser.id);
+    } catch (error) {
+        throw new ServiceError('write_failed', error);
+    }
+};
+
+export default create;

--- a/packages/api/server/services/directoryView/create/create.ts
+++ b/packages/api/server/services/directoryView/create/create.ts
@@ -2,9 +2,10 @@ import ServiceError from '#server/errors/ServiceError';
 import organizationModel from '#server/models/organizationModel/index';
 import statsDirectoryViewsModel from '#server/models/statsDirectoryViewsModel';
 import { User } from '#root/types/resources/User.d';
+import { Organization } from '#root/types/resources/Organization.d';
 
 const create = async (organizationId: number, requestingUser: User): Promise<void> => {
-    let organization;
+    let organization: Organization | null;
     try {
         organization = await organizationModel.findOneById(organizationId, false, requestingUser);
     } catch (error) {

--- a/packages/api/server/services/directoryView/directoryViewService.ts
+++ b/packages/api/server/services/directoryView/directoryViewService.ts
@@ -1,0 +1,5 @@
+import create from './create/create';
+
+export default {
+    create,
+};

--- a/packages/api/server/services/organization/create.spec.ts
+++ b/packages/api/server/services/organization/create.spec.ts
@@ -94,7 +94,7 @@ describe('services/organization/create', () => {
         const org = fakeOrganization({ id: 78 });
 
         createOrganization.resolves(42);
-        findOrganizationById.withArgs(42, false, transaction).resolves(org);
+        findOrganizationById.withArgs(42, false, undefined, transaction).resolves(org);
         const response = await create(42, {
             name: 'Test',
             abbreviation: 'TST',

--- a/packages/api/server/services/organization/create.ts
+++ b/packages/api/server/services/organization/create.ts
@@ -55,7 +55,7 @@ export default async (createdBy: number, input: OrganizationCreateInput): Promis
             intervention_areas: input.intervention_areas,
         }, transaction);
 
-        organization = await findOrganizationById(organizationId, false, transaction);
+        organization = await findOrganizationById(organizationId, false, undefined, transaction);
         await transaction.commit();
     } catch (error) {
         await transaction.rollback();

--- a/packages/api/server/services/organization/getDirectory/getDirectory.ts
+++ b/packages/api/server/services/organization/getDirectory/getDirectory.ts
@@ -1,0 +1,14 @@
+import ServiceError from '#server/errors/ServiceError';
+import getDirectoryModel from '#server/models/organizationModel/getDirectory';
+import { Organization } from '#root/types/resources/Organization.d';
+import { User } from '#root/types/resources/User.d';
+
+const getDirectory = async (requestingUser: User): Promise<Organization[]> => {
+    try {
+        return await getDirectoryModel(requestingUser);
+    } catch (error) {
+        throw new ServiceError('fetch_failed', error);
+    }
+};
+
+export default getDirectory;

--- a/packages/api/server/services/organization/organizationService.ts
+++ b/packages/api/server/services/organization/organizationService.ts
@@ -1,10 +1,12 @@
 import findJusticeReadersByLocation from './findJusticeReadersByLocation/findJusticeReadersByLocation';
+import getDirectory from './getDirectory/getDirectory';
 import search from './search/search';
 import listAll from './listAll/listAll';
 import searchActionOperators from './searchActionOperators/searchActionOperators';
 
 export default {
     findJusticeReadersByLocation,
+    getDirectory,
     search,
     listAll,
     searchActionOperators,

--- a/packages/frontend/webapp/src/components/CarteUtilisateur/CarteUtilisateur.vue
+++ b/packages/frontend/webapp/src/components/CarteUtilisateur/CarteUtilisateur.vue
@@ -37,9 +37,11 @@
                     >{{ user.email }}</Link
                 >
             </CarteUtilisateurDetailsIcon>
-            <CarteUtilisateurDetailsIcon v-if="user.phone" icon="phone">{{
-                user.phone
-            }}</CarteUtilisateurDetailsIcon>
+            <CarteUtilisateurDetailsIcon
+                v-if="user.phone && !hidePhone"
+                icon="phone"
+                >{{ user.phone }}</CarteUtilisateurDetailsIcon
+            >
         </div>
         <div
             v-if="user.expertise_topics?.length > 0"
@@ -96,6 +98,11 @@ const props = defineProps({
         default: true,
     },
     includeOrganization: {
+        type: Boolean,
+        required: false,
+        default: false,
+    },
+    hidePhone: {
         type: Boolean,
         required: false,
         default: false,

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionOperateur.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionOperateur.vue
@@ -19,17 +19,13 @@ import { defineProps, toRefs, computed } from "vue";
 import FicheSousRubrique from "@/components/FicheRubrique/FicheSousRubrique.vue";
 import CarteUtilisateur from "@/components/CarteUtilisateur/CarteUtilisateur.vue";
 import sortOperatorsByPrincipal from "@/utils/sortOperatorsByPrincipal";
-import { useUserStore } from "@/stores/user.store";
+import usePhoneVisibility from "@/composables/usePhoneVisibility";
 
 const props = defineProps({
     action: Object,
 });
 const { action } = toRefs(props);
-const userStore = useUserStore();
-
-const hidePhone = computed(() => {
-    return !userStore.user?.is_admin;
-});
+const { hidePhone } = usePhoneVisibility();
 const isDeactivatedUser = (user) =>
     user.first_name === "Utilisateur" && user.last_name === "Désactivé";
 const users = computed(() =>

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionOperateur.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionOperateur.vue
@@ -7,6 +7,7 @@
             :key="user.id"
             :user="user"
             :linkToUser="false"
+            :hidePhone="hidePhone"
             includeOrganization
         />
     </FicheSousRubrique>
@@ -18,11 +19,20 @@ import { defineProps, toRefs, computed } from "vue";
 import FicheSousRubrique from "@/components/FicheRubrique/FicheSousRubrique.vue";
 import CarteUtilisateur from "@/components/CarteUtilisateur/CarteUtilisateur.vue";
 import sortOperatorsByPrincipal from "@/utils/sortOperatorsByPrincipal";
+import { useUserStore } from "@/stores/user.store";
 
 const props = defineProps({
     action: Object,
 });
 const { action } = toRefs(props);
+const userStore = useUserStore();
+
+const hidePhone = computed(() => {
+    return (
+        !userStore.user?.is_admin &&
+        !userStore.user?.intervention_areas?.is_national
+    );
+});
 const isDeactivatedUser = (user) =>
     user.first_name === "Utilisateur" && user.last_name === "Désactivé";
 const users = computed(() =>

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionOperateur.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionOperateur.vue
@@ -28,10 +28,7 @@ const { action } = toRefs(props);
 const userStore = useUserStore();
 
 const hidePhone = computed(() => {
-    return (
-        !userStore.user?.is_admin &&
-        !userStore.user?.intervention_areas?.is_national
-    );
+    return !userStore.user?.is_admin;
 });
 const isDeactivatedUser = (user) =>
     user.first_name === "Utilisateur" && user.last_name === "Désactivé";

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionPilotes.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionPilotes.vue
@@ -7,6 +7,7 @@
             :key="user.id"
             :user="user"
             :linkToUser="false"
+            :hidePhone="hidePhone"
             includeOrganization
         />
         <div
@@ -40,6 +41,7 @@ import { defineProps, toRefs, computed, ref } from "vue";
 import FicheSousRubrique from "@/components/FicheRubrique/FicheSousRubrique.vue";
 import CarteUtilisateur from "@/components/CarteUtilisateur/CarteUtilisateur.vue";
 import { useActionsStore } from "@/stores/actions.store";
+import { useUserStore } from "@/stores/user.store";
 
 const props = defineProps({
     action: Object,
@@ -47,8 +49,16 @@ const props = defineProps({
 const { action } = toRefs(props);
 const loading = ref(false);
 const actionsStore = useActionsStore();
+const userStore = useUserStore();
+
+const hidePhone = computed(() => {
+    return (
+        !userStore.user?.is_admin &&
+        !userStore.user?.intervention_areas?.is_national
+    );
+});
 const users = computed(() => {
-    return action.value.managers.map(({ users }) => users).flat();
+    return action.value.managers.flatMap(({ users }) => users);
 });
 const onlyDeactivatedUsers = computed(() => {
     return (

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionPilotes.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionPilotes.vue
@@ -41,7 +41,7 @@ import { defineProps, toRefs, computed, ref } from "vue";
 import FicheSousRubrique from "@/components/FicheRubrique/FicheSousRubrique.vue";
 import CarteUtilisateur from "@/components/CarteUtilisateur/CarteUtilisateur.vue";
 import { useActionsStore } from "@/stores/actions.store";
-import { useUserStore } from "@/stores/user.store";
+import usePhoneVisibility from "@/composables/usePhoneVisibility";
 
 const props = defineProps({
     action: Object,
@@ -49,11 +49,7 @@ const props = defineProps({
 const { action } = toRefs(props);
 const loading = ref(false);
 const actionsStore = useActionsStore();
-const userStore = useUserStore();
-
-const hidePhone = computed(() => {
-    return !userStore.user?.is_admin;
-});
+const { hidePhone } = usePhoneVisibility();
 const users = computed(() => {
     return action.value.managers.flatMap(({ users }) => users);
 });

--- a/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionPilotes.vue
+++ b/packages/frontend/webapp/src/components/FicheAction/FicheActionContacts/FicheActionPilotes.vue
@@ -52,10 +52,7 @@ const actionsStore = useActionsStore();
 const userStore = useUserStore();
 
 const hidePhone = computed(() => {
-    return (
-        !userStore.user?.is_admin &&
-        !userStore.user?.intervention_areas?.is_national
-    );
+    return !userStore.user?.is_admin;
 });
 const users = computed(() => {
     return action.value.managers.flatMap(({ users }) => users);

--- a/packages/frontend/webapp/src/composables/usePhoneVisibility.js
+++ b/packages/frontend/webapp/src/composables/usePhoneVisibility.js
@@ -1,0 +1,12 @@
+import { computed } from "vue";
+import { useUserStore } from "@/stores/user.store";
+
+export default function usePhoneVisibility() {
+    const userStore = useUserStore();
+
+    const hidePhone = computed(() => {
+        return userStore.user?.is_admin !== true;
+    });
+
+    return { hidePhone };
+}


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/GRDthuOV/2724

## 🛠 Description de la PR

### Objectif
Restreindre l'affichage des numéros de téléphone des membres des structures : ils ne sont désormais visibles **que par les administrateurs**.

### Règle métier appliquée
Le téléphone d'un membre est visible **si et seulement si** l'utilisateur courant est administrateur (`is_admin`, c.-à-d. `fk_role` vaut `local_admin` ou `national_admin`).

**Note pour la revue** :
l'implémentation initiale utilisait `is_superuser || is_admin` côté back et `is_admin || intervention_areas.is_national` côté front. Ces deux conditions étaient **divergentes** (risque d'incohérence back/front). Elles ont été unifiées sur `is_admin` seul dans le commit `fix: unifier la règle...` :
    - `is_superuser` était redondant (tout `national_admin` est déjà `is_admin`) ;
    - la branche `is_national` a été retirée côté front.

### Changements

#### Backend
- Propagation d'un paramètre optionnel `requestingUser` dans le model `organization` (`find`, `findByIds`, `findOneById`, `getDirectory`) et dans le merge des membres d'action (`mergeManagers`, `mergeOperators`). Le téléphone est mis à `null` si
  l'utilisateur n'est pas admin.
- Transmission de `req.user` depuis les validators appelants (`organization.get`, `shantytown.createComment`, `user.write`).

#### Frontend
- Nouvelle prop `hidePhone` sur `CarteUtilisateur`, calculée dans `FicheActionOperateur` et `FicheActionPilotes`.

#### Refactorisation
- Extraction de la logique des contrôleurs `directoryView.create` et   `organization.list` vers des services dédiés levant des `ServiceError` (conformité aux patterns Controller => Service => Model).
- Ajout de `getDirectory` au barrel export du model `organization`.
- Nommage de la fabrique `createUserWriteValidator`  pour éviter l'alerte SonarQube S7726.

### Points d'attention pour la revue
- Les paramètres `requestingUser` sont **optionnels** : les appelants historiques qui ne  le passent pas masquent désormais le téléphone par défaut (comportement sûr, mais à   vérifier si un consommateur attendait le numéro).

## 📸 Captures d'écran
Sans objet

## 🚨 Notes pour la mise en production
- Rien à signaler