### PR TITLE
#patch (2738) [Liste sites, liste actions] Permettre le clic-droit pour ouvrir un site ou une action dans un nouvel onglet

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
@@ -1,77 +1,72 @@
 <template>
-    <RouterLink custom v-slot="{ navigate }" :to="`/site/${shantytown.id}`">
-        <div
-            :class="[
-                'rounded-sm cursor-pointer border-1 border-cardBorder preventPrintBreak print:h-[17.3rem]',
-                isHover ? 'bg-blue200 border-transparent' : '',
-                !isOpen ? 'closedShantytown' : '',
-                focusClasses.outline,
-            ]"
-            :aria-label="`Fiche site ${shantytown.addressSimple} ${
-                shantytown.name ? shantytown.name : ''
-            } ${shantytown.city.name}`"
-            @click="(event) => handleClickOnCard(event, navigate)"
-            @mouseenter="isHover = true"
-            @mouseleave="isHover = false"
-        >
-            <div class="-mt-1 print:mt-0">
-                <CarteSiteDetailleeHeader
-                    class="mb-4"
+    <div
+        :class="[
+            'relative rounded-sm cursor-pointer border-1 border-cardBorder preventPrintBreak print:h-[17.3rem]',
+            isHover ? 'bg-blue200 border-transparent' : '',
+            !isOpen ? 'closedShantytown' : '',
+            focusClasses.outline,
+        ]"
+        :aria-label="`Fiche site ${shantytown.addressSimple} ${
+            shantytown.name ? shantytown.name : ''
+        } ${shantytown.city.name}`"
+        @mouseenter="isHover = true"
+        @mouseleave="isHover = false"
+    >
+        <div class="-mt-1 print:mt-0">
+            <CarteSiteDetailleeHeader
+                class="mb-4"
+                :shantytown="shantytown"
+                :isHover="isHover"
+                :currentTab="currentTab"
+            />
+            <CarteSiteDetailleeName :shantytown="shantytown" />
+            <div
+                :class="[
+                    'flex flex-col',
+                    `space-y-${nbCol}`,
+                    'lg:flex-none lg:grid',
+                    `cardGridTemplateColumns${nbCol === '5' ? 'Five' : 'Four'}`,
+                    'print:grid lg:gap-10 px-6 py-4 items-start',
+                ]"
+            >
+                <CarteSiteDetailleeFieldType :shantytown="shantytown" />
+                <CarteSiteDetailleeOrigins
                     :shantytown="shantytown"
-                    :isHover="isHover"
-                    :currentTab="currentTab"
+                    class="pl-5"
                 />
-                <CarteSiteDetailleeName :shantytown="shantytown" />
-                <div
-                    :class="[
-                        'flex flex-col',
-                        `space-y-${nbCol}`,
-                        'lg:flex-none lg:grid',
-                        `cardGridTemplateColumns${
-                            nbCol === '5' ? 'Five' : 'Four'
-                        }`,
-                        'print:grid lg:gap-10 px-6 py-4 items-start',
-                    ]"
-                >
-                    <CarteSiteDetailleeFieldType :shantytown="shantytown" />
-                    <CarteSiteDetailleeOrigins
-                        :shantytown="shantytown"
-                        class="pl-5"
-                    />
-                    <template v-if="displayPhasesPreparatoiresResorption">
-                        <CarteSiteDetailleePhasesPreparatoiresResorption
-                            v-if="isOpen"
-                            :shantytown="shantytown"
-                        />
-                    </template>
-                    <template v-else>
-                        <CarteSiteDetailleeLivingConditions
-                            v-if="isOpen"
-                            :shantytown="shantytown"
-                        />
-                        <CarteSiteDetailleeClosingSolutions
-                            v-else
-                            :shantytown="shantytown"
-                        />
-                    </template>
-                    <CarteSiteDetailleeJustice
-                        v-if="userStore.hasJusticePermission"
+                <template v-if="displayPhasesPreparatoiresResorption">
+                    <CarteSiteDetailleePhasesPreparatoiresResorption
+                        v-if="isOpen"
                         :shantytown="shantytown"
                     />
-                    <CarteSiteDetailleeActors :shantytown="shantytown" />
-                </div>
-
-                <CarteSiteDetailleeFooter
+                </template>
+                <template v-else>
+                    <CarteSiteDetailleeLivingConditions
+                        v-if="isOpen"
+                        :shantytown="shantytown"
+                    />
+                    <CarteSiteDetailleeClosingSolutions
+                        v-else
+                        :shantytown="shantytown"
+                    />
+                </template>
+                <CarteSiteDetailleeJustice
+                    v-if="userStore.hasJusticePermission"
                     :shantytown="shantytown"
-                    :isHover="isHover"
                 />
+                <CarteSiteDetailleeActors :shantytown="shantytown" />
             </div>
+
+            <CarteSiteDetailleeFooter
+                :shantytown="shantytown"
+                :isHover="isHover"
+            />
         </div>
-    </RouterLink>
+    </div>
 </template>
 
 <script setup>
-import { defineProps, toRefs, computed, ref } from "vue";
+import { toRefs, computed, ref } from "vue";
 import { useUserStore } from "@/stores/user.store";
 import focusClasses from "@common/utils/focus_classes";
 
@@ -114,22 +109,6 @@ const displayPhasesPreparatoiresResorption = computed(() => {
 const nbCol = computed(() => {
     return userStore.hasJusticePermission ? "5" : "4";
 });
-
-function handleClickOnCard(event, navigateFunction) {
-    // On vérifie si le clic vient d'un bouton du footer ou d'un click sur intervenant ou sur la tuile complète
-    let targetElement = event.target;
-    while (targetElement && targetElement !== event.currentTarget) {
-        if (
-            targetElement.tagName === "BUTTON" ||
-            targetElement.tagName === "A" ||
-            targetElement.closest(".carte-site-detaillee-footer-wrapper")
-        ) {
-            return; // Ne pas naviguer si le clic vient d'un bouton du footer
-        }
-        targetElement = targetElement.parentElement;
-    }
-    navigateFunction();
-}
 </script>
 
 <style scoped lang="scss">

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeFooter.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="flex flex-wrap justify-end md:h-10 items-end m-4 gap-3 print:hidden sm:flex-row"
+        class="flex flex-wrap justify-end md:h-10 items-end m-4 gap-3 print:hidden sm:flex-row relative z-50"
     >
         <BoutonFavori :townId="shantytown.id" />
         <DsfrButton
@@ -206,9 +206,3 @@ async function handleNoChangeModalIfNeeded() {
     return false;
 }
 </script>
-
-<style scoped>
-button {
-    border: inherit;
-}
-</style>

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeName.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeName.vue
@@ -1,14 +1,26 @@
 <template>
     <div class="text-md px-6">
         <div class="text-primary text-display-md font-bold">
-            <span v-if="shantytown.name" class="font-bold">
-                « {{ shantytown.name }} » - {{ shantytown.addressSimple }}
-                {{ shantytown.city.name }} ({{ shantytown.departement.code }})
-            </span>
-            <span v-else class="font-bold">
-                {{ shantytown.addressSimple }}
-                {{ shantytown.city.name }} ({{ shantytown.departement.code }})
-            </span>
+            <RouterLink
+                :to="`/site/${shantytown.id}`"
+                class="focus:outline-none after:absolute after:inset-0"
+                :aria-label="`Fiche site ${shantytown.addressSimple} ${
+                    shantytown.name ? shantytown.name : ''
+                } ${shantytown.city.name}`"
+            >
+                <span v-if="shantytown.name" class="font-bold">
+                    « {{ shantytown.name }} » - {{ shantytown.addressSimple }}
+                    {{ shantytown.city.name }} ({{
+                        shantytown.departement.code
+                    }})
+                </span>
+                <span v-else class="font-bold">
+                    {{ shantytown.addressSimple }}
+                    {{ shantytown.city.name }} ({{
+                        shantytown.departement.code
+                    }})
+                </span>
+            </RouterLink>
         </div>
     </div>
     <div class="px-6" v-if="isClosed(shantytown)">

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsTableau.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsTableau.vue
@@ -9,9 +9,9 @@
                 v-for="action in actionsStore.currentPage.content"
                 :key="action.id"
                 class="cursor-pointer hover:bg-blue-france-925-125"
-                @click="navigateToAction(action.id)"
             >
-                <td @click.stop>
+                <!-- @click="navigateToAction(action.id)" -->
+                <td class="relative z-10">
                     <DsfrTagCopy
                         :label="action.displayId"
                         dataType="Identifiant de l'action"
@@ -29,7 +29,12 @@
                 </td>
                 <td>
                     <div class="font-bold">
-                        {{ formatProjectName(action) }}
+                        <RouterLink
+                            :to="`/action/${action.id}`"
+                            class="focus:outline-none after:absolute after:inset-0"
+                        >
+                            {{ formatProjectName(action) }}
+                        </RouterLink>
                     </div>
                 </td>
                 <td>
@@ -56,7 +61,6 @@
 
 <script setup>
 import { computed } from "vue";
-import { useRouter } from "vue-router";
 import { useActionsStore } from "@/stores/actions.store";
 import getSince from "@/utils/getSince";
 import formatMetricsUpdatedAt from "@/utils/formatMetricsUpdatedAt";
@@ -65,7 +69,6 @@ import formatTimestamp from "@common/utils/formatTimestamp";
 import DsfrTagCopy from "@/components/DsfrTagCopy/DsfrTagCopy.vue";
 import capitalizeFirstLetter from "@/utils/capitalizeFirstLetter";
 
-const router = useRouter();
 const actionsStore = useActionsStore();
 
 const headers = [
@@ -94,10 +97,6 @@ const currentPageIndex = computed({
         actionsStore.currentPage.index = value + 1;
     },
 });
-
-const navigateToAction = (actionId) => {
-    router.push(`/action/${actionId}`);
-};
 
 const formatDate = (timestamp) => {
     if (!timestamp) {

--- a/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsTableau.vue
+++ b/packages/frontend/webapp/src/components/ListeDesActions/ListeDesActionsTableau.vue
@@ -10,7 +10,6 @@
                 :key="action.id"
                 class="cursor-pointer hover:bg-blue-france-925-125"
             >
-                <!-- @click="navigateToAction(action.id)" -->
                 <td class="relative z-10">
                     <DsfrTagCopy
                         :label="action.displayId"


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/4yriSXPP/2738-liste-sites-liste-actions-permettre-le-clic-droit-pour-ouvrir-un-site-ou-une-action-dans-un-nouvel-onglet

## 🛠 Description de la PR
Cette PR permet aux utilisateurs de faire un click droit sur une action ou un site pour l'ouvrir dans un nouvel onglet, facilitant ainsi la navigation et permettant d'ouvrir simplement plusieurs sites et/ou actions dans plusieurs onglets en simultané, tout en respectant l'accessibilité.

## 📸 Captures d'écran
<img width="1499" height="434" alt="image" src="https://github.com/user-attachments/assets/e24f24e4-55ed-4ce4-acfe-14af26111bf4" />
<img width="1503" height="403" alt="image" src="https://github.com/user-attachments/assets/3e5298e7-9260-41c9-bfee-fce8b395b899" />

## 🚨 Notes pour la mise en production
RàS