### PR TITLE
#patch (2727) [Liste des sites] Préciser le nombre de mineurs

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeOrigins.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeOrigins.vue
@@ -8,6 +8,7 @@
             v-else
             class="text-lg font-bold"
             :population="shantytown.populationTotal"
+            :minors="shantytown.populationMinors"
         />
         <div>
             <div v-if="!socialOrigins.length" class="text-G700">

--- a/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
+++ b/packages/frontend/webapp/src/components/ListeDesSites/ListeDesSitesStatistiques.vue
@@ -14,6 +14,9 @@
                     représentant {{ formatStat(populationTotal) }} personne{{
                         isPlural(populationTotal) ? "s" : ""
                     }}
+                    dont {{ formatStat(minorTotal) }} mineur{{
+                        isPlural(minorTotal) ? "s" : ""
+                    }}
                 </p>
                 <p>
                     {{ updatedPopulationInTheLastThreeMonths }} sites<template
@@ -97,6 +100,12 @@ const title = computed(() => {
 const populationTotal = computed(() => {
     return townsStore.filteredTowns.reduce(
         (total, { populationTotal }) => total + (populationTotal || 0),
+        0
+    );
+});
+const minorTotal = computed(() => {
+    return townsStore.filteredTowns.reduce(
+        (total, { populationMinors }) => total + (populationMinors || 0),
         0
     );
 });

--- a/packages/frontend/webapp/src/components/NombreHabitants/NombreHabitants.vue
+++ b/packages/frontend/webapp/src/components/NombreHabitants/NombreHabitants.vue
@@ -1,7 +1,8 @@
 <template>
-    <div class="flex items-center">
+    <div class="flex items-center text-xl">
         <div class="mr-2">
-            {{ population }} <span class="sr-only">personnes sur site</span>
+            <span class="font-bold">{{ population }}</span
+            ><span class="sr-only">personnes sur site</span>
         </div>
         <div>
             <Icon icon="male" />{{ " " }}
@@ -10,10 +11,16 @@
             <span v-if="population >= 100"> <Icon icon="male" /></span>
         </div>
     </div>
+    <div class="flex items-center gap-1" v-if="minors">
+        <span class="text-sm">dont</span>
+        <span class="font-bold text-lg">{{ minors }}</span>
+        <span class="sr-only">mineurs sur le site</span>
+        <Icon icon="children" class="text-lg" />
+    </div>
 </template>
 
 <script setup>
-import { defineProps, toRefs } from "vue";
+import { toRefs } from "vue";
 import { Icon } from "@resorptionbidonvilles/ui";
 
 const props = defineProps({
@@ -21,6 +28,10 @@ const props = defineProps({
         type: Number,
         required: true,
     },
+    minors: {
+        type: Number,
+        required: false,
+    },
 });
-const { population } = toRefs(props);
+const { population, minors } = toRefs(props);
 </script>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/wZtVMBKX/2727-liste-des-sites-pr%C3%A9ciser-le-nombre-de-mineurs

## 🛠 Description de la PR
Cette PR intègre l'affichage du total de mineurs dans la liste des sites ainsi que le nombre de mineur par site dans les cartes.

## 📸 Captures d'écran
<img width="835" height="370" alt="image" src="https://github.com/user-attachments/assets/4d6640db-302f-4ace-918b-c07441f9105c" />
<img width="1495" height="492" alt="image" src="https://github.com/user-attachments/assets/7959a127-f38e-4f97-9809-edc3b77ae45b" />

## 🚨 Notes pour la mise en production
RàS