### PR TITLE
#patch (2738-fix) Correction de l'accessibilité sur les intervenant dans la liste des sites

### DIFF
--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetaillee.vue
@@ -11,6 +11,8 @@
         } ${shantytown.city.name}`"
         @mouseenter="isHover = true"
         @mouseleave="isHover = false"
+        @focusin="isHover = true"
+        @focusout="isHover = false"
     >
         <div class="-mt-1 print:mt-0">
             <CarteSiteDetailleeHeader

--- a/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeActors.vue
+++ b/packages/frontend/webapp/src/components/CarteSiteDetaillee/CarteSiteDetailleeActors.vue
@@ -1,6 +1,6 @@
 <template>
     <span class="sr-only">Liste des intervenants</span>
-    <div class="flex">
+    <div class="flex z-10">
         <div
             v-bind:class="{
                 'text-G700': shantytown.actors.length === 0,


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/4yriSXPP/2738-liste-sites-liste-actions-permettre-le-clic-droit-pour-ouvrir-un-site-ou-une-action-dans-un-nouvel-onglet

## 🛠 Description de la PR
Cette PR corrige un problème d'accès direct (click) sur les intervenants dans la liste des sites et corrige, par la même occasion, l'accessibilité et la mise en valeur (focus) de la carte site lors d'une navigation au clavier.

## 📸 Captures d'écran
<img width="1509" height="491" alt="image" src="https://github.com/user-attachments/assets/daab8626-b748-4dde-9498-8484fac174b9" />

## 🚨 Notes pour la mise en production
RàS