### PR TITLE
#patch (2729) [Visudonnées] Afficher par défaut la situation à date

### DIFF
--- a/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/FiltrageTemporel.vue
+++ b/packages/frontend/webapp/src/components/DonneesStatistiquesDepartement/components/header/FiltrageTemporel.vue
@@ -4,13 +4,13 @@
             :small="true"
             :options="[
                 {
-                    label: 'Les 2 années écoulées',
-                    value: '2-annees-ecoulees',
-                    icon: 'fr-icon-bar-chart-box-line',
+                    label: 'Situation à date',
+                    value: 'situation-a-date',
+                    icon: 'fr-icon-table-line',
                 },
                 {
-                    label: 'L\'année écoulée',
-                    value: 'annee-ecoulee',
+                    label: 'Les 7 derniers jours',
+                    value: '7-derniers-jours',
                     icon: 'fr-icon-bar-chart-box-line',
                 },
                 {
@@ -19,19 +19,19 @@
                     icon: 'fr-icon-bar-chart-box-line',
                 },
                 {
-                    label: 'Les 7 derniers jours',
-                    value: '7-derniers-jours',
+                    label: 'L\'année écoulée',
+                    value: 'annee-ecoulee',
+                    icon: 'fr-icon-bar-chart-box-line',
+                },
+                {
+                    label: 'Les 2 années écoulées',
+                    value: '2-annees-ecoulees',
                     icon: 'fr-icon-bar-chart-box-line',
                 },
                 {
                     label: 'Période personnalisée',
                     value: 'periode-personnalisee',
                     icon: 'fr-icon-calendar-event-line',
-                },
-                {
-                    label: 'Situation à date',
-                    value: 'situation-a-date',
-                    icon: 'fr-icon-table-line',
                 },
             ]"
             v-model="selectedOption"
@@ -45,7 +45,7 @@ import { ref, watch } from "vue";
 
 import updateDataRange from "../../utils/updateDataRange";
 
-const selectedOption = ref("2-annees-ecoulees");
+const selectedOption = ref("situation-a-date");
 const emit = defineEmits(["update:modelValue"]);
 
 watch(selectedOption, (value) => {

--- a/packages/frontend/webapp/src/stores/metrics.departement.store.js
+++ b/packages/frontend/webapp/src/stores/metrics.departement.store.js
@@ -22,7 +22,7 @@ export const useDepartementMetricsStore = defineStore(
             justice: { id: "city_name", order: "asc" },
         });
         const metrics = ref({});
-        const currentFormat = ref("summary");
+        const currentFormat = ref("table");
         const evolution = {
             from: ref(new Date()),
             to: ref(new Date()),
@@ -74,7 +74,7 @@ export const useDepartementMetricsStore = defineStore(
         function reset() {
             departement.value = null;
             activeTab.value = "summary";
-            currentFormat.value = "summary";
+            currentFormat.value = "table";
             error.value = null;
             sort.value = {
                 summary: { id: "city_name", order: "asc" },


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/5kYgS2iX/2729-visudonn%C3%A9es-afficher-par-d%C3%A9faut-la-situation-%C3%A0-date

## 🛠 Description de la PR
Cette PR modifie l'ordre d'affichage des onglets de visualisation de données départementales et active par défaut l'onglet "Situation à date" présentant les données actuelles sous forme de tableau et de carte.

## 📸 Captures d'écran
<img width="1522" height="310" alt="image" src="https://github.com/user-attachments/assets/5aa783f6-60d9-449b-8532-f320a22fa62d" />

## 🚨 Notes pour la mise en production
RàS