### PR TITLE
#patch (2733) Correction du bouton LinkedIn sur la page déconnecté

### DIFF
--- a/packages/frontend/webapp/src/components/FormDeclarationAction/__tests__/indicateursErrorReset.spec.js
+++ b/packages/frontend/webapp/src/components/FormDeclarationAction/__tests__/indicateursErrorReset.spec.js
@@ -95,7 +95,7 @@ function mountForm(initialValues) {
             indicateursErrors.value = fieldResult.errors.reduce((acc, msg) => {
                 const match =
                     typeof msg === "string"
-                        ? /^FIELD:([^|]+)\|MESSAGE:(.+)$/.RegExp.exec(msg)
+                        ? /^FIELD:([^|]+)\|MESSAGE:(.+)$/.exec(msg)
                         : null;
                 if (match) {
                     acc[match[1]] = match[2];

--- a/packages/frontend/www/components/Layout/Layout.vue
+++ b/packages/frontend/www/components/Layout/Layout.vue
@@ -184,8 +184,7 @@ const followDatas = {
         label: 'LinkedIn',
         title: 'Page LinkedIn de la DIHAL - Ouverture dans une nouvelle fenêtre',
         icon: 'fr-icon-linkedin-box-fill',
-        href: 'https://fr.linkedin.com/company/dihal',
-        target: '_blank'
+        onClick: () => globalThis.window != undefined && globalThis.window.open('https://fr.linkedin.com/company/dihal', '_blank'),
       }
     ]
   }


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/Spi6x9QP/2733-bug-lien-linkedin-non-fonctionnel-sur-la-page-d%C3%A9connect%C3%A9

## 🛠 Description de la PR
Cette PR applique le correctif du bouton LinkedIn du footer à la page déconnecté.
Elle applique également un correctif bloquant le test `indicateursErrorReset.spec.js`.

## 📸 Captures d'écran
N/A

## 🚨 Notes pour la mise en production
RàS