### PR TITLE
#patch (2720) [Mel recap hebdo] Remettre le nombre total de sites

### DIFF
--- a/packages/api/server/mails/dist/activity_summary.html
+++ b/packages/api/server/mails/dist/activity_summary.html
@@ -268,25 +268,30 @@
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">0%</span>
-            <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
-            <span aria-label="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
-            <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
-            <span aria-label="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #FFEB9C; color: #000000; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
-            <mj-raw>{% else %}</mj-raw>
-            <span aria-label="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #b8fec9; color: #18753c; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
-            <mj-raw>{% endif %}</mj-raw>
-             de sites (soit
-                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
-                un taux moyen)
-                <mj-raw>{% else %}</mj-raw>
-                un très bon taux)
-                <mj-raw>{% endif %}</mj-raw>
-             ont fait l'objet d'une mise à jour du nombre d'habitants dans les 3 derniers mois</div>
+      <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">0%</span>
+      <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80
+        %}</mj-raw>
+      <span aria-label="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
+      <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95
+        %}</mj-raw>
+      <span aria-label="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #FFEB9C; color: #000000; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
+      <mj-raw>{% else %}</mj-raw>
+      <span aria-label="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #b8fec9; color: #18753c; font-weight: bold;">{{ summary.updated_population_3_months_percentage }}%</span>
+      <mj-raw>{% endif %}</mj-raw>
+      de sites (soit
+      <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+      un taux faible)
+      <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80
+        %}</mj-raw>
+      un taux faible)
+      <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95
+        %}</mj-raw>
+      un taux moyen)
+      <mj-raw>{% else %}</mj-raw>
+      un très bon taux)
+      <mj-raw>{% endif %}</mj-raw>
+      ont fait l'objet d'une mise à jour du nombre d'habitants dans les 3
+      derniers mois</div>
     
                 </td>
               </tr>
@@ -295,25 +300,29 @@
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">0%</span>
-            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
-            <span aria-label="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
-            <span aria-label="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #FFEB9C; color: #000000; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% else %}</mj-raw>
-            <span aria-label="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #b8fec9; color: #18753c; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% endif %}</mj-raw>
-             de sites (soit
-                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
-                un taux moyen)
-                <mj-raw>{% else %}</mj-raw>
-                un très bon taux)
-                <mj-raw>{% endif %}</mj-raw>
-             ont été mis à jour au cours des 6 derniers mois</div>
+      <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">0%</span>
+      <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30
+        %}</mj-raw>
+      <span aria-label="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #ffe9e9; color: #ce0500; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+      <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60
+        %}</mj-raw>
+      <span aria-label="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #FFEB9C; color: #000000; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+      <mj-raw>{% else %}</mj-raw>
+      <span aria-label="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #b8fec9; color: #18753c; font-weight: bold;">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
+      <mj-raw>{% endif %}</mj-raw>
+      de sites (soit
+      <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+      un taux faible)
+      <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30
+        %}</mj-raw>
+      un taux faible)
+      <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60
+        %}</mj-raw>
+      un taux moyen)
+      <mj-raw>{% else %}</mj-raw>
+      un très bon taux)
+      <mj-raw>{% endif %}</mj-raw>
+      ont été mis à jour au cours des 6 derniers mois</div>
     
                 </td>
               </tr>
@@ -321,7 +330,10 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><span aria-label="{{ summary.population_total }} habitants" class="rate-span rate-none" title="{{ summary.population_total }}" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #e8edff; color: #0063cb; font-weight: bold;">{{ summary.population_total }}</span> habitants en bidonvilles ou squats</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:1.5em;text-align:left;color:#000000;"><span aria-label="{{ summary.population_total }} habitants" class="rate-span rate-none" title="{{ summary.population_total }}" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; font-size: 1rem; background-color: #e8edff; color: #0063cb; font-weight: bold;">{{ summary.population_total }}</span>
+      habitants dans
+      <span aria-label="{{ summary.shantytowns_total }} sites" class="rate-span rate-none" title="{{ summary.shantytowns_total }}" style="display: inline-block; padding: 0.15em 0.4em; border-radius: 0.25rem; background-color: #e8edff; color: #0063cb; font-size: 1rem; font-weight: bold;">{{ summary.shantytowns_total }}</span>
+      bidonvilles ou squats</div>
     
                 </td>
               </tr>

--- a/packages/api/server/mails/dist/activity_summary.text
+++ b/packages/api/server/mails/dist/activity_summary.text
@@ -47,7 +47,8 @@ summary.updated_shantytowns_6_months_percentage <= 30 %} un taux faible) {%
 elseif summary.updated_shantytowns_6_months_percentage <= 60 %} un taux moyen)
 {% else %} un très bon taux) {% endif %} ont été mis à jour au cours des 6
 derniers mois
