### PR TITLE
#minor (2723) Ajouter une phase "Diagnostic technique" parmi les phases initiales 

### DIFF
--- a/packages/api/db/migrations/30000113-01-add-technical-diagnosis-phase.js
+++ b/packages/api/db/migrations/30000113-01-add-technical-diagnosis-phase.js
@@ -1,0 +1,81 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            // 1. Insérer la nouvelle phase "Diagnostic technique" en position 4
+            await queryInterface.bulkInsert(
+                'preparatory_phases_toward_resorption',
+                [
+                    {
+                        uid: 'technical_diagnosis',
+                        name: 'Diagnostic technique',
+                        is_a_starting_phase: true,
+                        date_label: 'Réalisé',
+                        position: 2,
+                    },
+                ],
+                { transaction },
+            );
+
+            // 2. Mettre à jour les positions des phases existantes (décaler de +1 à partir de l'ancienne position 4)
+            const positionUpdates = [
+                { uid: 'social_assessment', newPosition: 3 },
+                { uid: 'political_validation', newPosition: 4 },
+                { uid: 'contract_preparation', newPosition: 5 },
+                { uid: 'land_equipment_development', newPosition: 6 },
+                { uid: 'family_information', newPosition: 7 },
+                { uid: 'contractualization_of_families', newPosition: 8 },
+                { uid: 'official_opening', newPosition: 9 },
+            ];
+
+            const updatePromises = positionUpdates.map(({ uid, newPosition }) => queryInterface.bulkUpdate(
+                'preparatory_phases_toward_resorption',
+                { position: newPosition },
+                { uid: { [Sequelize.Op.eq]: uid } },
+                { transaction },
+            ));
+
+            await Promise.all(updatePromises);
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            // 1. Supprimer la phase "Diagnostic technique"
+            await queryInterface.bulkDelete(
+                'preparatory_phases_toward_resorption',
+                { uid: 'technical_diagnosis' },
+                { transaction },
+            );
+
+            // 2. Restaurer les positions originales des phases existantes (décaler de -1 à partir de l'ancienne position 5)
+            const positionUpdates = [
+                { uid: 'social_assessment', newPosition: 2 },
+                { uid: 'political_validation', newPosition: 3 },
+                { uid: 'contract_preparation', newPosition: 4 },
+                { uid: 'land_equipment_development', newPosition: 5 },
+                { uid: 'family_information', newPosition: 6 },
+                { uid: 'contractualization_of_families', newPosition: 7 },
+                { uid: 'official_opening', newPosition: 8 },
+            ];
+
+            const updatePromises = positionUpdates.map(({ uid, newPosition }) => queryInterface.bulkUpdate(
+                'preparatory_phases_toward_resorption',
+                { position: newPosition },
+                { uid: { [Sequelize.Op.eq]: uid } },
+                { transaction },
+            ));
+
+            await Promise.all(updatePromises);
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+};

