### PR TITLE
#patch (2716) Le filtre des conditions de vie doit prendre en compte "à améliorer"

### DIFF
--- a/packages/api/server/models/shantytownModel/getHistoryAtGivenDate.ts
+++ b/packages/api/server/models/shantytownModel/getHistoryAtGivenDate.ts
@@ -466,8 +466,8 @@ async function applyLivingConditionsFilters(serializedTowns: Shantytown[], livin
 
     const livingConditionsFilters = decodeURIComponent(livingConditionFilters).split(',');
 
-    return serializedTowns.filter(town => livingConditionsFilters.some(filter => filterToCondition[filter].some(key => !town.livingConditions[key]
-            || ['bad', 'toImprove', 'unknown'].includes(town.livingConditions[key].status.status))));
+    return serializedTowns.filter(town => livingConditionsFilters.some(filter => filterToCondition[filter].some(key => !town.livingConditions?.[key]
+            || ['bad', 'toImprove', 'unknown'].includes(town.livingConditions[key]?.status?.status))));
 }
 
 

--- a/packages/api/server/models/shantytownModel/getHistoryAtGivenDate.ts
+++ b/packages/api/server/models/shantytownModel/getHistoryAtGivenDate.ts
@@ -466,8 +466,8 @@ async function applyLivingConditionsFilters(serializedTowns: Shantytown[], livin
 
     const livingConditionsFilters = decodeURIComponent(livingConditionFilters).split(',');
 
-    return serializedTowns.filter(town => livingConditionsFilters.some(filter => filterToCondition[filter].some(key => town.livingConditions[key]
-            && ['bad', 'unknown'].includes(town.livingConditions[key].status.status))));
+    return serializedTowns.filter(town => livingConditionsFilters.some(filter => filterToCondition[filter].some(key => !town.livingConditions[key]
+            || ['bad', 'toImprove', 'unknown'].includes(town.livingConditions[key].status.status))));
 }
 
 

--- a/packages/api/server/services/shantytown/exportTowns.fetchCurrentData.ts
+++ b/packages/api/server/services/shantytown/exportTowns.fetchCurrentData.ts
@@ -112,8 +112,8 @@ export default async function fetchCurrentData(user: AuthUser, locations: Locati
 
         const livingConditionsFilters = decodeURIComponent(postSqlFilters.conditions).split(',');
 
-        towns = towns.filter(town => livingConditionsFilters.some(filter => filterToCondition[filter].some(key => town.livingConditions[key]
-                && ['bad', 'unknown'].includes(town.livingConditions[key].status.status))));
+        towns = towns.filter(town => livingConditionsFilters.some(filter => filterToCondition[filter].some(key => !town.livingConditions[key]
+                || ['bad', 'toImprove', 'unknown'].includes(town.livingConditions[key].status.status))));
     }
     const clauseGroup = where().can(user).do('read', 'action');
     const currentYear = moment(new Date()).format('YYYY');

--- a/packages/api/server/services/shantytown/exportTowns.fetchCurrentData.ts
+++ b/packages/api/server/services/shantytown/exportTowns.fetchCurrentData.ts
@@ -112,8 +112,8 @@ export default async function fetchCurrentData(user: AuthUser, locations: Locati
 
         const livingConditionsFilters = decodeURIComponent(postSqlFilters.conditions).split(',');
 
-        towns = towns.filter(town => livingConditionsFilters.some(filter => filterToCondition[filter].some(key => !town.livingConditions[key]
-                || ['bad', 'toImprove', 'unknown'].includes(town.livingConditions[key].status.status))));
+        towns = towns.filter(town => livingConditionsFilters.some(filter => filterToCondition[filter].some(key => !town.livingConditions?.[key]
+                || ['bad', 'toImprove', 'unknown'].includes(town.livingConditions[key]?.status?.status))));
     }
     const clauseGroup = where().can(user).do('read', 'action');
     const currentYear = moment(new Date()).format('YYYY');

--- a/packages/frontend/webapp/src/utils/filterShantytowns.js
+++ b/packages/frontend/webapp/src/utils/filterShantytowns.js
@@ -144,8 +144,8 @@ function checkConditions(shantytown, filters) {
 
         return filterToCondition[filter].some(
             (key) =>
-                shantytown.livingConditions[key] &&
-                ["bad", "unknown"].includes(
+                !shantytown.livingConditions[key] ||
+                ["bad", "toImprove", "unknown"].includes(
                     shantytown.livingConditions[key].status.status
                 )
         );

--- a/packages/frontend/webapp/src/utils/filterShantytowns.js
+++ b/packages/frontend/webapp/src/utils/filterShantytowns.js
@@ -144,9 +144,9 @@ function checkConditions(shantytown, filters) {
 
         return filterToCondition[filter].some(
             (key) =>
-                !shantytown.livingConditions[key] ||
+                !shantytown.livingConditions?.[key] ||
                 ["bad", "toImprove", "unknown"].includes(
-                    shantytown.livingConditions[key].status.status
+                    shantytown.livingConditions[key]?.status?.status
                 )
         );
     });


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/crWg4YzS/2716

## 🛠 Description de la PR

### Problème principal constaté
La fonction `checkConditions()` dans *filterShantytowns.js* ne filtre que les conditions avec les statuts "bad" ou "unknown", mais ne prend pas en compte les conditions absentes ou non renseignées:

```javascript
function checkConditions(shantytown, filters) {
    return filters.some((filter) => {
        let filterToCondition = {
            accessToSanitary: ["sanitary"],
            accessToWater: ["water"],
            accessToTrash: ["trash"],
            accessToElectricity: ["electricity"],
            vermin: ["vermin", "pest_animals"],
            firePreventionMeasures: ["firePrevention", "fire_prevention"],
        };
        return filterToCondition[filter].some(
            (key) =>
                shantytown.livingConditions[key] &&  // ❌ Exclut les conditions absentes
                ["bad", "unknown"].includes(
                    shantytown.livingConditions[key].status.status
                )
        );
    });
}
```

### Correction attendue
Le filtre doit inclure les sites où la condition est :
    - Non renseignée (status = "unknown")
    - Absente (livingConditions[key] === null/undefined)
    - À améliorer (status = "toImprove")
    - Mauvaise (status = "bad")

Le même bug existe dans 3 fichiers :
    - *filterShantytowns.js (frontend)*,
    - *exportTowns.fetchCurrentData.ts* (backend export actuel),
    - *getHistoryAtGivenDate.ts* (backend export historique)

### Autre problème constaté
il y a un delta entre le nombre de sites annoncés sur la liste des sites et ceux qui figurent dans l'export. 

Le problème est que le filtre backend peut exclure des sites dont `livingConditions` est complètement absent ou mal structuré, alors que le frontend les inclut.
Le frontend a le même problème ! Si `shantytown.livingConditions` est `null`, alors `shantytown.livingConditions[key]` retourne `undefined`, et l'accès à ` .status.status` génère un plantage.

### Correction
Le problème a été corrigé dans 3 fichiers en ajoutant l'optional chaining (?.) pour gérer les cas où `livingConditions` est `null` ou `undefined` :

## 📸 Captures d'écran
- Sans objet

## 🚨 Notes pour la mise en production
- Rien à signaler