-{{ summary.population_total }} habitants en bidonvilles ou squats
+{{ summary.population_total }} habitants dans {{ summary.shantytowns_total }}
+bidonvilles ou squats
 {% if var:showDetails %}{% if summary.new_shantytowns_length > 1 %}
 {{ summary.new_shantytowns_length }} nouveaux sites
 {% else %}

--- a/packages/api/server/mails/src/common/summary.mjml
+++ b/packages/api/server/mails/src/common/summary.mjml
@@ -1,60 +1,141 @@
 <mj-section>
-    <mj-column>
-        <mj-text mj-class='text-display font-bold'>
-            {{ summary.code }} – {{ summary.name }}
-        </mj-text>
-        <mj-text mj-class='text-body'>
-            <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent">0%</span>
-            <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
-            <span aria-label="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent">{{ summary.updated_population_3_months_percentage }}%</span>
-            <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
-            <span aria-label="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent">{{ summary.updated_population_3_months_percentage }}%</span>
-            <mj-raw>{% else %}</mj-raw>
-            <span aria-label="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent">{{ summary.updated_population_3_months_percentage }}%</span>
-            <mj-raw>{% endif %}</mj-raw>
-             de sites (soit
-                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_population_3_months_percentage < 80 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_population_3_months_percentage < 95 %}</mj-raw>
-                un taux moyen)
-                <mj-raw>{% else %}</mj-raw>
-                un très bon taux)
-                <mj-raw>{% endif %}</mj-raw>
-             ont fait l'objet d'une mise à jour du nombre d'habitants dans les 3 derniers mois
-        </mj-text>        
-        <mj-text mj-class='text-body'>
-            <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-            <span aria-label="Taux faible : 0 pour cent" class="rate-span rate-bad" title="Taux faible : 0 pour cent">0%</span>
-            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
-            <span aria-label="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-bad" title="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
-            <span aria-label="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-medium" title="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% else %}</mj-raw>
-            <span aria-label="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent" class="rate-span rate-good" title="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent">{{ summary.updated_shantytowns_6_months_percentage }}%</span>
-            <mj-raw>{% endif %}</mj-raw>
-             de sites (soit
-                <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 30 %}</mj-raw>
-                un taux faible)
-                <mj-raw>{% elseif summary.updated_shantytowns_6_months_percentage <= 60 %}</mj-raw>
-                un taux moyen)
-                <mj-raw>{% else %}</mj-raw>
-                un très bon taux)
-                <mj-raw>{% endif %}</mj-raw>
-             ont été mis à jour au cours des 6 derniers mois
-        </mj-text>
-        <mj-text><span aria-label="{{ summary.population_total }} habitants" class="rate-span rate-none" title="{{ summary.population_total }}">{{ summary.population_total }}</span> habitants en bidonvilles ou squats</mj-text>
-        <mj-raw>{% if var:showDetails %}</mj-raw>
-            <mj-include path="summary_full_activities.mjml" />
-        <mj-raw>{% elseif summary.has_activity %}</mj-raw>
-            <mj-include path="summary_full_activities.mjml" />
-        <mj-raw>{% else %}</mj-raw>
-            <mj-text mj-class='pt-2 font-bold'>Aucune activité</mj-text>
-            <mj-include path="summary_footer.mjml" />
-        <mj-raw>{% endif %}</mj-raw>
-    </mj-column>
+  <mj-column>
+    <mj-text mj-class="text-display font-bold">
+      {{ summary.code }} – {{ summary.name }}
+    </mj-text>
+    <mj-text mj-class="text-body">
+      <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+      <span
+        aria-label="Taux faible : 0 pour cent"
+        class="rate-span rate-bad"
+        title="Taux faible : 0 pour cent"
+        >0%</span
+      >
+      <mj-raw
+        >{% elseif summary.updated_population_3_months_percentage < 80
+        %}</mj-raw
+      >
+      <span
+        aria-label="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent"
+        class="rate-span rate-bad"
+        title="Taux faible : {{ summary.updated_population_3_months_percentage }} pour cent"
+        >{{ summary.updated_population_3_months_percentage }}%</span
+      >
+      <mj-raw
+        >{% elseif summary.updated_population_3_months_percentage < 95
+        %}</mj-raw
+      >
+      <span
+        aria-label="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent"
+        class="rate-span rate-medium"
+        title="Taux moyen : {{ summary.updated_population_3_months_percentage }} pour cent"
+        >{{ summary.updated_population_3_months_percentage }}%</span
+      >
+      <mj-raw>{% else %}</mj-raw>
+      <span
+        aria-label="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent"
+        class="rate-span rate-good"
+        title="Très bon taux : {{ summary.updated_population_3_months_percentage }} pour cent"
+        >{{ summary.updated_population_3_months_percentage }}%</span
+      >
+      <mj-raw>{% endif %}</mj-raw>
+      de sites (soit
+      <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+      un taux faible)
+      <mj-raw
+        >{% elseif summary.updated_population_3_months_percentage < 80
+        %}</mj-raw
+      >
+      un taux faible)
+      <mj-raw
+        >{% elseif summary.updated_population_3_months_percentage < 95
+        %}</mj-raw
+      >
+      un taux moyen)
+      <mj-raw>{% else %}</mj-raw>
+      un très bon taux)
+      <mj-raw>{% endif %}</mj-raw>
+      ont fait l'objet d'une mise à jour du nombre d'habitants dans les 3
+      derniers mois
+    </mj-text>
+    <mj-text mj-class="text-body">
+      <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+      <span
+        aria-label="Taux faible : 0 pour cent"
+        class="rate-span rate-bad"
+        title="Taux faible : 0 pour cent"
+        >0%</span
+      >
+      <mj-raw
+        >{% elseif summary.updated_shantytowns_6_months_percentage <= 30
+        %}</mj-raw
+      >
+      <span
+        aria-label="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent"
+        class="rate-span rate-bad"
+        title="Taux faible : {{ summary.updated_shantytowns_6_months_percentage }} pour cent"
+        >{{ summary.updated_shantytowns_6_months_percentage }}%</span
+      >
+      <mj-raw
+        >{% elseif summary.updated_shantytowns_6_months_percentage <= 60
+        %}</mj-raw
+      >
+      <span
+        aria-label="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent"
+        class="rate-span rate-medium"
+        title="Taux moyen : {{ summary.updated_shantytowns_6_months_percentage }} pour cent"
+        >{{ summary.updated_shantytowns_6_months_percentage }}%</span
+      >
+      <mj-raw>{% else %}</mj-raw>
+      <span
+        aria-label="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent"
+        class="rate-span rate-good"
+        title="Très bon taux : {{ summary.updated_shantytowns_6_months_percentage }} pour cent"
+        >{{ summary.updated_shantytowns_6_months_percentage }}%</span
+      >
+      <mj-raw>{% endif %}</mj-raw>
+      de sites (soit
+      <mj-raw>{% if summary.shantytowns_total == 0 %}</mj-raw>
+      un taux faible)
+      <mj-raw
+        >{% elseif summary.updated_shantytowns_6_months_percentage <= 30
+        %}</mj-raw
+      >
+      un taux faible)
+      <mj-raw
+        >{% elseif summary.updated_shantytowns_6_months_percentage <= 60
+        %}</mj-raw
+      >
+      un taux moyen)
+      <mj-raw>{% else %}</mj-raw>
+      un très bon taux)
+      <mj-raw>{% endif %}</mj-raw>
+      ont été mis à jour au cours des 6 derniers mois
+    </mj-text>
+    <mj-text
+      ><span
+        aria-label="{{ summary.population_total }} habitants"
+        class="rate-span rate-none"
+        title="{{ summary.population_total }}"
+        >{{ summary.population_total }}</span
+      >
+      habitants dans
+      <span
+        aria-label="{{ summary.shantytowns_total }} sites"
+        class="rate-span rate-none"
+        title="{{ summary.shantytowns_total }}"
+        style="font-size: 1rem; font-weight: bold"
+        >{{ summary.shantytowns_total }}</span
+      >
+      bidonvilles ou squats</mj-text
+    >
+    <mj-raw>{% if var:showDetails %}</mj-raw>
+    <mj-include path="summary_full_activities.mjml" />
+    <mj-raw>{% elseif summary.has_activity %}</mj-raw>
+    <mj-include path="summary_full_activities.mjml" />
+    <mj-raw>{% else %}</mj-raw>
+    <mj-text mj-class="pt-2 font-bold">Aucune activité</mj-text>
+    <mj-include path="summary_footer.mjml" />
+    <mj-raw>{% endif %}</mj-raw>
+  </mj-column>
 </mj-section>


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/OsoBkBzh/2720-mel-recap-hebdo-remettre-le-nombre-total-de-sites

## 🛠 Description de la PR
Cette PR remet le nombre de sites par département dans le mail de récap' hebdo (envoyé le lundi à 9h00).

## 📸 Captures d'écran
<img width="590" height="260" alt="image" src="https://github.com/user-attachments/assets/1ae4cb18-babf-4b39-b61d-828bf7568735" />

## 🚨 Notes pour la mise en production
RàS