### PR TITLE
#minor (2730) [Export des actions] Ajouter une colonne "Financée par la Dihal"

### DIFF
--- a/packages/api/server/models/actionModel/fetchReport/fetchReport.spec.ts
+++ b/packages/api/server/models/actionModel/fetchReport/fetchReport.spec.ts
@@ -75,4 +75,13 @@ describe('models/actionModel/fetchReport/fetchReport()', () => {
         expect(sql).to.include('finance_dedie');
         expect(sql).to.include('depense_finance_etatique');
     });
+
+    // ── Test 5 : financee_dihal présent dans la requête SQL (BOOL_OR) ────────
+    it('génère une requête SQL qui calcule financee_dihal avec BOOL_OR', async () => {
+        await fetchReport(YEAR);
+
+        const sql: string = queryStub.firstCall.args[0];
+        expect(sql).to.include('financee_dihal');
+        expect(sql).to.include('BOOL_OR(af.fk_action_finance_type = \'dedie\')');
+    });
 });

--- a/packages/api/server/models/actionModel/fetchReport/fetchReport.ts
+++ b/packages/api/server/models/actionModel/fetchReport/fetchReport.ts
@@ -40,7 +40,8 @@ export default function fetchReport(
                 NULL::numeric as "depense_finance_collectivite",
                 NULL::numeric as "depense_finance_europeen",
                 NULL::numeric as "depense_finance_prive",
-                NULL::numeric as "depense_finance_autre"
+                NULL::numeric as "depense_finance_autre",
+                NULL::boolean as "financee_dihal"
             WHERE FALSE
         )`;
     } else {
@@ -65,8 +66,9 @@ export default function fetchReport(
             NULLIF(SUM(CASE WHEN af.fk_action_finance_type = 'collectivite' THEN af.real_amount ELSE 0 END), 0) as "depense_finance_collectivite",
             NULLIF(SUM(CASE WHEN af.fk_action_finance_type = 'europeen' THEN af.real_amount ELSE 0 END), 0) as "depense_finance_europeen",
             NULLIF(SUM(CASE WHEN af.fk_action_finance_type = 'prive' THEN af.real_amount ELSE 0 END), 0) as "depense_finance_prive",
-            NULLIF(SUM(CASE WHEN af.fk_action_finance_type = 'autre' THEN af.real_amount ELSE 0 END), 0) as "depense_finance_autre"
-        FROM 
+            NULLIF(SUM(CASE WHEN af.fk_action_finance_type = 'autre' THEN af.real_amount ELSE 0 END), 0) as "depense_finance_autre",
+            BOOL_OR(af.fk_action_finance_type = 'dedie') as "financee_dihal"
+        FROM
             action_finances af
         LEFT JOIN actions ON af.fk_action = actions.action_id
         LEFT JOIN departements ON actions.fk_departement = departements.code
@@ -286,6 +288,7 @@ export default function fetchReport(
         sm.scolaire_mineur_scolarise_dans_annee,
         fi.finance_etatique,
         fi.finance_dedie,
+        fi.financee_dihal,
         fi.finance_collectivite,
         fi.finance_europeen,
         fi.finance_prive,

--- a/packages/api/server/services/action/exportActions.creerClasseurExcel.spec.ts
+++ b/packages/api/server/services/action/exportActions.creerClasseurExcel.spec.ts
@@ -58,6 +58,7 @@ function buildActionItem(override: Partial<ActionItemExtended> = {}): ActionItem
         depense_finance_europeen: null,
         depense_finance_prive: null,
         depense_finance_autre: null,
+        financee_dihal: false,
         comments: null,
         last_comment: null,
         last_comment_date: null,
@@ -361,5 +362,117 @@ describe('services/action/exportActions.creerClasseurExcel()', () => {
 
         expect(rowData[mineursIdentifiesTotalIndex]).to.equal(0);
         expect(rowData[mineursScolarisesTotalIndex]).to.equal(0);
+    });
+
+    // ── Test 10 : Section FINANCEMENT étendue jusqu'à AV6 ─────────────────────
+    it('étend la plage de la section FINANCEMENT jusqu\'en colonne AV (de AJ6 à AV6)', async () => {
+        const row = buildActionReportRow();
+        await exportActions([row], YEAR);
+
+        const financementSectionCall = mergeCellsStub.getCalls().find(
+            call => call.args[0] === 'AJ6',
+        );
+        expect(financementSectionCall, 'appel mergeCells pour la section FINANCEMENT non trouvé').to.exist;
+        expect(financementSectionCall.args[1]).to.equal('AV6');
+    });
+
+    // ── Test 11 : Section COMMENTAIRES déplacée vers AW6-AY6 ─────────────────
+    it('place la section COMMENTAIRES de AW6 à AY6 (après l\'ajout de la colonne DIHAL)', async () => {
+        const row = buildActionReportRow();
+        await exportActions([row], YEAR);
+
+        const commentairesSectionCall = mergeCellsStub.getCalls().find(
+            call => call.args[0] === 'AW6',
+        );
+        expect(commentairesSectionCall, 'appel mergeCells pour la section COMMENTAIRES non trouvé').to.exist;
+        expect(commentairesSectionCall.args[1]).to.equal('AY6');
+    });
+
+    // ── Test 12 : Section MISE À JOUR déplacée vers AZ6-BA6 ──────────────────
+    it('place la section MISE À JOUR de AZ6 à BA6 (après l\'ajout de la colonne DIHAL)', async () => {
+        const row = buildActionReportRow();
+        await exportActions([row], YEAR);
+
+        const miseAJourSectionCall = mergeCellsStub.getCalls().find(
+            call => call.args[0] === 'AZ6',
+        );
+        expect(miseAJourSectionCall, 'appel mergeCells pour la section MISE À JOUR non trouvé').to.exist;
+        expect(miseAJourSectionCall.args[1]).to.equal('BA6');
+    });
+
+    // ── Test 13 : Header "Financée par la DIHAL" présent à l'index 37 ────────
+    it('place le header "Financée par la DIHAL" à l\'index 37 (entre dépenses étatiques et crédits dédiés)', async () => {
+        const row = buildActionReportRow();
+        await exportActions([row], YEAR);
+
+        const call = findHeadersRowCall();
+        expect(call, 'appel addRow des headers non trouvé').to.exist;
+
+        const labels: string[] = call.args[0];
+        expect(labels[37]).to.equal('Financée par la DIHAL');
+        expect(labels[36]).to.equal('Dépense sur financement étatique hors crédits dédiés');
+        expect(labels[38]).to.equal('Crédits dédiés à la résorption des bidonvilles');
+    });
+
+    // ── Test 14 : Colonne financee_dihal affiche "Oui" quand true ────────────
+    it('affiche "Oui" dans la colonne financee_dihal quand la valeur est true', async () => {
+        const row = buildActionReportRow({ financee_dihal: true });
+        await exportActions([row], YEAR);
+
+        const call = findFirstDataRowCall();
+        expect(call, 'appel addRow des données non trouvé').to.exist;
+
+        const rowData: any[] = call.args[0];
+        // Index 37 dans rowData (35 colonnes avant financement + finance_etatique + depense_finance_etatique)
+        const financeDihalIndex = 37;
+        expect(rowData[financeDihalIndex]).to.equal('Oui');
+    });
+
+    // ── Test 15 : Colonne financee_dihal affiche "Non" quand false ───────────
+    it('affiche "Non" dans la colonne financee_dihal quand la valeur est false', async () => {
+        const row = buildActionReportRow({ financee_dihal: false });
+        await exportActions([row], YEAR);
+
+        const call = findFirstDataRowCall();
+        expect(call, 'appel addRow des données non trouvé').to.exist;
+
+        const rowData: any[] = call.args[0];
+        const financeDihalIndex = 37;
+        expect(rowData[financeDihalIndex]).to.equal('Non');
+    });
+
+    // ── Test 16 : Colonne financee_dihal affiche "Non" quand null ────────────
+    it('affiche "Non" dans la colonne financee_dihal quand la valeur est null', async () => {
+        const row = buildActionReportRow({ financee_dihal: null });
+        await exportActions([row], YEAR);
+
+        const call = findFirstDataRowCall();
+        expect(call, 'appel addRow des données non trouvé').to.exist;
+
+        const rowData: any[] = call.args[0];
+        const financeDihalIndex = 37;
+        expect(rowData[financeDihalIndex]).to.equal('Non');
+    });
+
+    // ── Test 17 : Colonne financee_dihal absente quand includeFinances = false ───
+    it('n\'inclut pas la colonne financee_dihal quand includeFinances est false', async () => {
+        const row = buildActionReportRow({ financee_dihal: true });
+        await exportActions([row], YEAR, false); // includeFinances = false
+
+        const headerCall = findHeadersRowCall();
+        expect(headerCall, 'appel addRow des headers non trouvé').to.exist;
+
+        const labels: string[] = headerCall.args[0];
+        expect(labels).to.not.include('Financée par la DIHAL');
+        expect(labels).to.not.include('Crédits dédiés à la résorption des bidonvilles');
+        expect(labels).to.not.include('Financement étatique hors crédits dédiés');
+
+        const dataCall = findFirstDataRowCall();
+        expect(dataCall, 'appel addRow des données non trouvé').to.exist;
+
+        const rowData: any[] = dataCall.args[0];
+        // Sans bloc financement, rowData contient 35 colonnes avant financement + 5 colonnes après (commentaires+mises à jour)
+        // donc 40 colonnes au total, pas 53 (qui serait avec les 13 colonnes de financement)
+        expect(rowData).to.have.lengthOf(40);
     });
 });

--- a/packages/api/server/services/action/exportActions.creerClasseurExcel.spec.ts
+++ b/packages/api/server/services/action/exportActions.creerClasseurExcel.spec.ts
@@ -475,4 +475,29 @@ describe('services/action/exportActions.creerClasseurExcel()', () => {
         // donc 40 colonnes au total, pas 53 (qui serait avec les 13 colonnes de financement)
         expect(rowData).to.have.lengthOf(40);
     });
+
+    // ── Test 18 : accès financement restreint à une liste d'actions ──────────
+    it('affiche "Oui"/"Non" pour financee_dihal quand l\'action fait partie des actions autorisées', async () => {
+        const row = buildActionReportRow({ action_id: 251, financee_dihal: true });
+        await exportActions([row], YEAR, true, null, [251, 410]);
+
+        const call = findFirstDataRowCall();
+        expect(call, 'appel addRow des données non trouvé').to.exist;
+
+        const rowData: any[] = call.args[0];
+        const financeDihalIndex = 37;
+        expect(rowData[financeDihalIndex]).to.equal('Oui');
+    });
+
+    it('affiche "-" pour financee_dihal quand l\'action ne fait pas partie des actions autorisées', async () => {
+        const row = buildActionReportRow({ action_id: 999, financee_dihal: true });
+        await exportActions([row], YEAR, true, null, [251, 410]);
+
+        const call = findFirstDataRowCall();
+        expect(call, 'appel addRow des données non trouvé').to.exist;
+
+        const rowData: any[] = call.args[0];
+        const financeDihalIndex = 37;
+        expect(rowData[financeDihalIndex]).to.equal('-');
+    });
 });

--- a/packages/api/server/services/action/exportActions.creerClasseurExcel.ts
+++ b/packages/api/server/services/action/exportActions.creerClasseurExcel.ts
@@ -36,9 +36,9 @@ const sectionTitles = [
     { name: 'EMPLOI', range: { from: 'Q6', to: 'R6' } },
     { name: 'HÉBERGEMENT/LOGEMENT', range: { from: 'S6', to: 'V6' } },
     { name: 'SCOLARISATION', range: { from: 'W6', to: 'AI6' } },
-    { name: 'FINANCEMENT', range: { from: 'AJ6', to: 'AU6' } },
-    { name: 'COMMENTAIRES', range: { from: 'AV6', to: 'AX6' } },
-    { name: 'MISE À JOUR', range: { from: 'AY6', to: 'AZ6' } },
+    { name: 'FINANCEMENT', range: { from: 'AJ6', to: 'AV6' } },
+    { name: 'COMMENTAIRES', range: { from: 'AW6', to: 'AY6' } },
+    { name: 'MISE À JOUR', range: { from: 'AZ6', to: 'BA6' } },
 ];
 
 const headers = [
@@ -79,6 +79,7 @@ const headers = [
     { label: 'Nombre de mineurs scolarisés: autre', width: '5' },
     { label: 'Financement étatique hors crédits dédiés', width: '5' },
     { label: 'Dépense sur financement étatique hors crédits dédiés', width: '5' },
+    { label: 'Financée par la DIHAL', width: '5' },
     { label: 'Crédits dédiés à la résorption des bidonvilles', width: '5' },
     { label: 'Dépense sur crédits dédiés à la résorption des bidonvilles', width: '5' },
     { label: 'Cofinancement collectivité territoriale', width: '5' },
@@ -356,6 +357,7 @@ function addDataToWorksheet(data: ActionItem[], worksheet: ExcelJS.Worksheet, in
             rowData.push(
                 formatNumericValue(item.finance_etatique),
                 formatNumericValue(item.depense_finance_etatique),
+                item.financee_dihal ? 'Oui' : 'Non',
                 formatNumericValue(item.finance_dedie),
                 formatNumericValue(item.depense_finance_dedie),
                 formatNumericValue(item.finance_collectivite),
@@ -421,7 +423,7 @@ function formatWorksheetCells(worksheet: ExcelJS.Worksheet, columnNumbers: numbe
 }
 
 function formatCommentCol(worksheet: ExcelJS.Worksheet) {
-    const commentsCol = worksheet.getColumn('AX');
+    const commentsCol = worksheet.getColumn('AW');
     commentsCol.eachCell((cell) => {
         if (cell.value) {
             formaterCommentaires(cell, cell.value);
@@ -494,8 +496,9 @@ export default function exportActions(
     }
 
     // Déterminer les headers à inclure selon les permissions
-    // Les colonnes de financement vont de l'index 36 (finance_etatique) à 47 (depense_finance_autre)
-    const headersToInclude = includeFinances ? headers : headers.filter((_, index) => index < 35 || index > 46);
+    // Les colonnes de financement vont de l'index 35 (finance_etatique) à 47 (depense_finance_autre)
+    // Maintenant avec la nouvelle colonne 'Financée par la DIHAL', elles vont de 35 à 47
+    const headersToInclude = includeFinances ? headers : headers.filter((_, index) => index < 35 || index > 47);
 
     // Trouver la section "FINANCEMENT" si elle existe
     const financementSection = includeFinances ? findSection('FINANCEMENT') : null;

--- a/packages/api/server/services/action/exportActions.creerClasseurExcel.ts
+++ b/packages/api/server/services/action/exportActions.creerClasseurExcel.ts
@@ -292,8 +292,10 @@ const formatNumericValue = (value: number | null | undefined): number | string =
     return value;
 };
 
+const formatBoolean = (value: boolean | null | undefined): string => (value ? 'Oui' : 'Non');
+
 // Ajouter les lignes de données
-function addDataToWorksheet(data: ActionItem[], worksheet: ExcelJS.Worksheet, includeFinances: boolean = true) {
+function addDataToWorksheet(data: ActionItem[], worksheet: ExcelJS.Worksheet, includeFinances: boolean = true, allowedFinanceActions: number[] | null = null) {
     data.forEach((item: ActionItem) => {
         // Calculs pour les colonnes de scolarisation
         const mineursIdentifiesTotal = sumNumbers([
@@ -312,6 +314,10 @@ function addDataToWorksheet(data: ActionItem[], worksheet: ExcelJS.Worksheet, in
             item.scolaire_nombre_college,
             item.scolaire_nombre_lycee,
         ]);
+
+        // Vérifier l'accès aux financements pour cette action spécifique
+        const hasFinanceAccessForThisAction = allowedFinanceActions === null || allowedFinanceActions.includes(item.action_id);
+        const financeeDihalValue = hasFinanceAccessForThisAction ? formatBoolean(item.financee_dihal) : '-';
 
         // Construire la ligne de données selon les permissions
         const rowData = [
@@ -357,7 +363,7 @@ function addDataToWorksheet(data: ActionItem[], worksheet: ExcelJS.Worksheet, in
             rowData.push(
                 formatNumericValue(item.finance_etatique),
                 formatNumericValue(item.depense_finance_etatique),
-                item.financee_dihal ? 'Oui' : 'Non',
+                financeeDihalValue,
                 formatNumericValue(item.finance_dedie),
                 formatNumericValue(item.depense_finance_dedie),
                 formatNumericValue(item.finance_collectivite),
@@ -475,6 +481,7 @@ export default function exportActions(
     fetchedYear: number,
     includeFinances: boolean = true,
     allowedDepartements: string[] | null = null,
+    allowedFinanceActions: number[] | null = null,
 ) {
     // Déterminer les sections à inclure selon les permissions
     let sectionsToInclude: SectionTitle[];
@@ -549,7 +556,7 @@ export default function exportActions(
         });
 
         // Ajouter les lignes de données
-        addDataToWorksheet(donneeParDepartement.data, worksheet, includeFinances);
+        addDataToWorksheet(donneeParDepartement.data, worksheet, includeFinances, allowedFinanceActions);
 
         // Formater toutes les cellules
         formatWorksheetCells(worksheet, columnNumbers, financementColumns);

--- a/packages/api/server/services/action/exportActions.generateExportFile.ts
+++ b/packages/api/server/services/action/exportActions.generateExportFile.ts
@@ -9,4 +9,5 @@ export default async function exportActions(
     fetchedYear: number,
     includeFinances: boolean = true,
     allowedDepartements: string[] | null = null,
-): Promise<ExcelJS.Buffer> { return creerClasseurExcel(data, fetchedYear, includeFinances, allowedDepartements); }
+    allowedFinanceActions: number[] | null = null,
+): Promise<ExcelJS.Buffer> { return creerClasseurExcel(data, fetchedYear, includeFinances, allowedDepartements, allowedFinanceActions); }

--- a/packages/api/server/services/action/exportActions.spec.ts
+++ b/packages/api/server/services/action/exportActions.spec.ts
@@ -1,0 +1,110 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import { rewiremock } from '#test/rewiremock';
+import { serialized as fakeUser } from '#test/utils/user';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+const sandbox = sinon.createSandbox();
+
+const stubs = {
+    getPermission: sandbox.stub(),
+    where: sandbox.stub(),
+    can: sandbox.stub(),
+    fetchReport: sandbox.stub(),
+    generateExportFile: sandbox.stub(),
+};
+
+rewiremock('#server/utils/permission').with({
+    getPermission: stubs.getPermission,
+    where: stubs.where,
+});
+rewiremock('#server/models/actionModel').with({
+    fetchReport: stubs.fetchReport,
+});
+rewiremock('./exportActions.generateExportFile').with(stubs.generateExportFile);
+
+rewiremock.enable();
+// eslint-disable-next-line import/newline-after-import, import/first
+import exportActions from './exportActions';
+rewiremock.disable();
+
+describe('services/action/exportActions()', () => {
+    let user;
+    const year = '2024';
+
+    beforeEach(() => {
+        sandbox.reset();
+        user = fakeUser();
+
+        stubs.where.returns({
+            can: stubs.can,
+        });
+        stubs.getPermission.returns('allowed');
+        stubs.fetchReport.resolves([
+            {
+                action_id: 1, action_name: 'Action de test', departement_code: '75', finance_dedie: 1000,
+            },
+        ]);
+        stubs.generateExportFile.resolves(Buffer.from('excel file'));
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    // stubs.can(user).do('read'|'access', ...) doit distinguer les deux appels faits par exportActions :
+    // 1er pour les actions ('read', 'action'), 2nd pour les financements ('access', 'action_finances')
+    const stubDo = (actionClauseGroup: object, financeClauseGroup: object | null) => {
+        const doStub = sandbox.stub();
+        doStub.withArgs('read', 'action').returns(actionClauseGroup);
+        doStub.withArgs('access', 'action_finances').returns(financeClauseGroup);
+        stubs.can = sandbox.stub().returns({ do: doStub });
+        stubs.where.returns({ can: stubs.can });
+    };
+
+    const getGenerateExportFileArgs = async () => {
+        await exportActions(user, year);
+        return stubs.generateExportFile.lastCall.args;
+    };
+
+    describe('calcul de includeFinances et allowedFinanceActions selon financeClauseGroup', () => {
+        it('includeFinances=true et allowedFinanceActions=null quand financeClauseGroup est un objet vide (accès national/territorial complet)', async () => {
+            stubDo({}, {});
+
+            const args = await getGenerateExportFileArgs();
+
+            expect(args[2]).to.be.true; // includeFinances
+            expect(args[4]).to.be.null; // allowedFinanceActions
+        });
+
+        it('includeFinances=true et allowedFinanceActions=null quand financeClauseGroup contient des clés territoriales', async () => {
+            stubDo({}, { regions: { query: 'regions.code', value: ['11'] } });
+
+            const args = await getGenerateExportFileArgs();
+
+            expect(args[2]).to.be.true;
+            expect(args[4]).to.be.null;
+        });
+
+        it('includeFinances=true et allowedFinanceActions=[...] quand financeClauseGroup est restreint à une liste d\'actions', async () => {
+            stubDo({}, { actions: { query: 'actions.action_id', value: [251, 410, 523] } });
+
+            const args = await getGenerateExportFileArgs();
+
+            expect(args[2]).to.be.true;
+            expect(args[4]).to.deep.equal([251, 410, 523]);
+        });
+
+        it('includeFinances=false quand financeClauseGroup est null (aucun accès aux financements)', async () => {
+            stubDo({}, null);
+
+            const args = await getGenerateExportFileArgs();
+
+            expect(args[2]).to.be.false;
+        });
+    });
+});

--- a/packages/api/server/services/action/exportActions.ts
+++ b/packages/api/server/services/action/exportActions.ts
@@ -3,9 +3,18 @@ import ServiceError from '#server/errors/ServiceError';
 import { AuthUser } from '#server/middlewares/authMiddleware';
 import actionModel from '#server/models/actionModel';
 import permissionUtils from '#server/utils/permission';
+import { WhereClauseGroup } from '#server/models/_common/types/Where.d';
 import generateExportFile from './exportActions.generateExportFile';
 import { ActionReportRow } from '#root/types/resources/Action.d';
 
+// null = accès complet aux financements (aucune restriction par action)
+const calculateAllowedActionsForFinances = (financeClauseGroup: WhereClauseGroup | null): number[] | null => {
+    if (!financeClauseGroup?.actions) {
+        return null;
+    }
+
+    return (financeClauseGroup.actions.value as number[]) ?? [];
+};
 
 /**
  * Calcule la liste des départements autorisés pour l'utilisateur
@@ -65,6 +74,9 @@ const exportActions = async (user: AuthUser, year: string, dihalFinancing = fals
     // Calculer les départements autorisés pour l'export
     const allowedDepartements = calculateAllowedDepartements(user, actionClauseGroup);
 
+    // Calculer les actions autorisées pour les financements
+    const allowedFinanceActions = calculateAllowedActionsForFinances(financeClauseGroup);
+
     // on collecte les données et on génère le fichier excel
     let data: ActionReportRow[];
 
@@ -93,7 +105,7 @@ const exportActions = async (user: AuthUser, year: string, dihalFinancing = fals
     }
 
     try { // Génération du fichier Excel
-        const buffer = await generateExportFile(data, fetchedYear, includeFinances, allowedDepartements);
+        const buffer = await generateExportFile(data, fetchedYear, includeFinances, allowedDepartements, allowedFinanceActions);
         return buffer;
     } catch (error) {
         throw new ServiceError('export_failed', error instanceof Error ? error : new Error('Une erreur inconnue est survenue'));

--- a/packages/api/types/resources/Action.d.ts
+++ b/packages/api/types/resources/Action.d.ts
@@ -41,6 +41,7 @@ export type ActionItem = {
     scolaire_nombre_autre: number | null,
     finance_etatique: number | null,
     finance_dedie: number | null,
+    financee_dihal: boolean | null,
     finance_collectivite: number | null,
     finance_europeen: number | null,
     finance_prive: number | null,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/idDQbIJr/2730

## 🛠 Description de la PR
- Ajoute une colonne "Financée par la DIHAL" dans l'export Excel des actions, entre "Dépense sur financement étatique hors crédits dédiés" et "Crédits dédiés à la résorption des bidonvilles". La valeur ("Oui"/"Non") reflète l'existence d'un enregistrement de financement de type "dedie" pour l'année exportée, que la dotation soit valorisée ou non.
- Corrige un bug RBAC découvert en test : un opérateur pilote de certaines actions voyait la colonne afficher "Non" pour des actions hors de son périmètre d'accès aux financements, au lieu de masquer la valeur (`-`). Le masquage se fait désormais action par action, cohérent avec la règle métier "un utilisateur a accès aux financements d'une action si un membre de sa structure (lui inclus) en est pilote".

## 📸 Captures d'écran
- Sans objet

## 🚨 Notes pour la mise en production
- Rien à signaler