### PR TITLE
#patch (2721) Corriger le wording "dans les 6 derniers mois" sur la liste des actions

### DIFF
--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsStatistiques.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsStatistiques.vue
@@ -74,7 +74,7 @@
                                     small
                                 />
                                 des actions ont des indicateurs mis à jour dans
-                                6 derniers mois ({{
+                                les 6 derniers mois ({{
                                     updatedActionsInTheLastSixMonths
                                 }}
                                 actions sur {{ currentActionsCount }} )


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/4L4bYlG7/2721

## 🛠 Description de la PR
Correction du texte figurant dans le bandeau statistiques de la liste des actions. 
"x% des actions ont des indicateurs mis à jour dans 6 derniers" est corrigé en ajoutant "les" entre "dans" et "6 mois"

## 📸 Captures d'écran
<img width="445" height="20" alt="{5BDDFFCA-E7BD-49B4-80BA-211ED72C378E}" src="https://github.com/user-attachments/assets/0421023a-df0c-436d-8fca-8fc12eda91d1" />

## 🚨 Notes pour la mise en production
- Rien à signaler