--- a/packages/api/db/migrations/30000113-01-add-technical-diagnosis-phase.js
+++ b/packages/api/db/migrations/30000113-01-add-technical-diagnosis-phase.js
@@ -2,7 +2,7 @@ module.exports = {
     up: async (queryInterface, Sequelize) => {
         const transaction = await queryInterface.sequelize.transaction();
         try {
-            // 1. Insérer la nouvelle phase "Diagnostic technique" en position 4
+            // 1. Insérer la nouvelle phase "Diagnostic technique" en position 2
             await queryInterface.bulkInsert(
                 'preparatory_phases_toward_resorption',
                 [
@@ -17,7 +17,7 @@ module.exports = {
                 { transaction },
             );
 
-            // 2. Mettre à jour les positions des phases existantes (décaler de +1 à partir de l'ancienne position 4)
+            // 2. Mettre à jour les positions des phases existantes (décaler de +1 à partir de l'ancienne position 2)
             const positionUpdates = [
                 { uid: 'social_assessment', newPosition: 3 },
                 { uid: 'political_validation', newPosition: 4 },
@@ -53,7 +53,7 @@ module.exports = {
                 { transaction },
             );
 
-            // 2. Restaurer les positions originales des phases existantes (décaler de -1 à partir de l'ancienne position 5)
+            // 2. Restaurer les positions originales des phases existantes (décaler de -1 à partir de l'ancienne position 3)
             const positionUpdates = [
                 { uid: 'social_assessment', newPosition: 2 },
                 { uid: 'political_validation', newPosition: 3 },

--- a/packages/api/db/migrations/30000113-02-initialize-technical-diagnosis-phase-for-existing-sites.js
+++ b/packages/api/db/migrations/30000113-02-initialize-technical-diagnosis-phase-for-existing-sites.js
@@ -6,8 +6,7 @@ module.exports = {
             // Insérer la phase 'Diagnostic technique' en cours pour tous les sites
             // dont la résorption a déjà démarré (présence d'une phase 'sociological_diagnosis')
             // et qui n'ont pas encore cette phase
-            // Le created_by est récupéré à partir de la phase 'sociological_diagnosis' du site
-            // completed_at = null : intention métier -> les utilisateurs doivent déclarer eux-mêmes l'état de cette phase pour les sites existants
+            // Le created_by et completed_at sont récupérés à partir de la phase 'sociological_diagnosis' du site
             await queryInterface.sequelize.query(
                 `INSERT INTO shantytown_preparatory_phases_toward_resorption
                     (fk_shantytown, fk_preparatory_phase, created_by, completed_at)
@@ -15,7 +14,7 @@ module.exports = {
                     s.fk_shantytown,
                     'technical_diagnosis',
                     s.created_by,
-                    NULL
+                    s.completed_at
                  FROM shantytown_preparatory_phases_toward_resorption s
                  WHERE s.fk_preparatory_phase = 'sociological_diagnosis'
                  AND NOT EXISTS (

--- a/packages/api/db/migrations/30000113-02-initialize-technical-diagnosis-phase-for-existing-sites.js
+++ b/packages/api/db/migrations/30000113-02-initialize-technical-diagnosis-phase-for-existing-sites.js
@@ -7,6 +7,7 @@ module.exports = {
             // dont la résorption a déjà démarré (présence d'une phase 'sociological_diagnosis')
             // et qui n'ont pas encore cette phase
             // Le created_by est récupéré à partir de la phase 'sociological_diagnosis' du site
+            // completed_at = null : intention métier -> les utilisateurs doivent déclarer eux-mêmes l'état de cette phase pour les sites existants
             await queryInterface.sequelize.query(
                 `INSERT INTO shantytown_preparatory_phases_toward_resorption
                     (fk_shantytown, fk_preparatory_phase, created_by, completed_at)

--- a/packages/api/db/migrations/30000113-02-initialize-technical-diagnosis-phase-for-existing-sites.js
+++ b/packages/api/db/migrations/30000113-02-initialize-technical-diagnosis-phase-for-existing-sites.js
@@ -1,0 +1,61 @@
+module.exports = {
+    up: async (queryInterface) => {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            // Insérer la phase 'Diagnostic technique' en cours pour tous les sites
+            // dont la résorption a déjà démarré (présence d'une phase 'sociological_diagnosis')
+            // et qui n'ont pas encore cette phase
+            // Le created_by est récupéré à partir de la phase 'sociological_diagnosis' du site
+            await queryInterface.sequelize.query(
+                `INSERT INTO shantytown_preparatory_phases_toward_resorption
+                    (fk_shantytown, fk_preparatory_phase, created_by, completed_at)
+                 SELECT
+                    s.fk_shantytown,
+                    'technical_diagnosis',
+                    s.created_by,
+                    NULL
+                 FROM shantytown_preparatory_phases_toward_resorption s
+                 WHERE s.fk_preparatory_phase = 'sociological_diagnosis'
+                 AND NOT EXISTS (
+                    SELECT 1
+                    FROM shantytown_preparatory_phases_toward_resorption t
+                    WHERE t.fk_shantytown = s.fk_shantytown
+                    AND t.fk_preparatory_phase = 'technical_diagnosis'
+                 )`,
+                { transaction },
+            );
+
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+
+    down: async (queryInterface) => {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            // Supprimer les phases 'technical_diagnosis' en cours ajoutées par cette migration
+            // pour les sites ayant une phase 'sociological_diagnosis'
+            await queryInterface.sequelize.query(
+                `DELETE FROM shantytown_preparatory_phases_toward_resorption td
+                 WHERE td.fk_preparatory_phase = 'technical_diagnosis'
+                 AND td.completed_at IS NULL
+                 AND EXISTS (
+                    SELECT 1
+                    FROM shantytown_preparatory_phases_toward_resorption s
+                    WHERE s.fk_shantytown = td.fk_shantytown
+                    AND s.fk_preparatory_phase = 'sociological_diagnosis'
+                 )`,
+                { transaction },
+            );
+
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+};

--- a/packages/api/server/config/preparatory_phases_toward_resorption.ts
+++ b/packages/api/server/config/preparatory_phases_toward_resorption.ts
@@ -1,0 +1,8 @@
+const STARTING_PHASE_UIDS = new Set([
+    'sociological_diagnosis',
+    'social_assessment',
+    'political_validation',
+    'technical_diagnosis',
+]);
+
+export default STARTING_PHASE_UIDS;

--- a/packages/api/server/models/preparatoryPhasesTowardResorptionModel/getAll.ts
+++ b/packages/api/server/models/preparatoryPhasesTowardResorptionModel/getAll.ts
@@ -8,6 +8,7 @@ export default async (startingPhasesOnly?: boolean): Promise<PreparatoryPhaseTow
             uid,
             name,
             is_a_starting_phase,
+            date_label,
             position
         FROM 
             preparatory_phases_toward_resorption pptr`;

--- a/packages/api/server/models/shantytownModel/_common/queryHelpers/processPreparatoryPhases.ts
+++ b/packages/api/server/models/shantytownModel/_common/queryHelpers/processPreparatoryPhases.ts
@@ -34,7 +34,7 @@ export default function processPreparatoryPhases(
                 .filter(p => INITIAL_PHASE_UIDS.has(p.preparatoryPhaseId))
                 .map(p => p.preparatoryPhaseId);
 
-            townsHash[shantytownId].hasInitialResorptionPhases = initialPhasesPresent.length === 4;
+            townsHash[shantytownId].hasInitialResorptionPhases = initialPhasesPresent.length === INITIAL_PHASE_UIDS.size;
         }
     });
     /* eslint-enable no-param-reassign */

--- a/packages/api/server/models/shantytownModel/_common/queryHelpers/processPreparatoryPhases.ts
+++ b/packages/api/server/models/shantytownModel/_common/queryHelpers/processPreparatoryPhases.ts
@@ -5,6 +5,7 @@ const INITIAL_PHASE_UIDS = new Set([
     'sociological_diagnosis',
     'social_assessment',
     'political_validation',
+    'technical_diagnosis',
 ]);
 
 type TownPhase = {
@@ -33,7 +34,7 @@ export default function processPreparatoryPhases(
                 .filter(p => INITIAL_PHASE_UIDS.has(p.preparatoryPhaseId))
                 .map(p => p.preparatoryPhaseId);
 
-            townsHash[shantytownId].hasInitialResorptionPhases = initialPhasesPresent.length === 3;
+            townsHash[shantytownId].hasInitialResorptionPhases = initialPhasesPresent.length === 4;
         }
     });
     /* eslint-enable no-param-reassign */

--- a/packages/api/server/models/shantytownModel/_common/queryHelpers/processPreparatoryPhases.ts
+++ b/packages/api/server/models/shantytownModel/_common/queryHelpers/processPreparatoryPhases.ts
@@ -1,12 +1,6 @@
+import STARTING_PHASE_UIDS from '#server/config/preparatory_phases_toward_resorption';
 import { ShantytownPreparatoryPhaseTowardResorption } from '#root/types/resources/ShantytownPreparatoryPhasesTowardResorption.d';
 import { Shantytown } from '#root/types/resources/Shantytown.d';
-
-const INITIAL_PHASE_UIDS = new Set([
-    'sociological_diagnosis',
-    'social_assessment',
-    'political_validation',
-    'technical_diagnosis',
-]);
 
 type TownPhase = {
     townId: number;
@@ -31,10 +25,10 @@ export default function processPreparatoryPhases(
             townsHash[shantytownId].preparatoryPhasesTowardResorption = validPhases;
 
             const initialPhasesPresent = validPhases
-                .filter(p => INITIAL_PHASE_UIDS.has(p.preparatoryPhaseId))
+                .filter(p => STARTING_PHASE_UIDS.has(p.preparatoryPhaseId))
                 .map(p => p.preparatoryPhaseId);
 
-            townsHash[shantytownId].hasInitialResorptionPhases = initialPhasesPresent.length === INITIAL_PHASE_UIDS.size;
+            townsHash[shantytownId].hasInitialResorptionPhases = initialPhasesPresent.length === STARTING_PHASE_UIDS.size;
         }
     });
     /* eslint-enable no-param-reassign */

--- a/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
+++ b/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
@@ -1254,11 +1254,12 @@ export default (closingSolutions: ClosingSolution[]) => {
                     return null;
                 }
 
-                // UIDs des phases initiales (définis dans la migration 30000084-03)
+                // UIDs des phases initiales (définis dans les migrations 30000084-03 et 30000113-01)
                 const STARTING_PHASE_UIDS = new Set([
                     'sociological_diagnosis',
                     'social_assessment',
                     'political_validation',
+                    'technical_diagnosis',
                 ]);
 
                 // Séparer les phases initiales des autres phases en utilisant l'UID

--- a/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
+++ b/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
@@ -1,6 +1,7 @@
 import dateUtils from '#server/utils/date';
 import userModel from '#server/models/userModel';
 import shantytownActorThemes from '#server/config/shantytown_actor_themes';
+import STARTING_PHASE_UIDS from '#server/config/preparatory_phases_toward_resorption';
 import config from '#server/config';
 import electricityAccessTypes from '#server/models/electricityAccessTypesModel/_common/electricityAccessTypes';
 import waterAccessTypes from '#server/models/_common/waterAccessTypes';
@@ -1253,14 +1254,6 @@ export default (closingSolutions: ClosingSolution[]) => {
                 if (!preparatoryPhasesTowardResorption || preparatoryPhasesTowardResorption.length === 0) {
                     return null;
                 }
-
-                // UIDs des phases initiales (définis dans les migrations 30000085-03 et 30000113-01)
-                const STARTING_PHASE_UIDS = new Set([
-                    'sociological_diagnosis',
-                    'social_assessment',
-                    'political_validation',
-                    'technical_diagnosis',
-                ]);
 
                 // Séparer les phases initiales des autres phases en utilisant l'UID
                 const startingPhases = preparatoryPhasesTowardResorption.filter(

--- a/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
+++ b/packages/api/server/services/shantytown/_common/serializeExportProperties.ts
@@ -1254,7 +1254,7 @@ export default (closingSolutions: ClosingSolution[]) => {
                     return null;
                 }
 
-                // UIDs des phases initiales (définis dans les migrations 30000084-03 et 30000113-01)
+                // UIDs des phases initiales (définis dans les migrations 30000085-03 et 30000113-01)
                 const STARTING_PHASE_UIDS = new Set([
                     'sociological_diagnosis',
                     'social_assessment',

--- a/packages/api/server/services/shantytown/export/option_section_resorption_phases.ts
+++ b/packages/api/server/services/shantytown/export/option_section_resorption_phases.ts
@@ -2,10 +2,9 @@ import {
     Paragraph, TextRun, SectionType,
 } from 'docx';
 
+import STARTING_PHASE_UIDS from '#server/config/preparatory_phases_toward_resorption';
 import heading from './heading';
 import formatDate from '../_common/formatDate';
-
-const STARTING_PHASE_UIDS = new Set(['sociological_diagnosis', 'social_assessment', 'political_validation', 'technical_diagnosis']);
 
 const buildResorptionPhasesSection = shantytown => ({
     properties: {

--- a/packages/api/server/services/shantytown/export/option_section_resorption_phases.ts
+++ b/packages/api/server/services/shantytown/export/option_section_resorption_phases.ts
@@ -67,7 +67,7 @@ const buildResorptionPhasesSection = shantytown => ({
 
                 phaseList.forEach(({ preparatoryPhaseName, preparatoryPhaseDateLabel, completedAt }) => {
                     const status = completedAt
-                        ? `${preparatoryPhaseDateLabel.toLowerCase()} ${formatDate(completedAt, 'DD/MM/YYYY')}`
+                        ? `${preparatoryPhaseDateLabel.toLowerCase()} ${formatDate(new Date(completedAt).getTime() / 1000, 'DD/MM/YYYY')}`
                         : 'en cours';
 
                     paragraphDescriptors.push({

--- a/packages/api/server/services/shantytown/export/option_section_resorption_phases.ts
+++ b/packages/api/server/services/shantytown/export/option_section_resorption_phases.ts
@@ -5,7 +5,7 @@ import {
 import heading from './heading';
 import formatDate from '../_common/formatDate';
 
-const STARTING_PHASE_UIDS = new Set(['sociological_diagnosis', 'social_assessment', 'political_validation']);
+const STARTING_PHASE_UIDS = new Set(['sociological_diagnosis', 'social_assessment', 'political_validation', 'technical_diagnosis']);
 
 const buildResorptionPhasesSection = shantytown => ({
     properties: {

--- a/packages/api/test/utils/shantytown.ts
+++ b/packages/api/test/utils/shantytown.ts
@@ -172,6 +172,7 @@ export const updateInput = () => ({
         sociological_diagnosis: globalThis.generate('string'),
         social_assessment: globalThis.generate('string'),
         political_validation: globalThis.generate('string'),
+        technical_diagnosis: globalThis.generate('string'),
         contract_preparation: globalThis.generate('string'),
     },
     updated_without_any_change: false,

--- a/packages/api/types/resources/PreparatoryPhaseTowardResorption.d.ts
+++ b/packages/api/types/resources/PreparatoryPhaseTowardResorption.d.ts
@@ -2,5 +2,6 @@ export type PreparatoryPhaseTowardResorption = {
     uid: string,
     name: string,
     isAStartingPhase: boolean,
+    dateLabel: string,
     position: number,
 };

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteResorption/FicheSiteResorptionPhasesInitiales.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteResorption/FicheSiteResorptionPhasesInitiales.vue
@@ -2,7 +2,7 @@
     <div class="bg-G100">
         <div class="mb-4 pl-2 p-1 text-lg font-bold">Phases Initiales</div>
         <div
-            class="grid md:grid-cols-2 lg:grid-cols-4 justify-between items-center gap-2 mb-2"
+            class="grid lg:grid-cols-2 xl:grid-cols-4 justify-between items-center gap-2 mb-2"
         >
             <CartePhaseResorption
                 v-for="phase in phases_initiales"

--- a/packages/frontend/webapp/src/components/FicheSite/FicheSiteResorption/FicheSiteResorptionPhasesInitiales.vue
+++ b/packages/frontend/webapp/src/components/FicheSite/FicheSiteResorption/FicheSiteResorptionPhasesInitiales.vue
@@ -2,7 +2,7 @@
     <div class="bg-G100">
         <div class="mb-4 pl-2 p-1 text-lg font-bold">Phases Initiales</div>
         <div
-            class="grid md:grid-cols-3 justify-between items-center gap-2 mb-2"
+            class="grid md:grid-cols-2 lg:grid-cols-4 justify-between items-center gap-2 mb-2"
         >
             <CartePhaseResorption
                 v-for="phase in phases_initiales"

--- a/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
+++ b/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue
@@ -4,7 +4,7 @@
             {{ phase.name }}
             <DsfrBadge
                 v-if="completedDate"
-                label="Réalisée"
+                :label="phase.date_label"
                 type="success"
                 small
             />
@@ -20,7 +20,7 @@
                 :options="[
                     { label: 'Non démarrée', value: 'not_started' },
                     { label: 'En cours', value: 'started' },
-                    { label: 'Terminée', value: 'completed' },
+                    { label: phase.date_label, value: 'completed' },
                 ]"
                 v-model="phaseStatus"
                 :disabled="


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/gZCLP7U4/2723

## 🛠 Description de la PR

### Contexte
 Cette PR ajoute la phase préparatoire **"Diagnostic technique"** au processus de résorption des sites et met à jour l'ensemble des emplacements impactés (modèle de données, API, exports, frontend).
 
### Changements
 
#### Base de données
- **Migration `30000113-01`** : création de la phase `technical_diagnosis` dans `preparatory_phases_toward_resorption` (position 2, `is_a_starting_phase = true`, `date_label = 'Réalisé'`) et décalage des positions des phases existantes.
- **Migration `30000113-02`** : initialisation de la phase `technical_diagnosis` pour les sites dont la résorption a déjà démarré (présence d'une phase `sociological_diagnosis`). L'auteur (`created_by`) et la date de réalisation (`completed_at`) sont récupérés depuis la phase `sociological_diagnosis` du site.
 
#### API
- Exposition du champ `date_label` dans la configuration des phases préparatoires ([getAll.ts](cci:7://file:///home/christophe/Documents/Professionnel/code/fabnum/rb-project/resorption-bidonvilles/packages/api/server/models/preparatoryPhasesTowardResorptionModel/getAll.ts:0:0-0:0) et type [PreparatoryPhaseTowardResorption](cci:2://file:///home/christophe/Documents/Professionnel/code/fabnum/rb-project/resorption-bidonvilles/packages/api/types/resources/PreparatoryPhaseTowardResorption.d.ts:0:0-6:2)).
- Mise à jour du calcul des phases initiales et du comptage dans [processPreparatoryPhases.ts](cci:7://file:///home/christophe/Documents/Professionnel/code/fabnum/rb-project/resorption-bidonvilles/packages/api/server/models/shantytownModel/_common/queryHelpers/processPreparatoryPhases.ts:0:0-0:0).
- Prise en compte de `technical_diagnosis` dans les exports Excel ([serializeExportProperties.ts](cci:7://file:///home/christophe/Documents/Professionnel/code/fabnum/rb-project/resorption-bidonvilles/packages/api/server/services/shantytown/_common/serializeExportProperties.ts:0:0-0:0)) et Word ([option_section_resorption_phases.ts](cci:7://file:///home/christophe/Documents/Professionnel/code/fabnum/rb-project/resorption-bidonvilles/packages/api/server/services/shantytown/export/option_section_resorption_phases.ts:0:0-0:0)).
- Correction du formatage des dates dans l'export Word des phases.
- Factorisation des UIDs des phases initiales dans [packages/api/server/config/preparatory_phases_toward_resorption.ts](cci:7://file:///home/christophe/Documents/Professionnel/code/fabnum/rb-project/resorption-bidonvilles/packages/api/server/config/preparatory_phases_toward_resorption.ts:0:0-0:0) et mise à jour des 3 imports consommateurs.
 
#### Frontend
- Adaptation de la grille des phases initiales ([FicheSiteResorptionPhasesInitiales.vue](cci:7://file:///home/christophe/Documents/Professionnel/code/fabnum/rb-project/resorption-bidonvilles/packages/frontend/webapp/src/components/FicheSite/FicheSiteResorption/FicheSiteResorptionPhasesInitiales.vue:0:0-0:0)) pour afficher 4 colonnes.
- Utilisation du `date_label` dans le formulaire d'édition des phases ([FormDeclarationDeSiteInputResorptionPhaseItem.vue](cci:7://file:///home/christophe/Documents/Professionnel/code/fabnum/rb-project/resorption-bidonvilles/packages/frontend/webapp/src/components/FormDeclarationDeSite/inputs/FormDeclarationDeSiteInputResorptionPhaseItem.vue:0:0-0:0)).
 
#### Tests & documentation
- Ajout de `technical_diagnosis` dans les fixtures de test.
- Correction et clarification de commentaires.

## 📸 Captures d'écran
<img width="1151" height="283" alt="image" src="https://github.com/user-attachments/assets/d184babd-dbc5-4e6f-8727-c9352c01de05" />

<img width="721" height="916" alt="{E3965A5E-A39F-4EA5-B88E-6CF1A8EA0462}" src="https://github.com/user-attachments/assets/e231ac66-9679-4197-983f-1d3dc795ff8b" />

## 🚨 Notes pour la mise en production
Exécuter les migrations:
    - 30000113-01-add-technical-diagnosis-phase.js
    - 30000113-02-initialize-technical-diagnosis-phase-for-existing-sites.js