### PR TITLE
#patch (2722) Remplacer l'option de tri "Nom de l'action" par "Opérateur"

### DIFF
--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActions.tris.js
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActions.tris.js
@@ -13,7 +13,7 @@ export default {
     },
     operatorName: {
         value: "operator_name",
-        label: "Nom de l'action",
+        label: "Opérateur",
     },
     projectName: {
         value: "project_name",


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/BbRYfHci/2722

## 🛠 Description de la PR
Dans la liste des valeurs de tri des actions, renommer la valeur “Nom de l’action” par “Opérateur”

## 📸 Captures d'écran
<img width="360" height="329" alt="{F377A652-3B43-422B-83CC-AFE4B363BE2A}" src="https://github.com/user-attachments/assets/37d516b1-7975-482c-9ae9-070392f35251" />

## 🚨 Notes pour la mise en production
- Rien à signaler