### PR TITLE
#patch (2719) [Liste des sites] Permettre de trier par nom

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeName.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeName.vue
@@ -31,6 +31,6 @@ const props = defineProps({
 const { shantytown } = toRefs(props);
 
 const displayName = computed(() => {
-    return shantytown.value.name.replace(/^["']/, "");
+    return shantytown.value.name?.replace(/^["']/, "") || "";
 });
 </script>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeName.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeName.vue
@@ -1,11 +1,12 @@
 <template>
     <div class="text-md px-6">
         <div class="text-primary text-display-md font-bold">
-            <span class="font-bold">
-                {{ shantytown.addressSimple }}
-                <span v-if="shantytown.name">« {{ shantytown.name }} » </span>
+            <span v-if="shantytown.name" class="font-bold">
+                « {{ displayName }} » - {{ shantytown.addressSimple }}
+                {{ shantytown.city.name }} ({{ shantytown.departement.code }})
             </span>
-            <span class="font-normal">
+            <span v-else class="font-bold">
+                {{ shantytown.addressSimple }}
                 {{ shantytown.city.name }} ({{ shantytown.departement.code }})
             </span>
         </div>
@@ -19,7 +20,7 @@
 </template>
 
 <script setup>
-import { toRefs } from "vue";
+import { toRefs, computed } from "vue";
 import formatDate from "@common/utils/formatDate.js";
 import isSolved from "@/utils/isShantytownResorbed";
 import isClosed from "@/utils/isShantytownClosed";
@@ -28,4 +29,8 @@ const props = defineProps({
     shantytown: Object,
 });
 const { shantytown } = toRefs(props);
+
+const displayName = computed(() => {
+    return shantytown.value.name.replace(/^["']/, "");
+});
 </script>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeName.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeName.vue
@@ -2,7 +2,7 @@
     <div class="text-md px-6">
         <div class="text-primary text-display-md font-bold">
             <span v-if="shantytown.name" class="font-bold">
-                « {{ displayName }} » - {{ shantytown.addressSimple }}
+                « {{ shantytown.name }} » - {{ shantytown.addressSimple }}
                 {{ shantytown.city.name }} ({{ shantytown.departement.code }})
             </span>
             <span v-else class="font-bold">
@@ -20,7 +20,7 @@
 </template>
 
 <script setup>
-import { toRefs, computed } from "vue";
+import { toRefs } from "vue";
 import formatDate from "@common/utils/formatDate.js";
 import isSolved from "@/utils/isShantytownResorbed";
 import isClosed from "@/utils/isShantytownClosed";
@@ -29,8 +29,4 @@ const props = defineProps({
     shantytown: Object,
 });
 const { shantytown } = toRefs(props);
-
-const displayName = computed(() => {
-    return shantytown.value.name?.replace(/^["']/, "") || "";
-});
 </script>

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.tris.js
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSites.tris.js
@@ -3,6 +3,10 @@ export default {
         value: "cityName",
         label: "Commune",
     },
+    siteName: {
+        value: "siteName",
+        label: "Nom du site",
+    },
     builtAt: {
         value: "builtAt",
         label: "Date d'installation",

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesFiltres.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesFiltres.vue
@@ -165,14 +165,21 @@ const groupedFilters = computed(() => ({
     },
 }));
 const groupedSorts = {
-    open: [sorts.cityName, sorts.builtAt, sorts.updatedAt, sorts.declaredAt],
-    inProgress: [
+    open: [
         sorts.cityName,
+        sorts.siteName,
         sorts.builtAt,
         sorts.updatedAt,
         sorts.declaredAt,
     ],
-    close: [sorts.cityName, sorts.closedAt, sorts.updatedAt],
+    inProgress: [
+        sorts.cityName,
+        sorts.siteName,
+        sorts.builtAt,
+        sorts.updatedAt,
+        sorts.declaredAt,
+    ],
+    close: [sorts.cityName, sorts.siteName, sorts.closedAt, sorts.updatedAt],
 };
 
 const currentFilters = computed(() => {

--- a/packages/frontend/webapp/src/stores/towns.store.js
+++ b/packages/frontend/webapp/src/stores/towns.store.js
@@ -32,6 +32,7 @@ import filterShantytowns from "@/utils/filterShantytowns";
 import { deleteAttachment } from "@/api/attachments.api";
 import { getMostRecentComment } from "@/utils/townLastUpdateManager";
 import getSince from "@/utils/getSince";
+import computeSiteName from "@/utils/computeSiteName";
 
 const ITEMS_PER_PAGE = 20;
 
@@ -83,6 +84,14 @@ export const useTownsStore = defineStore("towns", () => {
                     return 1;
                 }
                 return 0;
+            };
+        }
+
+        if (sort.value === "siteName") {
+            return (a, b) => {
+                const nameA = computeSiteName(a);
+                const nameB = computeSiteName(b);
+                return nameA.localeCompare(nameB);
             };
         }
 

--- a/packages/frontend/webapp/src/utils/computeSiteName.js
+++ b/packages/frontend/webapp/src/utils/computeSiteName.js
@@ -1,0 +1,16 @@
+export default function computeSiteName(shantytown) {
+    if (shantytown.name) {
+        return shantytown.name.replace(/^["']/, "");
+    }
+
+    const parts = [
+        shantytown.addressSimple || "",
+        shantytown.city?.name || "",
+        shantytown.departement?.code ? `(${shantytown.departement.code})` : "",
+    ];
+
+    return parts
+        .filter((part) => part.trim() !== "")
+        .join(" ")
+        .trim();
+}

--- a/packages/frontend/webapp/src/utils/computeSiteName.js
+++ b/packages/frontend/webapp/src/utils/computeSiteName.js
@@ -1,6 +1,6 @@
 export default function computeSiteName(shantytown) {
     if (shantytown.name) {
-        return shantytown.name.replace(/^["']/, "");
+        return shantytown.name.replace(/^["'«»]/, "");
     }
 
     const parts = [


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/NZ8BVFMM/2719

## 🛠 Description de la PR
- Ajout d'un tri par nom de site
- Trier les sites de la liste des sites selon le critère "Par nom":
    - si le site a un nom (propriété facultative), c'est le nom qui est pris en compte pour le tri, sans les éventuels guillemets en début de nom,
    - si le nom n'est pas renseigné, on trie sur l'adresse.

### Impact sur la liste des sites
- Pour que le tri soit reflété dans la liste des sites, le nom affiché a été sensiblement modifié. Au lieu d'afficher l'adresse en première position suivi de l'éventuel nom du site, on affiche d'abord le nom du site entre guillemets typographiques, puis l'adresse après un tiret.

## 🚨 Notes pour la mise en production
- Rien à signaler